### PR TITLE
Use load_config and service from_config in CLI scripts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,6 +46,17 @@ from core_config import load_config
 cfg = load_config("configs/run_sim.yaml")
 ```
 
+### CLI-скрипты
+
+Несколько вспомогательных скриптов принимают путь к YAML через
+флаг `--config` и запускают соответствующие сервисы через `from_config`:
+
+```
+python run_realtime_signaler.py --config configs/config_live.yaml
+python run_sandbox.py          --config configs/config_sim.yaml
+python evaluate_performance.py --config configs/config_eval.yaml
+```
+
 ## ServiceTrain
 
 `ServiceTrain` подготавливает датасет и запускает обучение модели.  Он

--- a/run_realtime_signaler.py
+++ b/run_realtime_signaler.py
@@ -1,78 +1,31 @@
-"""Run realtime signaler using ServiceSignalRunner.
+"""Run realtime signaler using :mod:`service_signal_runner`.
 
-This script wires together a market data source, feature pipeline,
-strategy and optional guards, then passes them into
-:class:`ServiceSignalRunner`. It demonstrates configuring the service
-purely via dependencies without relying on the legacy ``SignalRunner``
-class.
+The script now relies on ``load_config``/``from_config`` pair and does not
+manually construct any of the runtime components.
 """
 
 from __future__ import annotations
 
 import argparse
-import importlib
-from typing import Any, Dict, List
 
-import yaml
-
-from impl_binance_public import BinancePublicBarSource
-from execution_sim import ExecutionSimulator
-from sandbox.sim_adapter import SimAdapter
-from service_signal_runner import ServiceSignalRunner
-from feature_pipe import FeatureConfig, FeaturePipe
-
-
-class _HistoryGuard:
-    """Blocks decisions until enough history bars accumulated."""
-
-    def __init__(self, min_history_bars: int = 0) -> None:
-        self._min = int(min_history_bars)
-        self._cnt: Dict[str, int] = {}
-
-    def apply(self, ts_ms: int, symbol: str, decisions):
-        c = self._cnt.get(symbol, 0) + 1
-        self._cnt[symbol] = c
-        if c < self._min:
-            return []
-        return decisions
+from core_config import load_config
+from service_signal_runner import from_config
 
 
 def main() -> None:
-    p = argparse.ArgumentParser(description="Run realtime signaler (public Binance WS, no keys).")
-    p.add_argument("--config", default="configs/config_live.yaml", help="Путь к YAML конфигу")
+    p = argparse.ArgumentParser(
+        description="Run realtime signaler (public Binance WS, no keys).",
+    )
+    p.add_argument(
+        "--config",
+        default="configs/config_live.yaml",
+        help="Путь к YAML-конфигу запуска",
+    )
     args = p.parse_args()
 
-    with open(args.config, "r", encoding="utf-8") as f:
-        cfg: Dict[str, Any] = yaml.safe_load(f)
+    cfg = load_config(args.config)
 
-    symbols: List[str] = [str(s).upper() for s in cfg.get("symbols", [])]
-    if not symbols:
-        raise ValueError("At least one symbol must be provided")
-    interval: str = str(cfg.get("interval", "1m"))
-
-    strat_cfg = cfg.get("strategy", {}) or {}
-    strat_mod = str(strat_cfg.get("module", "strategies.momentum"))
-    strat_cls = str(strat_cfg.get("class", "MomentumStrategy"))
-    strat_params = dict(strat_cfg.get("params", {}))
-    strategy = getattr(importlib.import_module(strat_mod), strat_cls)(**strat_params)
-
-    feats_cfg = cfg.get("features", {}) or {}
-    fp_cfg = {
-        "lookbacks_prices": list(feats_cfg.get("lookbacks_prices", [5, 15, 60])),
-        "rsi_period": int(feats_cfg.get("rsi_period", 14)),
-    }
-    feature_pipe = FeaturePipe(FeatureConfig(**fp_cfg))
-
-    guards_cfg = cfg.get("guards", {}) or {}
-    guards = _HistoryGuard(int(guards_cfg.get("min_history_bars", 0)))
-
-    source = BinancePublicBarSource(interval)
-    sim = ExecutionSimulator(symbol=symbols[0])
-    adapter = SimAdapter(sim, symbol=symbols[0], timeframe=interval, source=source)
-
-    runner = ServiceSignalRunner(adapter, feature_pipe, strategy, guards)
-
-    for report in runner.run():
+    for report in from_config(cfg):
         print(report)
 
 

--- a/run_sandbox.py
+++ b/run_sandbox.py
@@ -5,70 +5,44 @@ import argparse
 import os
 
 import pandas as pd
-import yaml
 
-from execution_sim import ExecutionSimulator  # type: ignore
-from service_backtest import BacktestConfig, ServiceBacktest
-from services.utils_sandbox import build_strategy, read_df
+from core_config import load_config
+from service_backtest import BacktestConfig, from_config
+from services.utils_sandbox import read_df
 
 
 def main() -> None:
     p = argparse.ArgumentParser(description="Strategy sandbox runner")
-    p.add_argument("--config", default="configs/legacy_sandbox.yaml", help="Путь к YAML-конфигу песочницы")
+    p.add_argument(
+        "--config",
+        default="configs/config_sim.yaml",
+        help="Путь к YAML-конфигу запуска",
+    )
     args = p.parse_args()
 
-    with open(args.config, "r", encoding="utf-8") as f:
-        cfg = yaml.safe_load(f)
+    cfg = load_config(args.config)
 
-    # симулятор
-    with open(cfg["sim_config_path"], "r", encoding="utf-8") as f:
-        sim_cfg = yaml.safe_load(f)
+    data_path = getattr(cfg.data, "prices_path", None)
+    if data_path is None:
+        md_params = cfg.components.market_data.params or {}
+        paths = md_params.get("paths") or []
+        data_path = paths[0] if paths else None
+    if not data_path:
+        raise ValueError("Data path must be specified in config")
 
-    sim = ExecutionSimulator(
-        symbol=cfg.get("symbol", "BTCUSDT"),
-        latency_steps=int(cfg.get("latency_steps", 0)),
-        filters_path=sim_cfg["filters"]["path"],
-        enforce_ppbs=sim_cfg["filters"]["enforce_percent_price_by_side"],
-        strict_filters=sim_cfg["filters"]["strict"],
-        fees_config=sim_cfg.get("fees", {}),
-        funding_config=sim_cfg.get("funding", {}),
-        slippage_config=sim_cfg.get("slippage", {}),
-        execution_config=sim_cfg.get("execution", {}),
-        latency_config=sim_cfg.get("latency", {}),
-        pnl_config=sim_cfg.get("pnl", {}),
-        risk_config=sim_cfg.get("risk", {}),
-        logging_config=sim_cfg.get("logging", {}),
-    )
+    df = read_df(data_path)
 
-    # стратегия
-    strat = build_strategy(
-        cfg["strategy"]["module"],
-        cfg["strategy"]["class"],
-        cfg["strategy"].get("params", {}),
-    )
+    params = cfg.components.backtest_engine.params or {}
+    bt_kwargs = {k: v for k, v in params.items() if k in BacktestConfig.__annotations__}
+    svc_cfg = BacktestConfig(**bt_kwargs)
 
-    # бэктест
-    data_cfg = cfg["data"]
-    df = read_df(data_cfg["path"])
-    ts_col = data_cfg.get("ts_col", "ts_ms")
-    sym_col = data_cfg.get("symbol_col", "symbol")
-    price_col = data_cfg.get("price_col", "ref_price")
+    ts_col = params.get("ts_col", "ts_ms")
+    sym_col = params.get("symbol_col", "symbol")
+    price_col = params.get("price_col", "ref_price")
 
-    bt_cfg = BacktestConfig(
-        symbol=cfg.get("symbol", "BTCUSDT"),
-        timeframe=data_cfg.get("timeframe", "1m"),
-        dynamic_spread_config=cfg.get("dynamic_spread", {}),
-        exchange_specs_path=cfg.get("exchange_specs_path", "data/exchange_specs.json"),
-        guards_config=cfg.get("sim_guards", {}),
-        signal_cooldown_s=int(cfg.get("min_signal_gap_s", 0)),
-        no_trade_config=cfg.get("no_trade", {}),
-    )
+    reports = from_config(cfg, df, ts_col=ts_col, symbol_col=sym_col, price_col=price_col, svc_cfg=svc_cfg)
 
-    svc = ServiceBacktest(strategy=strat, sim=sim, cfg=bt_cfg)
-    reports = svc.run(df, ts_col=ts_col, symbol_col=sym_col, price_col=price_col)
-
-    # сохранить
-    out_path = cfg.get("out_reports", "logs/sandbox_reports.csv")
+    out_path = params.get("out_reports", "logs/sandbox_reports.csv")
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
     if out_path.lower().endswith(".parquet"):
         pd.DataFrame(reports).to_parquet(out_path, index=False)


### PR DESCRIPTION
## Summary
- Simplify `run_realtime_signaler.py` by delegating setup to `load_config` and `service_signal_runner.from_config`
- Replace manual sandbox initialization with config-driven `service_backtest.from_config`
- Add YAML-config based evaluation via `service_eval.from_config`
- Document new `--config` usage for CLI helpers

## Testing
- `pytest` *(fails: /workspace/TradingBot/pyproject.toml: Expected '=' after a key in a key/value pair)*

------
https://chatgpt.com/codex/tasks/task_e_68bdda9e8e10832fa1b74585cd48b872