### PR TITLE
Add run comparison script and docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,6 +94,21 @@ python run_sandbox.py          --config configs/config_sim.yaml
 python evaluate_performance.py --config configs/config_eval.yaml
 ```
 
+### Сравнение запусков
+
+Для агрегирования результатов нескольких прогонов используйте скрипт
+`script_compare_runs.py`. Он принимает список путей к файлам
+`metrics.json` или каталогам запусков и формирует таблицу ключевых
+метрик:
+
+```bash
+python script_compare_runs.py run1/ run2/metrics.json --csv summary.csv
+```
+
+В консоль выводятся значения `run_id`, `Sharpe`, `Sortino`, `MDD`, `PnL`,
+`Hit-rate`, `CVaR` и других найденных показателей. При указании флага
+`--csv` таблица сохраняется в указанный файл.
+
 ## ServiceTrain
 
 `ServiceTrain` подготавливает датасет и запускает обучение модели.  Он

--- a/script_compare_runs.py
+++ b/script_compare_runs.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Aggregate metrics from multiple runs.
+
+This script loads ``metrics.json`` files and prints a table with key
+performance indicators.  Each path supplied on the command line may
+point directly to a ``metrics.json`` file or to a directory containing
+one.  The resulting table is printed to stdout and may optionally be
+saved to a CSV file.
+"""
+import argparse
+import csv
+import json
+import os
+import sys
+from typing import Dict, Tuple
+
+# Known aliases for canonical metric names.
+KEY_ALIASES = {
+    "sharpe": ["sharpe", "sharpe_ratio"],
+    "sortino": ["sortino", "sortino_ratio"],
+    "mdd": ["max_drawdown", "mdd"],
+    "pnl": ["pnl", "pnl_total", "profit"],
+    "hit_rate": ["hit_rate", "hitratio", "hit_ratio"],
+    "cvar": ["cvar", "conditional_value_at_risk"],
+}
+
+
+def _find_metrics_file(path: str) -> str | None:
+    """Return path to metrics.json for the given input path."""
+    if os.path.isdir(path):
+        candidate = os.path.join(path, "metrics.json")
+        if os.path.isfile(candidate):
+            return candidate
+        for root, _, files in os.walk(path):
+            if "metrics.json" in files:
+                return os.path.join(root, "metrics.json")
+        return None
+    if os.path.isfile(path):
+        return path
+    return None
+
+
+def _flatten(prefix: str, obj, out: Dict[str, float]) -> None:
+    """Recursively flattens dictionaries of metrics."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            _flatten(f"{prefix}{key}.", value, out)
+    else:
+        out[prefix[:-1]] = obj
+
+
+def _load_metrics(path: str) -> Tuple[str, Dict[str, float]]:
+    """Load metrics from the given run path."""
+    metrics_file = _find_metrics_file(path)
+    if not metrics_file:
+        raise FileNotFoundError(f"metrics.json not found for {path}")
+    with open(metrics_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    flat: Dict[str, float] = {}
+    _flatten("", data, flat)
+
+    result: Dict[str, float] = {}
+    remaining = dict(flat)
+    for canon, aliases in KEY_ALIASES.items():
+        for alias in aliases:
+            if alias in remaining:
+                result[canon] = remaining.pop(alias)
+                break
+    result.update(remaining)
+
+    run_id = os.path.basename(os.path.dirname(metrics_file))
+    return run_id, result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare metrics from multiple runs.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Paths to metrics.json files or run directories.",
+    )
+    parser.add_argument(
+        "--csv",
+        help="Optional path to save CSV output.",
+    )
+    args = parser.parse_args()
+
+    rows = []
+    all_keys = set()
+    for path in args.paths:
+        try:
+            run_id, metrics = _load_metrics(path)
+        except FileNotFoundError as exc:  # pragma: no cover - user feedback
+            print(exc, file=sys.stderr)
+            continue
+        rows.append({"run_id": run_id, **metrics})
+        all_keys.update(metrics.keys())
+
+    preferred = ["sharpe", "sortino", "mdd", "pnl", "hit_rate", "cvar"]
+    ordered_keys = [k for k in preferred if k in all_keys]
+    ordered_keys += sorted(k for k in all_keys if k not in ordered_keys)
+    headers = ["run_id"] + ordered_keys
+
+    def write_rows(writer: csv.writer) -> None:
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow([row.get(h, "") for h in headers])
+
+    write_rows(csv.writer(sys.stdout))
+
+    if args.csv:
+        with open(args.csv, "w", newline="", encoding="utf-8") as f:
+            write_rows(csv.writer(f))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `script_compare_runs.py` to aggregate metrics from `metrics.json` files
- document run comparison usage in architecture guide

## Testing
- `python script_compare_runs.py /tmp/run1 /tmp/run2`
- `pytest -q` *(fails: Expected '=' after a key in a key/value pair in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68bea526eed8832fb08e6003bd3abba4