### PR TITLE
refactor: centralize Decision dataclass

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,9 +48,9 @@ core_ → impl_ → service_ → strategies → scripts_
 
 ```python
 # strategies/momentum.py
-from strategies.base import BaseStrategy, Decision
+from core_strategy import Strategy, Decision
 
-class MomentumStrategy(BaseStrategy):
+class MomentumStrategy(Strategy):
     def decide(self, ctx: dict) -> list[Decision]:
         if ctx["ref_price"] > ctx["features"]["ma"]:
             return [Decision(side="BUY", volume_frac=0.1)]

--- a/core_strategy.py
+++ b/core_strategy.py
@@ -1,7 +1,10 @@
 """Core strategy contract and protocol."""
 from __future__ import annotations
 
-from typing import Protocol, Dict, Any, Sequence, runtime_checkable
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol, Sequence, runtime_checkable
+
+from action_proto import ActionProto, ActionType
 
 
 @runtime_checkable
@@ -21,4 +24,47 @@ class Strategy(Protocol):
         ...
 
 
-__all__ = ["Strategy"]
+@dataclass(frozen=True)
+class Decision:
+    """High level strategy decision.
+
+    Parameters
+    ----------
+    side:
+        "BUY" or "SELL" direction of the order.
+    volume_frac:
+        Target order size as a fraction of the allowed position in
+        range ``[-1.0; 1.0]``.  Sign defines the side for market orders.
+    price_offset_ticks:
+        Price offset in ticks for limit orders.  Ignored for market
+        orders.
+    tif:
+        Time in force of the order: ``GTC``, ``IOC`` or ``FOK``.
+    client_tag:
+        Optional custom tag attached to resulting orders.
+    """
+
+    side: str
+    volume_frac: float
+    price_offset_ticks: int = 0
+    tif: str = "GTC"
+    client_tag: Optional[str] = None
+
+    def to_action_proto(self) -> ActionProto:
+        """Convert decision to :class:`ActionProto` without information loss."""
+        v = float(self.volume_frac)
+        if str(self.side).upper() == "SELL":
+            v = -abs(v)
+        else:
+            v = abs(v)
+        return ActionProto(
+            action_type=(
+                ActionType.MARKET if self.price_offset_ticks == 0 else ActionType.LIMIT
+            ),
+            volume_frac=v,
+            price_offset_ticks=int(self.price_offset_ticks),
+            tif=str(self.tif),
+            client_tag=self.client_tag,
+        )
+
+__all__ = ["Strategy", "Decision"]

--- a/order_shims.py
+++ b/order_shims.py
@@ -24,7 +24,7 @@ from decimal import Decimal
 from typing import Any, Dict, Mapping, Optional, Callable, Sequence, List
 
 from core_models import Order, OrderIntent, Side, OrderType, TimeInForce
-from strategies.base import Decision
+from core_strategy import Decision
 try:
     from action_proto import ActionProto, ActionType
 except Exception:

--- a/sandbox/sim_adapter.py
+++ b/sandbox/sim_adapter.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Iterator, Protoco
 
 from execution_sim import ExecutionSimulator, SimStepReport as ExecReport  # type: ignore
 from action_proto import ActionProto, ActionType
-from strategies.base import Decision
+from core_strategy import Decision
 from core_models import Bar, as_dict
 from compat_shims import sim_report_dict_to_core_exec_reports
 from event_bus import log_trade_exec as _bus_log_trade_exec

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,4 +1,5 @@
-from .base import BaseStrategy, Decision
+from core_strategy import Decision
+from .base import BaseStrategy
 from .momentum import MomentumStrategy
 
 __all__ = [

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,50 +1,9 @@
 # strategies/base.py
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from core_strategy import Strategy
-
-from action_proto import ActionProto, ActionType
-
-
-@dataclass(frozen=True)
-class Decision:
-    """
-    Результат решения стратегии на шаге.
-
-    Поля:
-      - side: "BUY" | "SELL"
-      - volume_frac: целевая величина заявки в долях позиции ([-1.0; 1.0]).
-        Для MARKET это величина, знак задаёт сторону.
-      - price_offset_ticks: сдвиг цены в тиках для LIMIT (по умолчанию 0; для MARKET игнорируется)
-      - tif: GTC|IOC|FOK (строка, совместимо с ActionProto.tif)
-      - client_tag: произвольная метка стратегии
-    """
-    side: str
-    volume_frac: float
-    price_offset_ticks: int = 0
-    tif: str = "GTC"
-    client_tag: Optional[str] = None
-
-    def to_action_proto(self) -> ActionProto:
-        """
-        Преобразование решения в ActionProto без потери информации.
-        Для side="BUY" volume_frac >= 0; для "SELL" — volume_frac <= 0.
-        """
-        v = float(self.volume_frac)
-        if str(self.side).upper() == "SELL":
-            v = -abs(v)
-        else:
-            v = abs(v)
-        return ActionProto(
-            action_type=(ActionType.MARKET if self.price_offset_ticks == 0 else ActionType.LIMIT),
-            volume_frac=v,
-            price_offset_ticks=int(self.price_offset_ticks),
-            tif=str(self.tif),
-            client_tag=self.client_tag,
-        )
+from core_strategy import Decision, Strategy
 
 
 class BaseStrategy(Strategy):
@@ -82,3 +41,6 @@ class BaseStrategy(Strategy):
         Реализации должны вернуть список Decision.
         """
         return []
+
+
+__all__ = ["BaseStrategy", "Decision"]

--- a/strategies/momentum.py
+++ b/strategies/momentum.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from collections import deque
 from typing import Any, Dict, List
 
-from .base import BaseStrategy, Decision
+from core_strategy import Decision
+from .base import BaseStrategy
 
 
 class MomentumStrategy(BaseStrategy):
@@ -46,7 +47,7 @@ class MomentumStrategy(BaseStrategy):
         avg = sum(self._window) / float(len(self._window))
         out: List[Decision] = []
         if float(ref) > avg + self.threshold:
-            out.append(Decision(kind="MARKET", side="BUY", volume_frac=self.order_qty))
+            out.append(Decision(side="BUY", volume_frac=self.order_qty))
         elif float(ref) < avg - self.threshold:
-            out.append(Decision(kind="MARKET", side="SELL", volume_frac=self.order_qty))
+            out.append(Decision(side="SELL", volume_frac=self.order_qty))
         return out


### PR DESCRIPTION
## Summary
- define Decision dataclass in core_strategy and export it
- update strategies and shims to import Decision from core_strategy
- refresh documentation snippet to show new import path

## Testing
- `python -m py_compile core_strategy.py order_shims.py sandbox/sim_adapter.py strategies/__init__.py strategies/base.py strategies/momentum.py`
- `pytest` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68be95a8de70832f960d133ce875c4dc