### PR TITLE
Implement YAML run config loader

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,6 +20,31 @@ core_ → impl_ → service_ → strategy_ → scripts_
 
 Общий план развития проекта приведён в файле [План.txt](План.txt).
 
+## Конфигурации запусков
+
+Конфигурации описываются в формате YAML. Для загрузки и валидации
+используйте функцию `load_config`:
+
+```yaml
+# configs/run_sim.yaml
+mode: sim
+components:
+  market_data:
+    target: impl_offline_data:OfflineCSVBarSource
+    params: {paths: ["data/sample.csv"], timeframe: "1m"}
+  executor:
+    target: impl_sim_executor:SimExecutor
+    params: {symbol: "BTCUSDT"}
+data:
+  symbols: ["BTCUSDT"]
+  timeframe: "1m"
+```
+
+```python
+from core_config import load_config
+
+cfg = load_config("configs/run_sim.yaml")
+```
 
 ## ServiceTrain
 

--- a/core_config.py
+++ b/core_config.py
@@ -8,6 +8,8 @@ Pydantic-модели конфигураций: sim/live/train/eval + декла
 from __future__ import annotations
 
 from typing import Dict, Any, Optional, List, Mapping, Union
+
+import yaml
 from pydantic import BaseModel, Field, validator
 
 
@@ -111,3 +113,39 @@ class EvalConfig(CommonRunConfig):
     mode: str = Field(default="eval")
     input: EvalInputConfig
     metrics: List[str] = Field(default_factory=lambda: ["sharpe", "sortino", "mdd", "pnl"])
+
+
+def load_config(path: str) -> CommonRunConfig:
+    """Загрузить конфигурацию запуска из YAML-файла."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+
+    mode = data.get("mode")
+    mapping = {
+        "sim": SimulationConfig,
+        "live": LiveConfig,
+        "train": TrainConfig,
+        "eval": EvalConfig,
+    }
+    cfg_cls = mapping.get(mode)
+    if cfg_cls is None:
+        raise ValueError(f"Unknown mode: {mode}")
+    return cfg_cls(**data)
+
+
+__all__ = [
+    "ComponentSpec",
+    "Components",
+    "CommonRunConfig",
+    "SimulationDataConfig",
+    "SimulationConfig",
+    "LiveAPIConfig",
+    "LiveDataConfig",
+    "LiveConfig",
+    "TrainDataConfig",
+    "ModelConfig",
+    "TrainConfig",
+    "EvalInputConfig",
+    "EvalConfig",
+    "load_config",
+]


### PR DESCRIPTION
## Summary
- add `load_config` to parse YAML run configs and dispatch to the appropriate pydantic model
- document configuration usage in ARCHITECTURE.md

## Testing
- `pytest` *(fails: /workspace/TradingBot/pyproject.toml: Expected '=' after a key in a key/value pair)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd6f80940832f822c01340852ecaf