### PR TITLE
Refactor trade log aggregation to support only TradeLogRow

### DIFF
--- a/aggregate_exec_logs.py
+++ b/aggregate_exec_logs.py
@@ -25,69 +25,39 @@ def _read_any(path: str) -> pd.DataFrame:
 
 def _normalize_trades(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Normalize trades to unified schema:
-    ts, run_id, symbol, side, order_type, price, qty, fee, fee_asset, pnl, exec_status, liquidity, client_order_id, order_id, meta_json
-    Supports legacy schema: ts, price, volume, side, agent_flag, order_id
+    Normalize trades to TradeLogRow schema:
+    ts, run_id, symbol, side, order_type, price, quantity, fee, fee_asset, pnl,
+    exec_status, liquidity, client_order_id, order_id, meta_json.
+    Only TradeLogRow format is supported.
     """
     if df is None or df.empty:
-        return pd.DataFrame(columns=["ts","run_id","symbol","side","order_type","price","qty","fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json"])
+        return pd.DataFrame(columns=[
+            "ts","run_id","symbol","side","order_type","price","quantity",
+            "fee","fee_asset","pnl","exec_status","liquidity",
+            "client_order_id","order_id","meta_json"
+        ])
 
+    required = {"ts","run_id","symbol","side","order_type","price","quantity"}
     cols = set(df.columns)
+    missing = required - cols
+    if missing:
+        raise ValueError(f"Missing required columns: {missing}")
 
-    # Unified already
-    if {"ts","run_id","symbol","side","order_type","price","quantity"}.issubset(cols):
-        df = df.copy()
-        df = df.rename(columns={"quantity":"qty"})
-        for c in ["fee","pnl"]:
-            if c in df.columns:
-                df[c] = pd.to_numeric(df[c], errors="coerce")
-        # ensure required cols exist
-        for c in ["fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json"]:
-            if c not in df.columns:
-                df[c] = None
-        return df[["ts","run_id","symbol","side","order_type","price","qty","fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json"]]
-
-    # Legacy -> map
-    if {"ts","price","volume","side"}.issubset(cols):
-        out = pd.DataFrame()
-        out["ts"] = pd.to_numeric(df["ts"], errors="coerce").astype("Int64")
-        out["run_id"] = ""
-        out["symbol"] = "UNKNOWN"
-        out["side"] = df["side"].astype(str).str.upper()
-        out["order_type"] = "MARKET"
-        out["price"] = pd.to_numeric(df["price"], errors="coerce")
-        out["qty"] = pd.to_numeric(df["volume"], errors="coerce")
-        out["fee"] = 0.0
-        out["fee_asset"] = None
-        out["pnl"] = None
-        out["exec_status"] = "FILLED"
-        out["liquidity"] = "UNKNOWN"
-        out["client_order_id"] = None
-        out["order_id"] = df["order_id"] if "order_id" in df.columns else None
-        out["meta_json"] = "{}"
-        return out
-
-    # Unknown schema -> attempt minimal
     df = df.copy()
-    if "ts" not in df.columns:
-        df["ts"] = pd.NA
-    if "price" not in df.columns:
-        df["price"] = pd.NA
-    if "qty" not in df.columns:
-        if "quantity" in df.columns:
-            df["qty"] = pd.to_numeric(df["quantity"], errors="coerce")
-        elif "volume" in df.columns:
-            df["qty"] = pd.to_numeric(df["volume"], errors="coerce")
-        else:
-            df["qty"] = pd.NA
-    df["run_id"] = ""
-    df["symbol"] = "UNKNOWN"
-    df["side"] = df.get("side", "BUY")
-    df["order_type"] = df.get("order_type", "MARKET")
-    for c in ["fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json"]:
+    for c in ["fee","pnl","price","quantity"]:
+        if c in df.columns:
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["ts"] = pd.to_numeric(df["ts"], errors="coerce").astype("Int64")
+    # ensure optional columns exist
+    for c in ["fee","fee_asset","pnl","exec_status","liquidity",
+              "client_order_id","order_id","meta_json"]:
         if c not in df.columns:
             df[c] = None
-    return df[["ts","run_id","symbol","side","order_type","price","qty","fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json"]]
+    return df[[
+        "ts","run_id","symbol","side","order_type","price","quantity",
+        "fee","fee_asset","pnl","exec_status","liquidity",
+        "client_order_id","order_id","meta_json"
+    ]]
 
 
 def _bucket_ts_ms(ts_ms: pd.Series, *, bar_seconds: int) -> pd.Series:
@@ -99,7 +69,7 @@ def _bucket_ts_ms(ts_ms: pd.Series, *, bar_seconds: int) -> pd.Series:
 def aggregate(trades_path: str, reports_path: str, out_bars: str, out_days: str, bar_seconds: int = 60) -> Tuple[str, str]:
     """
     Aggregates trade logs into per-bar and per-day summaries.
-    - trades_path: path or glob to log_trades_*.csv (unified) or legacy trades.csv
+    - trades_path: path or glob to log_trades_*.csv (TradeLogRow format)
     - reports_path: optional path/glob to equity reports (csv/parquet) — if present, we will attach equity at bar ends
     - out_bars, out_days: output CSV paths
     Returns (out_bars, out_days).
@@ -115,7 +85,7 @@ def aggregate(trades_path: str, reports_path: str, out_bars: str, out_days: str,
 
     # Ensure numeric types
     trades["price"] = pd.to_numeric(trades["price"], errors="coerce")
-    trades["qty"] = pd.to_numeric(trades["qty"], errors="coerce")
+    trades["quantity"] = pd.to_numeric(trades["quantity"], errors="coerce")
     trades["ts"] = pd.to_numeric(trades["ts"], errors="coerce").astype("Int64")
     trades["side_sign"] = trades["side"].astype(str).map(lambda s: 1 if s.upper()=="BUY" else -1)
 
@@ -124,11 +94,11 @@ def aggregate(trades_path: str, reports_path: str, out_bars: str, out_days: str,
     g = trades.groupby(["symbol","ts_bucket"], as_index=False)
 
     def _agg(df: pd.DataFrame) -> pd.Series:
-        qty_abs = df["qty"].abs().sum()
-        notional = (df["price"] * df["qty"].abs()).sum()
+        qty_abs = df["quantity"].abs().sum()
+        notional = (df["price"] * df["quantity"].abs()).sum()
         vwap = float(notional / qty_abs) if qty_abs and math.isfinite(notional) else float("nan")
-        buy_qty = df.loc[df["side_sign"]>0, "qty"].abs().sum()
-        sell_qty = df.loc[df["side_sign"]<0, "qty"].abs().sum()
+        buy_qty = df.loc[df["side_sign"]>0, "quantity"].abs().sum()
+        sell_qty = df.loc[df["side_sign"]<0, "quantity"].abs().sum()
         n_trades = int(len(df))
         fee_sum = float(pd.to_numeric(df["fee"], errors="coerce").fillna(0.0).sum()) if "fee" in df.columns else 0.0
         return pd.Series({
@@ -149,12 +119,12 @@ def aggregate(trades_path: str, reports_path: str, out_bars: str, out_days: str,
     trades["day"] = (trades["ts"].astype("Int64") // day_ms) * day_ms
     gd = trades.groupby(["symbol","day"], as_index=False)
     days = gd.apply(lambda df: pd.Series({
-        "volume": float(df["qty"].abs().sum()),
+        "volume": float(df["quantity"].abs().sum()),
         "trades": int(len(df)),
-        "buy_qty": float(df.loc[df["side_sign"]>0, "qty"].abs().sum()),
-        "sell_qty": float(df.loc[df["side_sign"]<0, "qty"].abs().sum()),
+        "buy_qty": float(df.loc[df["side_sign"]>0, "quantity"].abs().sum()),
+        "sell_qty": float(df.loc[df["side_sign"]<0, "quantity"].abs().sum()),
         "fee_total": float(pd.to_numeric(df["fee"], errors="coerce").fillna(0.0).sum()) if "fee" in df.columns else 0.0,
-        "vwap": float(((df["price"] * df["qty"].abs()).sum() / df["qty"].abs().sum())) if df["qty"].abs().sum() else float("nan"),
+        "vwap": float(((df["price"] * df["quantity"].abs()).sum() / df["quantity"].abs().sum())) if df["quantity"].abs().sum() else float("nan"),
     }))
     days = days.rename(columns={"day":"ts"})
     days["ts"] = days["ts"].astype("Int64")
@@ -168,7 +138,7 @@ def aggregate(trades_path: str, reports_path: str, out_bars: str, out_days: str,
 
 def main() -> None:
     p = argparse.ArgumentParser(description="Aggregate execution logs into per-bar and per-day summaries.")
-    p.add_argument("--trades", required=True, help="Path or glob to unified Exec logs (log_trades_*.csv). Legacy trades.csv is supported but deprecated.")
+    p.add_argument("--trades", required=True, help="Path or glob to TradeLogRow logs (log_trades_*.csv). Only TradeLogRow format is supported.")
     p.add_argument("--reports", default="", help="Optional path or glob to equity reports (csv/parquet)")
     p.add_argument("--out-bars", default="logs/agg_bars.csv", help="Output CSV path for per-bar aggregation")
     p.add_argument("--out-days", default="logs/agg_days.csv", help="Output CSV path for per-day aggregation")


### PR DESCRIPTION
## Summary
- drop legacy trade schema handling in aggregate_exec_logs
- switch normalization and aggregation to use `quantity`
- clarify CLI help to require TradeLogRow format

## Testing
- `python -m py_compile aggregate_exec_logs.py`
- `python aggregate_exec_logs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ebfc388832fa383651699ac1ff0