### PR TITLE
Pass svc config to runner scripts for config snapshot

### DIFF
--- a/evaluate_performance.py
+++ b/evaluate_performance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 
 from core_config import load_config
-from service_eval import EvalConfig, from_config
+from service_eval import EvalConfig, EvalServiceConfig, from_config
 
 
 def main() -> None:
@@ -30,7 +30,8 @@ def main() -> None:
         capital_base=10_000.0,
         rf_annual=0.0,
     )
-    from_config(cfg, eval_cfg)
+    svc_cfg = EvalServiceConfig(snapshot_config_path=args.config, artifacts_dir=cfg.artifacts_dir)
+    from_config(cfg, eval_cfg, svc_cfg=svc_cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/run_realtime_signaler.py
+++ b/run_realtime_signaler.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import argparse
 
 from core_config import load_config
-from service_signal_runner import from_config
+from service_signal_runner import RunnerConfig, from_config
 
 
 def main() -> None:
@@ -25,7 +25,9 @@ def main() -> None:
 
     cfg = load_config(args.config)
 
-    for report in from_config(cfg):
+    svc_cfg = RunnerConfig(snapshot_config_path=args.config, artifacts_dir=cfg.artifacts_dir)
+
+    for report in from_config(cfg, svc_cfg=svc_cfg):
         print(report)
 
 

--- a/run_sandbox.py
+++ b/run_sandbox.py
@@ -34,7 +34,7 @@ def main() -> None:
 
     params = cfg.components.backtest_engine.params or {}
     bt_kwargs = {k: v for k, v in params.items() if k in BacktestConfig.__annotations__}
-    svc_cfg = BacktestConfig(**bt_kwargs)
+    svc_cfg = BacktestConfig(**bt_kwargs, snapshot_config_path=args.config, artifacts_dir=cfg.artifacts_dir)
 
     ts_col = params.get("ts_col", "ts_ms")
     sym_col = params.get("symbol_col", "symbol")


### PR DESCRIPTION
## Summary
- pass Runner/Backtest/Eval service configs in CLI wrappers to enable YAML snapshots
- add service-level config with snapshot support for evaluation service

## Testing
- `python -m py_compile run_realtime_signaler.py run_sandbox.py evaluate_performance.py service_eval.py`
- `PYTHONPATH=/usr/lib/python3.12:/workspace/TradingBot python -m evaluate_performance --config /workspace/TradingBot/test_config_eval.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68bddf047b6c832f9018086a489e03c7