### PR TITLE
feat: support config snapshot in eval service

### DIFF
--- a/evaluate_performance.py
+++ b/evaluate_performance.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 
 from core_config import load_config
-from service_eval import EvalConfig, EvalServiceConfig, from_config
+from service_eval import EvalConfig, from_config
 
 
 def main() -> None:
@@ -29,9 +29,10 @@ def main() -> None:
         equity_png=f"{cfg.logs_dir}/equity.png",
         capital_base=10_000.0,
         rf_annual=0.0,
+        snapshot_config_path=args.config,
+        artifacts_dir=cfg.artifacts_dir,
     )
-    svc_cfg = EvalServiceConfig(snapshot_config_path=args.config, artifacts_dir=cfg.artifacts_dir)
-    from_config(cfg, eval_cfg, svc_cfg=svc_cfg)
+    from_config(cfg, eval_cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- allow EvalConfig to include snapshot path and artifact directory
- snapshot configuration when running eval service
- build DI container and pass it to ServiceEval in from_config
- simplify CLI wrapper after config changes

## Testing
- `PYTHONPATH=. pytest -c /dev/null tests` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68bde1a2c964832fbad9de20740dbb19