### PR TITLE
Handle optional extra field in DecisionContext

### DIFF
--- a/core_contracts.py
+++ b/core_contracts.py
@@ -107,10 +107,10 @@ class DecisionContext:
     """
     Контекст принятия решения, который может предоставлять BacktestEngine/сервис.
     Обязательные ключи: ts (int ms), symbol (str).
-    Дополнительно: position (Position), limits (PortfolioLimits).
+    Дополнительно: position (Position), limits (PortfolioLimits), extra (Dict[str, Any]).
     """
     ts: int
     symbol: str
     position: Optional[Position] = None
     limits: Optional[PortfolioLimits] = None
-    extra: Dict[str, Any] = None  # type: ignore[assignment]
+    extra: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- make `DecisionContext.extra` optional and document the extra field

## Testing
- `pytest` *(fails: `/workspace/TradingBot/pyproject.toml: Expected '=' after a key in a key/value pair (at line 35, column 9)`)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9b5644d8832f93a7efeac6c0bfda