### PR TITLE
refactor yaml config loading

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -133,6 +133,22 @@ def load_config(path: str) -> CommonRunConfig:
     return cfg_cls(**data)
 
 
+def load_config_from_str(content: str) -> CommonRunConfig:
+    """Parse configuration from YAML string."""
+    data = yaml.safe_load(content) or {}
+    mode = data.get("mode")
+    mapping = {
+        "sim": SimulationConfig,
+        "live": LiveConfig,
+        "train": TrainConfig,
+        "eval": EvalConfig,
+    }
+    cfg_cls = mapping.get(mode)
+    if cfg_cls is None:
+        raise ValueError(f"Unknown mode: {mode}")
+    return cfg_cls(**data)
+
+
 __all__ = [
     "ComponentSpec",
     "Components",
@@ -148,4 +164,5 @@ __all__ = [
     "EvalInputConfig",
     "EvalConfig",
     "load_config",
+    "load_config_from_str",
 ]

--- a/ingest_config.py
+++ b/ingest_config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import List
+from pydantic import BaseModel, Field
+import yaml
+
+
+class PeriodConfig(BaseModel):
+    start: str
+    end: str
+
+
+class PathsConfig(BaseModel):
+    klines_dir: str = Field("data/klines", description="Directory for klines output")
+    futures_dir: str = Field("data/futures", description="Directory for futures data")
+    prices_out: str = Field("data/prices.parquet", description="Output path for normalized prices")
+
+
+class FuturesConfig(BaseModel):
+    mark_interval: str = "1m"
+
+
+class SlownessConfig(BaseModel):
+    api_limit: int = 1500
+    sleep_ms: int = 350
+
+
+class IngestConfig(BaseModel):
+    symbols: List[str]
+    market: str = "spot"
+    intervals: List[str] = Field(default_factory=lambda: ["1m"])
+    aggregate_to: List[str] = Field(default_factory=list)
+    period: PeriodConfig
+    paths: PathsConfig = PathsConfig()
+    futures: FuturesConfig = FuturesConfig()
+    slowness: SlownessConfig = Field(default_factory=SlownessConfig)
+
+
+def load_config(path: str) -> IngestConfig:
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return IngestConfig(**data)
+
+
+def load_config_from_str(content: str) -> IngestConfig:
+    data = yaml.safe_load(content) or {}
+    return IngestConfig(**data)
+
+
+__all__ = ["IngestConfig", "load_config", "load_config_from_str"]

--- a/legacy_sandbox_config.py
+++ b/legacy_sandbox_config.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from pydantic import BaseModel, Field
+import yaml
+
+
+class StrategyConfig(BaseModel):
+    module: str = "strategies.momentum"
+    class_name: str = Field("MomentumStrategy", alias="class")
+    params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class DataConfig(BaseModel):
+    path: str
+    ts_col: str = "ts_ms"
+    symbol_col: str = "symbol"
+    price_col: str = "ref_price"
+
+
+class SandboxConfig(BaseModel):
+    mode: str = "backtest"
+    symbol: str = "BTCUSDT"
+    latency_steps: int = 0
+    sim_config_path: str
+    exchange_specs_path: Optional[str] = None
+    sim_guards: Dict[str, Any] = Field(default_factory=dict)
+    min_signal_gap_s: int = 0
+    no_trade: Dict[str, Any] = Field(default_factory=dict)
+    strategy: StrategyConfig = StrategyConfig()
+    data: DataConfig
+    dynamic_spread: Dict[str, Any] = Field(default_factory=dict)
+    out_reports: Optional[str] = None
+
+
+def load_config(path: str) -> SandboxConfig:
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return SandboxConfig(**data)
+
+
+def load_config_from_str(content: str) -> SandboxConfig:
+    data = yaml.safe_load(content) or {}
+    return SandboxConfig(**data)
+
+
+__all__ = ["SandboxConfig", "load_config", "load_config_from_str"]


### PR DESCRIPTION
## Summary
- add Pydantic-based ingest and sandbox configuration loaders
- refactor ingest orchestrator and Streamlit app to use typed config loading and service `from_config`
- support loading configuration from YAML strings

## Testing
- `pytest` *(fails: Expected '=' after a key in a key/value pair (pyproject.toml))*
- `python -m py_compile app.py core_config.py ingest_orchestrator.py ingest_config.py legacy_sandbox_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde63de810832faec7130e856de952