### PR TITLE
Introduce Strategy protocol and align strategies

### DIFF
--- a/base.py
+++ b/base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from core_strategy import Strategy
+
 from action_proto import ActionProto, ActionType
 
 
@@ -45,7 +47,7 @@ class Decision:
         )
 
 
-class BaseStrategy:
+class BaseStrategy(Strategy):
     """
     Базовый класс стратегии.
 
@@ -63,6 +65,16 @@ class BaseStrategy:
 
     def __init__(self, **params: Any) -> None:
         self.params: Dict[str, Any] = dict(params or {})
+
+    # --- Strategy interface -------------------------------------------------
+
+    def setup(self, config: Dict[str, Any]) -> None:  # pragma: no cover - trivial
+        """Configure strategy with ``config`` parameters."""
+        self.params.update(dict(config or {}))
+
+    def on_features(self, row: Dict[str, Any]) -> None:  # pragma: no cover - trivial
+        """Receive feature row from pipeline. Base implementation does nothing."""
+        return None
 
     def decide(self, ctx: Dict[str, Any]) -> List[Decision]:
         """

--- a/core_strategy.py
+++ b/core_strategy.py
@@ -1,0 +1,24 @@
+"""Core strategy contract and protocol."""
+from __future__ import annotations
+
+from typing import Protocol, Dict, Any, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class Strategy(Protocol):
+    """Trading strategy interface."""
+
+    def setup(self, config: Dict[str, Any]) -> None:
+        """Initialize strategy with configuration."""
+        ...
+
+    def on_features(self, row: Dict[str, Any]) -> None:
+        """Receive new feature row from pipeline."""
+        ...
+
+    def decide(self, ctx: Dict[str, Any]) -> Sequence[Any]:
+        """Make trading decision given context."""
+        ...
+
+
+__all__ = ["Strategy"]

--- a/momentum.py
+++ b/momentum.py
@@ -30,6 +30,7 @@ class MomentumStrategy(BaseStrategy):
         self._window = deque(maxlen=self.lookback)
 
     def on_features(self, row: Dict[str, Any]) -> None:
+        super().on_features(row)
         # ожидаем, что ref_price присутствует в features (или придёт в ctx)
         price = row.get("ref_price")
         if price is not None:

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -27,11 +27,7 @@ from core_contracts import FeaturePipe
 from services.utils_config import snapshot_config  # снапшот конфига (Фаза 3)  # noqa: F401
 from core_config import CommonRunConfig
 import di_registry
-
-
-class Strategy(Protocol):
-    def on_features(self, feats: Dict[str, Any]) -> None: ...
-    def decide(self, ctx: Dict[str, Any]) -> Sequence[Any]: ...
+from core_strategy import Strategy
 
 
 class RiskGuards(Protocol):


### PR DESCRIPTION
## Summary
- define reusable `Strategy` protocol
- implement setup and feature hooks in `BaseStrategy`
- update momentum strategy and service runner to use the new contract

## Testing
- `python - <<'PY'
import sys, pytest
sys.path.append('/workspace/TradingBot')
res = pytest.main(['/workspace/TradingBot/tests/test_market_utils.py','-c','/tmp/empty.ini'])
print('pytest exit code', res)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68be8821ef4c832f9bb5c2f839fd39c6