### PR TITLE
Use fractional order quantity in Momentum strategy

### DIFF
--- a/app.py
+++ b/app.py
@@ -928,7 +928,7 @@ strategy:
   params:
     lookback: 5
     threshold: 0.0
-    order_qty: 0.001
+    order_qty: 0.1  # доля позиции
 data:
   path: "data/train.parquet"
   ts_col: "ts_ms"
@@ -975,7 +975,7 @@ strategy:
   params:
     lookback: 5
     threshold: 0.0
-    order_qty: 0.001
+    order_qty: 0.1  # доля позиции
     model_path: "artifacts/model.pkl"
 features:
   lookbacks_prices: [5, 15, 60]

--- a/configs/legacy_realtime.yaml
+++ b/configs/legacy_realtime.yaml
@@ -29,7 +29,7 @@ strategy:
   params:
     lookback: 5
     threshold: 0.0
-    order_qty: 0.001
+    order_qty: 0.1  # доля позиции
 
 features:
   lookbacks_prices: [5, 15, 60]

--- a/configs/legacy_sandbox.yaml
+++ b/configs/legacy_sandbox.yaml
@@ -34,7 +34,7 @@ strategy:
   params:
     lookback: 5
     threshold: 0.0
-    order_qty: 0.001
+    order_qty: 0.1  # доля позиции
 
 data:
   path: "data/train.parquet"   # или любой CSV/Parquet с колонками: ts_ms, symbol, ref_price(+фичи)


### PR DESCRIPTION
## Summary
- Use named fields for all Decision parameters in MomentumStrategy
- Allow configuring price_offset_ticks, tif and client_tag
- Treat `order_qty` as position fraction in sample configs and docs

## Testing
- `python - <<'PY'
import sys
import logging
sys.path.append('/workspace/TradingBot')
import pytest
exit(pytest.main(['-c','/dev/null','/workspace/TradingBot/tests/test_market_utils.py']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68be9728770c832fa13111242f4b683d