### PR TITLE
Add warmup method to FeaturePipe and unify imports

### DIFF
--- a/core_contracts.py
+++ b/core_contracts.py
@@ -57,10 +57,10 @@ class FeaturePipe(Protocol):
     def reset(self) -> None:
         ...
 
-    def on_bar(self, bar: Bar) -> Optional[Mapping[str, Any]]:
+    def warmup(self) -> None:
         ...
 
-    def on_tick(self, tick: Tick) -> Optional[Mapping[str, Any]]:
+    def on_bar(self, bar: Bar) -> Optional[Mapping[str, Any]]:
         ...
 
 

--- a/feature_pipe.py
+++ b/feature_pipe.py
@@ -2,13 +2,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, TYPE_CHECKING
+from typing import Any, Dict, Iterable, List
 
 from transformers import FeatureSpec, OnlineFeatureTransformer
 from core_models import Bar
-
-if TYPE_CHECKING:
-    from core_contracts import FeaturePipe as FeaturePipeProtocol
+from core_contracts import FeaturePipe as FeaturePipeProtocol  # noqa: F401
 
 @dataclass
 class FeatureConfig:

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -12,12 +12,8 @@ from typing import Any, Dict, Optional, Sequence, Iterator, Protocol
 
 from sandbox.sim_adapter import SimAdapter, DecisionsProvider  # исп. как TradeExecutor-подобный мост
 from core_models import Bar
+from core_contracts import FeaturePipe
 from services.utils_config import snapshot_config  # снапшот конфига (Фаза 3)  # noqa: F401
-
-
-class FeaturePipe(Protocol):
-    def warmup(self) -> None: ...
-    def on_bar(self, bar: Bar) -> Dict[str, Any]: ...
 
 
 class Strategy(Protocol):

--- a/service_train.py
+++ b/service_train.py
@@ -28,10 +28,10 @@ import time
 import pandas as pd
 
 from services.utils_config import snapshot_config  # снапшот конфигурации
+from core_contracts import FeaturePipe as BaseFeaturePipe
 
 
-class FeaturePipe(Protocol):
-    def warmup(self) -> None: ...
+class FeaturePipe(BaseFeaturePipe, Protocol):
     def fit(self, df: pd.DataFrame) -> None: ...
     def transform_df(self, df: pd.DataFrame) -> pd.DataFrame: ...
     # опционально: целевая переменная


### PR DESCRIPTION
## Summary
- add `warmup` to `FeaturePipe` contract and drop `on_tick`
- use shared `FeaturePipe` protocol from `core_contracts` across services
- adjust service modules and feature pipe implementation to new interface

## Testing
- `mypy --config-file=/tmp/mypy.ini core_contracts.py feature_pipe.py service_signal_runner.py service_train.py`
- `python - <<'PY'
import sys
repo = '/workspace/TradingBot'
if sys.path and sys.path[0] in ('', repo):
    sys.path.pop(0)
sys.path.append(repo)
import pytest
raise SystemExit(pytest.main(['-c','/tmp/pytest.ini','tests/test_market_utils.py']))
PY


------
https://chatgpt.com/codex/tasks/task_e_68bdd0781a7c832f91e586ac01465604