### PR TITLE
Refactor SimAdapter step to reuse exec reports

### DIFF
--- a/sandbox/sim_adapter.py
+++ b/sandbox/sim_adapter.py
@@ -63,18 +63,20 @@ class SimAdapter:
 
         # Пишем унифицированный лог построчно (без изменения возврата)
         try:
-            # логирование по единому контракту ExecReport
-            exec_reports = sim_report_dict_to_core_exec_reports(d, symbol=self.symbol, client_order_id=None)
-            for _er in exec_reports:
+            exec_reports = sim_report_dict_to_core_exec_reports(
+                d, symbol=self.symbol, client_order_id=None
+            )
+        except Exception:
+            exec_reports = []
+
+        for _er in exec_reports:
+            try:
                 _bus_log_trade_exec(_er)
-        except Exception:
-            pass
+            except Exception:
+                pass
+
         # формируем core_exec_reports (унифицированные отчёты исполнения) без изменения существующего интерфейса
-        try:
-            exec_reports = sim_report_dict_to_core_exec_reports(d, symbol=self.symbol, client_order_id=None)
-            d["core_exec_reports"] = [as_dict(er) for er in exec_reports]
-        except Exception:
-            d["core_exec_reports"] = []
+        d["core_exec_reports"] = [as_dict(er) for er in exec_reports]
         return d
 
     def run_events(self, provider: "DecisionsProvider") -> Iterator[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Call `sim_report_dict_to_core_exec_reports` once in `SimAdapter.step` and reuse the result for logging and output population.

## Testing
- `python -m py_compile sandbox/sim_adapter.py`
- `python -m pytest -q TradingBot` *(fails: `/workspace/TradingBot/pyproject.toml: Expected '=' after a key in a key/value pair`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbce8aa6c832f9adb16622189e144