### PR TITLE
refactor: update feature pipe protocol

### DIFF
--- a/app.py
+++ b/app.py
@@ -461,7 +461,7 @@ with tabs[6]:
             def warmup(self):
                 pass
 
-            def on_bar(self, bar):
+            def update(self, bar):
                 return {"ref_price": float(bar.close)}
 
         class DummyStrat:

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -54,7 +54,7 @@ class _Provider(DecisionsProvider):
         self._guards = guards
 
     def on_bar(self, bar: Bar):
-        feats = self._fp.on_bar(bar)
+        feats = self._fp.update(bar)
         self._strat.on_features({**feats, "ref_price": float(bar.close)})
         dec = list(self._strat.decide({"ts_ms": int(bar.ts), "symbol": bar.symbol, "ref_price": float(bar.close), "features": feats}) or [])
         if self._guards:


### PR DESCRIPTION
## Summary
- replace `on_bar` with `update` in `FeaturePipe` protocol
- support optional offline methods (`fit`, `transform_df`, `make_targets`)
- update ServiceSignalRunner and demo to use new `update` method

## Testing
- `pytest` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68becce22198832f9e82eda362584b3c