### PR TITLE
Clarify Binance public source docstring

### DIFF
--- a/impl_binance_public.py
+++ b/impl_binance_public.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 impl_binance_public.py
-Источник рыночных данных Binance Public WS. Выдаёт MarketEvent(BAR) по kline.
+Источник рыночных данных Binance Public WS. Источник выдаёт объекты `Bar` через `stream_bars`.
 Работает синхронно через внутренний поток, который обслуживает asyncio + websockets.
 """
 


### PR DESCRIPTION
## Summary
- Clarify Binance public WS module docstring to note it yields `Bar` objects via `stream_bars`

## Testing
- `pytest -q` *(fails: Expected '=' after a key in a key/value pair in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbcd324c8832f94163e8ba49a39fb