### PR TITLE
Improve to_ms time parsing

### DIFF
--- a/tests/test_market_utils.py
+++ b/tests/test_market_utils.py
@@ -1,0 +1,25 @@
+import datetime
+
+from market_data_port import to_ms
+from utils_time import parse_time_to_ms
+
+
+def test_numeric_seconds_to_ms():
+    assert to_ms(1) == 1000
+    assert to_ms(1234567890) == 1234567890 * 1000
+    assert to_ms(1.5) == 1500
+
+
+def test_numeric_ms_passthrough():
+    ms = 1_600_000_000_000
+    assert to_ms(ms) == ms
+
+
+def test_string_delegation():
+    s = "2023-01-02 03:04:05"
+    assert to_ms(s) == parse_time_to_ms(s)
+
+
+def test_datetime_to_ms():
+    dt = datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc)
+    assert to_ms(dt) == 1672531200000


### PR DESCRIPTION
## Summary
- Add seconds-to-ms detection and delegate string parsing to `utils_time.parse_time_to_ms`
- Document numeric handling in `to_ms`
- Introduce tests covering numeric, string, and datetime inputs

## Testing
- `python - <<'PY'
import sys
sys.path = [p for p in sys.path if p != '']
import pytest
sys.path.append('.')
args = ['tests/test_market_utils.py', '-q', '--rootdir=tests']
raise SystemExit(pytest.main(args))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bdbcea4a60832f8de40a7d7255e61c