### PR TITLE
docs: document cli entry points

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,19 @@ python script_compare_runs.py run1/ run2/metrics.json --csv summary.csv
 `Hit-rate`, `CVaR` и других найденных показателей. При указании флага
 `--csv` таблица сохраняется в указанный файл.
 
+## CLI‑точки входа
+
+Все консольные скрипты используют DI‑контейнер и не содержат бизнес‑логики. Они
+описывают аргументы командной строки и делегируют работу соответствующим
+сервисам:
+
+- `script_train.py` — запускает обучение через `ServiceTrain`.
+- `script_backtest.py` — проводит бэктест через `ServiceBacktest`.
+- `script_eval.py` — рассчитывает метрики через `ServiceEval`.
+- `script_live.py` — исполняет стратегию на живых данных через `ServiceSignalRunner`.
+- `script_calibrate_tcost.py` — калибрует параметры T‑cost через `ServiceCalibrateTCost`.
+- `script_calibrate_slippage.py` — калибрует проскальзывание через `ServiceCalibrateSlippage`.
+
 ## ServiceTrain
 
 `ServiceTrain` подготавливает датасет и запускает обучение модели.  Он

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# TradingBot
+
+Скрипты `script_*.py` выступают CLI‑точками входа в сервисы. Все они
+используют dependency injection и не содержат бизнес‑логики, ограничиваясь
+описанием аргументов и вызовом соответствующих сервисов.
+
+## Примеры запуска
+
+```bash
+python script_backtest.py --config configs/config_sim.yaml
+python script_train.py --config configs/train.yaml --trainer-module mypackage.trainer:MyTrainer
+```
+


### PR DESCRIPTION
## Summary
- document CLI entry points and Dependency Injection usage
- add run examples to README

## Testing
- `pytest` *(fails: Expected '=' after a key in a key/value pair in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68bebced16e4832faa6b6e47583dcdfd