### PR TITLE
refactor: centralize performance eval

### DIFF
--- a/evaluate_performance.py
+++ b/evaluate_performance.py
@@ -1,116 +1,37 @@
-# scripts/evaluate_performance.py
+"""CLI wrapper around :mod:`service_eval`."""
+
 from __future__ import annotations
 
 import argparse
-import glob
-import json
-import os
-from typing import List, Tuple
 
-import numpy as np
-import pandas as pd
-import matplotlib.pyplot as plt
-
-from services.metrics import compute_equity_metrics, compute_trade_metrics
+from service_eval import EvalConfig, ServiceEval
 
 
-def _read_any(path: str) -> pd.DataFrame:
-    # поддержка glob
-    if any(ch in path for ch in ["*", "?", "["]):
-        parts: List[str] = glob.glob(path)
-        dfs = []
-        for p in parts:
-            dfs.append(_read_any(p))
-        if not dfs:
-            return pd.DataFrame()
-        return pd.concat(dfs, ignore_index=True)
-    if path.lower().endswith(".parquet"):
-        return pd.read_parquet(path)
-    return pd.read_csv(path)
-
-
-def _try_plot_equity(reports: pd.DataFrame, out_path: str) -> None:
-    if reports.empty:
-        return
-    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
-    r = reports.sort_values("ts_ms")
-    x = r["ts_ms"].values.astype("int64")
-    y = r["equity"].values.astype(float)
-    plt.figure(figsize=(12, 5))
-    plt.plot(x, y)
-    plt.xlabel("ts_ms")
-    plt.ylabel("equity")
-    plt.title("Equity curve")
-    plt.tight_layout()
-    plt.savefig(out_path)
-    plt.close()
-
-
-def _compute_turnover_from_trades(trades: pd.DataFrame, capital_base: float) -> float:
-    if trades is None or trades.empty or capital_base <= 0:
-        return float("nan")
-    notional = trades["notional"].astype(float) if "notional" in trades.columns else None
-    if notional is None:
-        return float("nan")
-    gross = float(notional.abs().sum())
-    return float(gross / float(capital_base))
-
-
-def main():
-    p = argparse.ArgumentParser(description="Evaluate strategy performance from execution logs.")
-    p.add_argument("--trades", required=True, help="Путь к трейдам (CSV/Parquet или glob)")
-    p.add_argument("--reports", required=True, help="Путь к отчётам (CSV/Parquet или glob)")
-    p.add_argument("--out-json", default="logs/metrics.json", help="Куда сохранить метрики в JSON")
-    p.add_argument("--out-md", default="logs/metrics.md", help="Куда сохранить краткий Markdown-отчёт")
-    p.add_argument("--equity-png", default="logs/equity.png", help="PNG с кривой капитала")
-    p.add_argument("--capital-base", type=float, default=10000.0, help="Базовый капитал для нормировки доходностей")
-    p.add_argument("--rf-annual", type=float, default=0.0, help="Годовая безрисковая ставка (например, 0.03)")
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Evaluate strategy performance via ServiceEval",
+    )
+    p.add_argument("--trades", required=True, help="Path to trades (CSV/Parquet or glob)")
+    p.add_argument("--reports", required=True, help="Path to reports (CSV/Parquet or glob)")
+    p.add_argument("--out-json", default="logs/metrics.json", help="Where to save metrics JSON")
+    p.add_argument("--out-md", default="logs/metrics.md", help="Where to save Markdown report")
+    p.add_argument("--equity-png", default="logs/equity.png", help="PNG with equity curve")
+    p.add_argument("--capital-base", type=float, default=10_000.0, help="Base capital for returns")
+    p.add_argument("--rf-annual", type=float, default=0.0, help="Annual risk-free rate")
     args = p.parse_args()
 
-    trades = _read_any(args.trades)
-    reports = _read_any(args.reports)
-
-    # Унификация колонок для нового формата трейдов (log_trades_*.csv): quantity -> qty
-    if set(['ts','run_id','symbol','side','order_type','price','quantity']).issubset(set(trades.columns)):
-        trades = trades.rename(columns={'quantity':'qty'})
-    # Приводим side к верхнему регистру для консистентности
-    if 'side' in trades.columns:
-        trades['side'] = trades['side'].astype(str).str.upper()
-
-    eqm = compute_equity_metrics(reports, capital_base=float(args.capital_base), rf_annual=float(args.rf_annual))
-    trm = compute_trade_metrics(trades)
-
-    # Дооценим turnover по трейдам и добавим в eqm.to_dict() как post-fix
-    turnover = _compute_turnover_from_trades(trades, float(args.capital_base))
-    eqd = eqm.to_dict()
-    eqd["turnover"] = float(turnover)
-
-    # Сохранить JSON
-    os.makedirs(os.path.dirname(args.out_json) or ".", exist_ok=True)
-    with open(args.out_json, "w", encoding="utf-8") as f:
-        json.dump({"equity": eqd, "trades": trm.to_dict()}, f, ensure_ascii=False, indent=2)
-
-    # Сохранить Markdown
-    os.makedirs(os.path.dirname(args.out_md) or ".", exist_ok=True)
-    with open(args.out_md, "w", encoding="utf-8") as f:
-        f.write("# Performance Metrics\n\n")
-        f.write("## Equity\n")
-        for k, v in eqd.items():
-            f.write(f"- **{k}**: {v}\n")
-        f.write("\n## Trades\n")
-        for k, v in trm.to_dict().items():
-            f.write(f"- **{k}**: {v}\n")
-
-    # График equity
-    try:
-        _try_plot_equity(reports, args.equity_png)
-    except Exception:
-        pass
-
-    print(f"Wrote metrics JSON -> {args.out_json}")
-    print(f"Wrote metrics MD   -> {args.out_md}")
-    print(f"Wrote equity PNG   -> {args.equity_png}")
+    cfg = EvalConfig(
+        trades_path=args.trades,
+        reports_path=args.reports,
+        out_json=args.out_json,
+        out_md=args.out_md,
+        equity_png=args.equity_png,
+        capital_base=float(args.capital_base),
+        rf_annual=float(args.rf_annual),
+    )
+    ServiceEval(cfg).run()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
+


### PR DESCRIPTION
## Summary
- Wrap evaluate_performance CLI around new ServiceEval
- Move file I/O, plotting and turnover helpers into services.metrics
- Introduce ServiceEval service for reading logs and producing metrics reports

## Testing
- `python evaluate_performance.py --help`
- `pytest -q` *(fails: Expected '=' after a key in a key/value pair)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc7b3b840832fa6d0d6b28a5cd7ba