### PR TITLE
Add from_config helpers for services

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,15 +31,13 @@ core_ → impl_ → service_ → strategy_ → scripts_
 Пример запуска обучения:
 
 ```python
-from transformers import FeatureSpec
-from offline_feature_pipe import OfflineFeaturePipe
-from service_train import ServiceTrain, TrainConfig
+from core_config import CommonRunConfig
+from service_train import from_config, TrainConfig
 
-spec = FeatureSpec(lookbacks_prices=[5, 15, 60], rsi_period=14)
-fp = OfflineFeaturePipe(spec, price_col="ref_price")
+cfg_run = CommonRunConfig(...)
 trainer = ...
 cfg = TrainConfig(input_path="data/train.parquet")
-ServiceTrain(fp, trainer, cfg).run()
+from_config(cfg_run, trainer=trainer, train_cfg=cfg)
 ```
 =======
 ## Проверка паритета фич

--- a/service_eval.py
+++ b/service_eval.py
@@ -1,5 +1,17 @@
 # -*- coding: utf-8 -*-
-"""Service for evaluating strategy performance."""
+"""Service for evaluating strategy performance.
+
+Example
+-------
+```python
+from core_config import CommonRunConfig
+from service_eval import from_config, EvalConfig
+
+cfg = CommonRunConfig(...)
+eval_cfg = EvalConfig(trades_path="trades.csv", reports_path="reports.csv")
+metrics = from_config(cfg, eval_cfg)
+```
+"""
 
 from __future__ import annotations
 
@@ -11,6 +23,8 @@ from typing import Dict
 import pandas as pd
 
 from services.metrics import calculate_metrics, read_any, plot_equity_curve
+from core_config import CommonRunConfig
+import di_registry
 
 
 @dataclass
@@ -82,5 +96,12 @@ class ServiceEval:
         return metrics
 
 
-__all__ = ["EvalConfig", "ServiceEval"]
+def from_config(cfg: CommonRunConfig, eval_cfg: EvalConfig) -> Dict[str, Dict[str, float]]:
+    """Run :class:`ServiceEval` using dependencies described in ``cfg``."""
+    di_registry.build_graph(cfg.components, cfg)
+    service = ServiceEval(eval_cfg)
+    return service.run()
+
+
+__all__ = ["EvalConfig", "ServiceEval", "from_config"]
 


### PR DESCRIPTION
## Summary
- add `from_config` helpers to SignalRunner, Backtest, Train and Eval services
- document service usage with config-driven examples

## Testing
- `pytest` *(fails: /workspace/TradingBot/pyproject.toml: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68bdd53bf9f0832faa8ae2cb82780d90