### PR TITLE
Use FeaturePipe.update in provider

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -54,6 +54,8 @@ class _Provider(DecisionsProvider):
         self._guards = guards
 
     def on_bar(self, bar: Bar):
+        # FeaturePipe now uses ``update`` for streaming features
+        # (``on_bar`` is kept only as a backward-compatible alias).
         feats = self._fp.update(bar)
         self._strat.on_features({**feats, "ref_price": float(bar.close)})
         dec = list(self._strat.decide({"ts_ms": int(bar.ts), "symbol": bar.symbol, "ref_price": float(bar.close), "features": feats}) or [])


### PR DESCRIPTION
## Summary
- clarify FeaturePipe usage in ServiceSignalRunner provider to call `update` instead of legacy `on_bar`

## Testing
- `PYTHONPATH=. pytest -q -c /dev/null` *(fails: cannot import name 'LogRecord' from 'logging')*

------
https://chatgpt.com/codex/tasks/task_e_68bed03a6ea8832f92b641cd8d7c8750