### PR TITLE
refactor: use core Strategy interface in services

### DIFF
--- a/sandbox/backtest_adapter.py
+++ b/sandbox/backtest_adapter.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from strategies.base import BaseStrategy
+from core_strategy import Strategy
 from sandbox.sim_adapter import SimAdapter
 from exchange.specs import load_specs, round_price_to_tick, round_qty_to_step, notional_ok
 
@@ -87,7 +87,7 @@ class BacktestAdapter:
     """
     def __init__(
         self,
-        strategy: BaseStrategy,
+        strategy: Strategy,
         sim_bridge: SimAdapter,
         dynamic_spread_config: Optional[Dict[str, Any]] = None,
         exchange_specs_path: Optional[str] = None,

--- a/service_backtest.py
+++ b/service_backtest.py
@@ -24,7 +24,7 @@ import pandas as pd
 from execution_sim import ExecutionSimulator  # type: ignore
 from sandbox.backtest_adapter import BacktestAdapter
 from sandbox.sim_adapter import SimAdapter
-from strategies.base import BaseStrategy  # существующий контракт стратегии
+from core_strategy import Strategy
 from services.utils_config import snapshot_config  # сохранение снапшота конфига
 from core_config import CommonRunConfig
 import di_registry
@@ -57,7 +57,7 @@ class ServiceBacktest:
         def stream_ticks(self, symbols):  # pragma: no cover - простая заглушка
             return iter(())
 
-    def __init__(self, strategy: BaseStrategy, sim: ExecutionSimulator, cfg: Optional[BacktestConfig] = None) -> None:
+    def __init__(self, strategy: Strategy, sim: ExecutionSimulator, cfg: Optional[BacktestConfig] = None) -> None:
         self.strategy = strategy
         self.sim = sim
         self.cfg = cfg or BacktestConfig()
@@ -108,7 +108,7 @@ def from_config(
         Additional service configuration.
     """
     container = di_registry.build_graph(cfg.components, cfg)
-    strat: BaseStrategy = container["strategy"]
+    strat: Strategy = container["strategy"]
     sim: ExecutionSimulator = container["executor"]  # type: ignore[assignment]
     service = ServiceBacktest(strat, sim, svc_cfg)
     return service.run(df, ts_col=ts_col, symbol_col=symbol_col, price_col=price_col)

--- a/services/utils_sandbox.py
+++ b/services/utils_sandbox.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 import pandas as pd
 
-from strategies.base import BaseStrategy
+from core_strategy import Strategy
 
 
 def read_df(path: str) -> pd.DataFrame:
@@ -17,10 +17,10 @@ def read_df(path: str) -> pd.DataFrame:
     return pd.read_csv(path)
 
 
-def build_strategy(mod: str, cls: str, params: Dict[str, Any]) -> BaseStrategy:
+def build_strategy(mod: str, cls: str, params: Dict[str, Any]) -> Strategy:
     """Создаёт стратегию и вызывает setup."""
     m = importlib.import_module(mod)
     Cls = getattr(m, cls)
-    s: BaseStrategy = Cls()
+    s: Strategy = Cls()
     s.setup(params or {})
     return s


### PR DESCRIPTION
## Summary
- switch services to import Strategy protocol from core
- annotate strategy dependencies with Strategy interface
- keep strategy instances supplied via di_registry

## Testing
- `pytest` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68be8a98b038832fa03269a55917baf8