### PR TITLE
Add mode and run config fields to configuration YAMLs

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -1,3 +1,9 @@
+mode: eval
+run_id: eval-run
+logs_dir: logs
+artifacts_dir: artifacts
+input:
+  trades_path: "data/trades.csv"
 components:
   market_data:
     target: impl_offline_data:OfflineCSVBarSource

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -1,3 +1,13 @@
+mode: live
+run_id: live-run
+logs_dir: logs
+artifacts_dir: artifacts
+api:
+  api_key: null
+  api_secret: null
+data:
+  symbols: ["BTCUSDT"]
+  timeframe: "1m"
 components:
   market_data:
     target: impl_binance_public:BinancePublicBarSource

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -1,3 +1,10 @@
+mode: sim
+run_id: sim-run
+logs_dir: logs
+artifacts_dir: artifacts
+data:
+  symbols: ["BTCUSDT"]
+  timeframe: "1m"
 components:
   market_data:
     target: impl_offline_data:OfflineCSVBarSource

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -1,3 +1,13 @@
+mode: train
+run_id: train-run
+logs_dir: logs
+artifacts_dir: artifacts
+data:
+  symbols: ["BTCUSDT"]
+  timeframe: "1m"
+model:
+  algo: "ppo"
+  params: {}
 components:
   market_data:
     target: impl_offline_data:OfflineCSVBarSource


### PR DESCRIPTION
## Summary
- add `mode` and common run fields to example configs
- add minimal `data`, `api`, `model`, and `input` sections so configs load through `core_config.load_config`

## Testing
- `python - <<'PY' ... PY`
- `pytest -q` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68bdd99e0b50832f8924c90967e708ce