### PR TITLE
Use runid in equity log paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,7 +147,7 @@ from_config(cfg_run, trainer=trainer, train_cfg=cfg)
 1700000000000,sim,BTCUSDT,BUY,LIMIT,30000,0.01,0.0005,USDT,FILLED,TAKER,c1,o1,t1,15.0,30010,1005.0,{}
 ```
 
-### `logs/sim_reports.csv`
+### `logs/report_equity_<runid>.csv`
 
 - Строки соответствуют [`EquityPoint`](core_models.py).
 - Обязательные колонки: `ts`, `run_id`, `symbol`, `fee_total`,

--- a/aggregate_exec_logs.py
+++ b/aggregate_exec_logs.py
@@ -253,7 +253,11 @@ def aggregate(
 def main() -> None:
     p = argparse.ArgumentParser(description="Aggregate execution logs into per-bar and per-day summaries.")
     p.add_argument("--trades", required=True, help="Path or glob to unified Exec logs (log_trades_*.csv). Legacy trades.csv is supported but deprecated.")
-    p.add_argument("--reports", default="", help="Optional path or glob to equity reports (csv/parquet)")
+    p.add_argument(
+        "--reports",
+        default="",
+        help="Optional path or glob to equity reports (report_equity_*.csv)",
+    )
     p.add_argument("--out-bars", default="logs/agg_bars.csv", help="Output CSV path for per-bar aggregation")
     p.add_argument("--out-days", default="logs/agg_days.csv", help="Output CSV path for per-day aggregation")
     p.add_argument("--bar-seconds", type=int, default=60, help="Bar length in seconds (default: 60)")

--- a/configs/legacy_sim.yaml
+++ b/configs/legacy_sim.yaml
@@ -71,5 +71,5 @@ logging:
   enabled: true
   format: "csv"                 # "csv" | "parquet"
   trades_path: "logs/log_trades_<runid>.csv"
-  reports_path: "logs/sim_reports.csv"
+  reports_path: "logs/report_equity_<runid>.csv"
   flush_every: 1000

--- a/logging.py
+++ b/logging.py
@@ -27,7 +27,7 @@ class LogConfig:
     enabled: bool = True
     format: str = "csv"
     trades_path: str = "logs/log_trades_<runid>.csv"
-    reports_path: str = "logs/sim_reports.csv"
+    reports_path: str = "logs/report_equity_<runid>.csv"
     flush_every: int = 1000
 
     @classmethod
@@ -36,7 +36,7 @@ class LogConfig:
             enabled=bool(d.get("enabled", True)),
             format=str(d.get("format", "csv")).lower(),
             trades_path=str(d.get("trades_path", "logs/log_trades_<runid>.csv")),
-            reports_path=str(d.get("reports_path", "logs/reports.csv")),
+            reports_path=str(d.get("reports_path", "logs/report_equity_<runid>.csv")),
             flush_every=int(d.get("flush_every", 1000)),
         )
 

--- a/service_backtest.py
+++ b/service_backtest.py
@@ -69,7 +69,7 @@ class ServiceBacktest:
         logs_dir = self.cfg.logs_dir or "logs"
         logging_config = {
             "trades_path": os.path.join(logs_dir, f"log_trades_{run_id}.csv"),
-            "reports_path": os.path.join(logs_dir, f"sim_reports_{run_id}.csv"),
+            "reports_path": os.path.join(logs_dir, f"report_equity_{run_id}.csv"),
         }
         try:  # переподключаем логгер симулятора с нужными путями
             from logging import LogWriter, LogConfig  # type: ignore

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -83,7 +83,7 @@ class ServiceSignalRunner:
         if sim is not None:
             logging_config = {
                 "trades_path": os.path.join(logs_dir, f"log_trades_{run_id}.csv"),
-                "reports_path": os.path.join(logs_dir, f"sim_reports_{run_id}.csv"),
+                "reports_path": os.path.join(logs_dir, f"report_equity_{run_id}.csv"),
             }
             try:
                 from logging import LogWriter, LogConfig  # type: ignore


### PR DESCRIPTION
## Summary
- default equity report path uses report_equity_<runid>.csv
- services supply new equity report path to simulator loggers
- docs and helper scripts reference report_equity_<runid>.csv convention

## Testing
- `python -m py_compile logging.py service_backtest.py service_signal_runner.py aggregate_exec_logs.py`
- `python aggregate_exec_logs.py --help`
- `python script_compare_runs.py --help`
- `pytest` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68beacf26a00832f83aeb430692e8d9a