### PR TITLE
Add CVaR metric to equity metrics and reports

### DIFF
--- a/service_eval.py
+++ b/service_eval.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Service for evaluating strategy performance.
 
+Includes equity metrics such as Sharpe, Sortino and Conditional Value at Risk (CVaR).
+
 Example
 -------
 ```python


### PR DESCRIPTION
## Summary
- add `cvar` field and computation for equity metrics via new `_cvar` helper
- expose CVaR in evaluation output and documentation

## Testing
- `pytest -c /tmp/pytest.ini tests/test_market_utils.py -q` *(fails: ModuleNotFoundError: No module named 'utils_time')*


------
https://chatgpt.com/codex/tasks/task_e_68bea32a221c832f827bba9a7ce4c726