### PR TITLE
feat: define signal policy interface

### DIFF
--- a/core_contracts.py
+++ b/core_contracts.py
@@ -101,14 +101,29 @@ class RiskGuards(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class PolicyCtx:
+    """
+    Контекст принятия решения, который может предоставлять BacktestEngine/сервис.
+    Обязательные поля: ``ts`` (мс) и ``symbol``.
+    Дополнительно могут передаваться текущая позиция и лимиты портфеля.
+    """
+
+    ts: int
+    symbol: str
+    position: Optional[Position] = None
+    limits: Optional[PortfolioLimits] = None
+    extra: Optional[Dict[str, Any]] = None
+
+
 @runtime_checkable
 class SignalPolicy(Protocol):
     """
-    Политика принятия решений. На вход подаются признаки и контекст.
-    Возвращает список заявок (Order) для исполнения.
+    Политика принятия решений. На вход подаются признаки и контекст,
+    возвращает список заявок (:class:`Order`) для исполнения.
     """
 
-    def decide(self, features: Mapping[str, Any], ctx: Mapping[str, Any]) -> List[Order]:
+    def decide(self, features: Mapping[str, Any], ctx: PolicyCtx) -> List[Order]:
         ...
 
 
@@ -123,17 +138,3 @@ class BacktestEngine(Protocol):
         Возвращает словарь с итоговыми артефактами: trades: List[ExecReport], equity: List[Dict], metrics: Dict
         """
         ...
-
-
-@dataclass(frozen=True)
-class DecisionContext:
-    """
-    Контекст принятия решения, который может предоставлять BacktestEngine/сервис.
-    Обязательные ключи: ts (int ms), symbol (str).
-    Дополнительно: position (Position), limits (PortfolioLimits), extra (Dict[str, Any]).
-    """
-    ts: int
-    symbol: str
-    position: Optional[Position] = None
-    limits: Optional[PortfolioLimits] = None
-    extra: Optional[Dict[str, Any]] = None

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,9 +1,10 @@
 from core_strategy import Decision
-from .base import BaseStrategy
+from .base import BaseSignalPolicy, BaseStrategy
 from .momentum import MomentumStrategy
 
 __all__ = [
     "BaseStrategy",
+    "BaseSignalPolicy",
     "Decision",
     "MomentumStrategy",
 ]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,8 +1,11 @@
 # strategies/base.py
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from decimal import Decimal
+from typing import Any, Dict, List, Mapping, Sequence
 
+from core_contracts import PolicyCtx, SignalPolicy
+from core_models import Order, OrderType, Side, TimeInForce, to_decimal
 from core_strategy import Decision, Strategy
 
 
@@ -43,4 +46,76 @@ class BaseStrategy(Strategy):
         return []
 
 
-__all__ = ["BaseStrategy", "Decision"]
+class BaseSignalPolicy(SignalPolicy):
+    """Convenience base class for :class:`SignalPolicy` implementations."""
+
+    required_features: Sequence[str] = ()
+
+    def __init__(self, **params: Any) -> None:
+        self.params: Dict[str, Any] = dict(params)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _validate_inputs(self, features: Mapping[str, Any], ctx: PolicyCtx) -> None:
+        if not isinstance(features, Mapping):
+            raise TypeError("features must be a mapping")
+        if not isinstance(ctx, PolicyCtx):
+            raise TypeError("ctx must be PolicyCtx")
+        if ctx.ts is None or ctx.symbol is None:
+            raise ValueError("ctx.ts and ctx.symbol must be provided")
+        for name in self.required_features:
+            if name not in features:
+                raise ValueError(f"missing feature '{name}'")
+
+    def decide(self, features: Mapping[str, Any], ctx: PolicyCtx) -> List[Order]:
+        self._validate_inputs(features, ctx)
+        return []
+
+    # Helper methods to construct orders
+    def market_order(
+        self,
+        *,
+        side: Side,
+        qty: Decimal | float | int,
+        ctx: PolicyCtx,
+        tif: TimeInForce = TimeInForce.GTC,
+        client_tag: str | None = None,
+    ) -> Order:
+        quantity = to_decimal(qty)
+        return Order(
+            ts=ctx.ts,
+            symbol=ctx.symbol,
+            side=side,
+            order_type=OrderType.MARKET,
+            quantity=quantity,
+            price=None,
+            time_in_force=tif,
+            client_order_id=client_tag or "",
+        )
+
+    def limit_order(
+        self,
+        *,
+        side: Side,
+        qty: Decimal | float | int,
+        price: Decimal | float | int,
+        ctx: PolicyCtx,
+        tif: TimeInForce = TimeInForce.GTC,
+        client_tag: str | None = None,
+    ) -> Order:
+        quantity = to_decimal(qty)
+        price_dec = to_decimal(price)
+        return Order(
+            ts=ctx.ts,
+            symbol=ctx.symbol,
+            side=side,
+            order_type=OrderType.LIMIT,
+            quantity=quantity,
+            price=price_dec,
+            time_in_force=tif,
+            client_order_id=client_tag or "",
+        )
+
+
+__all__ = ["BaseStrategy", "Decision", "BaseSignalPolicy"]


### PR DESCRIPTION
## Summary
- formalize signal policy API and introduce PolicyCtx context dataclass
- provide BaseSignalPolicy helper with validation and order builders

## Testing
- `ruff --isolated check strategies/base.py strategies/__init__.py`
- `mypy strategies/base.py strategies/__init__.py --ignore-missing-imports --follow-imports=skip`
- `python check_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68be85b61168832fafdb65a055eb13a3