### PR TITLE
Add offline feature pipe and integrate with training service

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,3 +19,24 @@ core_ → impl_ → service_ → strategy_ → scripts_
 Каждый слой может зависеть только от слоёв, расположенных левее.
 
 Общий план развития проекта приведён в файле [План.txt](План.txt).
+
+## ServiceTrain
+
+`ServiceTrain` подготавливает датасет и запускает обучение модели.  Он
+ожидает реализацию протокола `FeaturePipe`.  Для оффлайн‑расчёта фич
+можно использовать класс `OfflineFeaturePipe`, который оборачивает
+функцию `apply_offline_features`.
+
+Пример запуска обучения:
+
+```python
+from transformers import FeatureSpec
+from offline_feature_pipe import OfflineFeaturePipe
+from service_train import ServiceTrain, TrainConfig
+
+spec = FeatureSpec(lookbacks_prices=[5, 15, 60], rsi_period=14)
+fp = OfflineFeaturePipe(spec, price_col="ref_price")
+trainer = ...
+cfg = TrainConfig(input_path="data/train.parquet")
+ServiceTrain(fp, trainer, cfg).run()
+```

--- a/offline_feature_pipe.py
+++ b/offline_feature_pipe.py
@@ -1,0 +1,76 @@
+"""Offline feature pipe for ServiceTrain.
+
+Computes deterministic features using ``apply_offline_features`` and
+optionally builds simple targets. The pipe conforms to the
+``FeaturePipe`` protocol expected by :class:`ServiceTrain`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+
+from transformers import FeatureSpec, apply_offline_features
+
+
+@dataclass
+class OfflineFeaturePipe:
+    """Simple offline feature builder.
+
+    Parameters
+    ----------
+    spec:
+        Feature specification for SMA/returns and RSI parameters.
+    price_col:
+        Name of the column containing prices in the input dataframe.
+    label_col:
+        Optional column name for existing target values.  When provided and
+        present in the dataframe, :meth:`make_targets` simply returns this
+        column.  Otherwise a next-step return is computed from ``price_col``.
+    """
+
+    spec: FeatureSpec
+    price_col: str = "price"
+    label_col: Optional[str] = None
+
+    # Protocol methods -------------------------------------------------
+    def warmup(self) -> None:  # noqa: D401 - protocol no-op
+        """No warmup needed for offline computation."""
+        # nothing to warm up for deterministic offline features
+
+    def fit(self, df: pd.DataFrame) -> None:  # noqa: D401 - protocol no-op
+        """No fitting required."""
+        # offline features are stateless; the method exists for protocol
+        # compatibility
+
+    def transform_df(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Apply feature transformer to ``df``.
+
+        The dataframe must contain ``ts_ms`` and ``symbol`` columns together
+        with ``price_col``.  The resulting dataframe follows the same schema
+        as produced by :func:`apply_offline_features`.
+        """
+        return apply_offline_features(
+            df,
+            spec=self.spec,
+            ts_col="ts_ms",
+            symbol_col="symbol",
+            price_col=self.price_col,
+        )
+
+    def make_targets(self, df: pd.DataFrame) -> Optional[pd.Series]:
+        """Build target series.
+
+        If ``label_col`` is provided and present in ``df`` the existing column
+        is returned.  Otherwise the method computes a one-step ahead return
+        based on ``price_col``.
+        """
+        if self.label_col and self.label_col in df.columns:
+            return df[self.label_col]
+
+        # compute forward return within each symbol
+        price = df[self.price_col].astype(float)
+        future_price = df.groupby("symbol")[self.price_col].shift(-1)
+        target = future_price.div(price) - 1.0
+        return target.rename("target")

--- a/service_train.py
+++ b/service_train.py
@@ -3,6 +3,20 @@
 services/service_train.py
 Сервис подготовки данных (офлайн) и запуска обучения модели.
 Оркестрация: OfflineData -> FeaturePipe(offl) -> Dataset -> Trainer.fit -> сохранение артефактов.
+
+Пример использования
+--------------------
+```python
+from transformers import FeatureSpec
+from offline_feature_pipe import OfflineFeaturePipe
+from service_train import ServiceTrain, TrainConfig
+
+spec = FeatureSpec(lookbacks_prices=[5, 15, 60], rsi_period=14)
+fp = OfflineFeaturePipe(spec, price_col="ref_price")
+trainer = ...  # реализация Trainer
+cfg = TrainConfig(input_path="data/train.parquet")
+ServiceTrain(fp, trainer, cfg).run()
+```
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- implement `OfflineFeaturePipe` for deterministic offline feature generation and targets
- integrate the new pipe into `ServiceTrain` usage and baseline app
- document how to run training with `ServiceTrain` and `OfflineFeaturePipe`

## Testing
- `python -m py_compile offline_feature_pipe.py service_train.py app.py`
- `PYTHONPATH=/root/.pyenv/versions/3.12.10/lib/python3.12:/workspace/TradingBot pytest -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68bdcd253db8832fbdc2e58a0f287f4f