### PR TITLE
Refactor SimAdapter to consume bar streams

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Sequence, Iterator, Protocol
 
 from sandbox.sim_adapter import SimAdapter, DecisionsProvider  # исп. как TradeExecutor-подобный мост
-from market_data_port import Bar
+from core_models import Bar
 from services.utils_config import snapshot_config  # снапшот конфига (Фаза 3)  # noqa: F401
 
 


### PR DESCRIPTION
## Summary
- rewrite sandbox SimAdapter to pull bars via `MarketDataSource.stream_bars` and drop `MarketEvent`
- update service signal runner to rely on `core_models.Bar`

## Testing
- `pytest` *(fails: /workspace/TradingBot/pyproject.toml: Expected '=' after a key in a key/value pair (at line 35, column 9))*
- `python -m py_compile sandbox/sim_adapter.py service_signal_runner.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb999becc832f99e549b8740fd724