### PR TITLE
Refactor sandbox runner to use backtest service

### DIFF
--- a/services/utils_sandbox.py
+++ b/services/utils_sandbox.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Утилиты для запуска песочницы/бэктеста."""
+from __future__ import annotations
+
+import importlib
+from typing import Any, Dict
+
+import pandas as pd
+
+from strategies.base import BaseStrategy
+
+
+def read_df(path: str) -> pd.DataFrame:
+    """Читает DataFrame из CSV или Parquet."""
+    if path.lower().endswith(".parquet"):
+        return pd.read_parquet(path)
+    return pd.read_csv(path)
+
+
+def build_strategy(mod: str, cls: str, params: Dict[str, Any]) -> BaseStrategy:
+    """Создаёт стратегию и вызывает setup."""
+    m = importlib.import_module(mod)
+    Cls = getattr(m, cls)
+    s: BaseStrategy = Cls()
+    s.setup(params or {})
+    return s


### PR DESCRIPTION
## Summary
- route sandbox runner through ServiceBacktest and BacktestConfig
- build SimAdapter internally in ServiceBacktest
- factor out dataframe and strategy helpers

## Testing
- `pytest` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68bdc7b413c4832fa05b8e93a27529b1