### PR TITLE
refactor: migrate momentum to signal policy

### DIFF
--- a/core_contracts.py
+++ b/core_contracts.py
@@ -101,14 +101,29 @@ class RiskGuards(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class PolicyCtx:
+    """
+    Контекст принятия решения, который может предоставлять BacktestEngine/сервис.
+    Обязательные поля: ``ts`` (мс) и ``symbol``.
+    Дополнительно могут передаваться текущая позиция и лимиты портфеля.
+    """
+
+    ts: int
+    symbol: str
+    position: Optional[Position] = None
+    limits: Optional[PortfolioLimits] = None
+    extra: Optional[Dict[str, Any]] = None
+
+
 @runtime_checkable
 class SignalPolicy(Protocol):
     """
-    Политика принятия решений. На вход подаются признаки и контекст.
-    Возвращает список заявок (Order) для исполнения.
+    Политика принятия решений. На вход подаются признаки и контекст,
+    возвращает список заявок (:class:`Order`) для исполнения.
     """
 
-    def decide(self, features: Mapping[str, Any], ctx: Mapping[str, Any]) -> List[Order]:
+    def decide(self, features: Mapping[str, Any], ctx: PolicyCtx) -> List[Order]:
         ...
 
 
@@ -123,17 +138,3 @@ class BacktestEngine(Protocol):
         Возвращает словарь с итоговыми артефактами: trades: List[ExecReport], equity: List[Dict], metrics: Dict
         """
         ...
-
-
-@dataclass(frozen=True)
-class DecisionContext:
-    """
-    Контекст принятия решения, который может предоставлять BacktestEngine/сервис.
-    Обязательные ключи: ts (int ms), symbol (str).
-    Дополнительно: position (Position), limits (PortfolioLimits), extra (Dict[str, Any]).
-    """
-    ts: int
-    symbol: str
-    position: Optional[Position] = None
-    limits: Optional[PortfolioLimits] = None
-    extra: Optional[Dict[str, Any]] = None

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,9 +1,10 @@
 from core_strategy import Decision
-from .base import BaseStrategy
+from .base import BaseSignalPolicy, BaseStrategy
 from .momentum import MomentumStrategy
 
 __all__ = [
     "BaseStrategy",
+    "BaseSignalPolicy",
     "Decision",
     "MomentumStrategy",
 ]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,8 +1,11 @@
 # strategies/base.py
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from decimal import Decimal
+from typing import Any, Dict, List, Mapping, Sequence
 
+from core_contracts import PolicyCtx, SignalPolicy
+from core_models import Order, OrderType, Side, TimeInForce, to_decimal
 from core_strategy import Decision, Strategy
 
 
@@ -43,4 +46,76 @@ class BaseStrategy(Strategy):
         return []
 
 
-__all__ = ["BaseStrategy", "Decision"]
+class BaseSignalPolicy(SignalPolicy):
+    """Convenience base class for :class:`SignalPolicy` implementations."""
+
+    required_features: Sequence[str] = ()
+
+    def __init__(self, **params: Any) -> None:
+        self.params: Dict[str, Any] = dict(params)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _validate_inputs(self, features: Mapping[str, Any], ctx: PolicyCtx) -> None:
+        if not isinstance(features, Mapping):
+            raise TypeError("features must be a mapping")
+        if not isinstance(ctx, PolicyCtx):
+            raise TypeError("ctx must be PolicyCtx")
+        if ctx.ts is None or ctx.symbol is None:
+            raise ValueError("ctx.ts and ctx.symbol must be provided")
+        for name in self.required_features:
+            if name not in features:
+                raise ValueError(f"missing feature '{name}'")
+
+    def decide(self, features: Mapping[str, Any], ctx: PolicyCtx) -> List[Order]:
+        self._validate_inputs(features, ctx)
+        return []
+
+    # Helper methods to construct orders
+    def market_order(
+        self,
+        *,
+        side: Side,
+        qty: Decimal | float | int,
+        ctx: PolicyCtx,
+        tif: TimeInForce = TimeInForce.GTC,
+        client_tag: str | None = None,
+    ) -> Order:
+        quantity = to_decimal(qty)
+        return Order(
+            ts=ctx.ts,
+            symbol=ctx.symbol,
+            side=side,
+            order_type=OrderType.MARKET,
+            quantity=quantity,
+            price=None,
+            time_in_force=tif,
+            client_order_id=client_tag or "",
+        )
+
+    def limit_order(
+        self,
+        *,
+        side: Side,
+        qty: Decimal | float | int,
+        price: Decimal | float | int,
+        ctx: PolicyCtx,
+        tif: TimeInForce = TimeInForce.GTC,
+        client_tag: str | None = None,
+    ) -> Order:
+        quantity = to_decimal(qty)
+        price_dec = to_decimal(price)
+        return Order(
+            ts=ctx.ts,
+            symbol=ctx.symbol,
+            side=side,
+            order_type=OrderType.LIMIT,
+            quantity=quantity,
+            price=price_dec,
+            time_in_force=tif,
+            client_order_id=client_tag or "",
+        )
+
+
+__all__ = ["BaseStrategy", "Decision", "BaseSignalPolicy"]

--- a/strategies/momentum.py
+++ b/strategies/momentum.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
 
-from core_strategy import Decision
-from .base import BaseStrategy
+from core_contracts import PolicyCtx
+from core_models import Order, Side, TimeInForce
+from .base import BaseSignalPolicy
 
 
-class MomentumStrategy(BaseStrategy):
+class MomentumStrategy(BaseSignalPolicy):
     """
     Простейшая стратегия импульса по цене ref_price:
       - считаем среднее за lookback
@@ -16,62 +17,51 @@ class MomentumStrategy(BaseStrategy):
       - если ref_price < avg - threshold → SELL с фиксированным qty
     В проде ты заменишь логику на свою ML/сигналы — контракт тот же.
     """
+    required_features = ("ref_price",)
+
     def __init__(self) -> None:
         super().__init__()
         self.lookback = 5
         self.threshold = 0.0
-        self.order_qty = 0.001  # доля позиции
-        self.price_offset_ticks = 0
-        self.tif = "GTC"
+        self.order_qty = 0.001  # абсолютное количество
+        self.tif = TimeInForce.GTC
         self.client_tag: str | None = None
         self._window: deque[float] = deque(maxlen=5)
 
     def setup(self, config: Dict[str, Any]) -> None:
-        super().setup(config)
         self.lookback = int(config.get("lookback", self.lookback))
         self.threshold = float(config.get("threshold", self.threshold))
         self.order_qty = float(config.get("order_qty", self.order_qty))
-        self.price_offset_ticks = int(
-            config.get("price_offset_ticks", self.price_offset_ticks)
-        )
-        self.tif = str(config.get("tif", self.tif))
+        self.tif = TimeInForce(str(config.get("tif", self.tif.value)))
         self.client_tag = config.get("client_tag", self.client_tag)
         self._window = deque(maxlen=self.lookback)
 
-    def on_features(self, row: Dict[str, Any]) -> None:
-        super().on_features(row)
-        # ожидаем, что ref_price присутствует в features (или придёт в ctx)
-        price = row.get("ref_price")
-        if price is not None:
-            try:
-                self._window.append(float(price))
-            except Exception:
-                pass
-
-    def decide(self, ctx: Dict[str, Any]) -> List[Decision]:
-        ref = ctx.get("ref_price")
-        if ref is None or len(self._window) < self._window.maxlen:  # не торгуем, пока не набрали окно
+    def decide(self, features: Mapping[str, Any], ctx: PolicyCtx) -> List[Order]:
+        self._validate_inputs(features, ctx)
+        ref = float(features["ref_price"])
+        self._window.append(ref)
+        maxlen = self._window.maxlen or 0
+        if len(self._window) < maxlen:
             return []
         avg = sum(self._window) / float(len(self._window))
-        out: List[Decision] = []
-        if float(ref) > avg + self.threshold:
-            out.append(
-                Decision(
-                    side="BUY",
-                    volume_frac=self.order_qty,
-                    price_offset_ticks=self.price_offset_ticks,
+        if ref > avg + self.threshold:
+            return [
+                self.market_order(
+                    side=Side.BUY,
+                    qty=self.order_qty,
+                    ctx=ctx,
                     tif=self.tif,
                     client_tag=self.client_tag,
                 )
-            )
-        elif float(ref) < avg - self.threshold:
-            out.append(
-                Decision(
-                    side="SELL",
-                    volume_frac=self.order_qty,
-                    price_offset_ticks=self.price_offset_ticks,
+            ]
+        if ref < avg - self.threshold:
+            return [
+                self.market_order(
+                    side=Side.SELL,
+                    qty=self.order_qty,
+                    ctx=ctx,
                     tif=self.tif,
                     client_tag=self.client_tag,
                 )
-            )
-        return out
+            ]
+        return []

--- a/tests/test_momentum_policy.py
+++ b/tests/test_momentum_policy.py
@@ -1,0 +1,32 @@
+from decimal import Decimal
+
+from core_contracts import PolicyCtx
+from core_models import Side
+from strategies.momentum import MomentumStrategy
+
+
+def _ctx(ts: int) -> PolicyCtx:
+    return PolicyCtx(ts=ts, symbol="BTCUSDT")
+
+
+def test_momentum_policy_produces_orders():
+    policy = MomentumStrategy()
+    policy.setup({"lookback": 3, "order_qty": 1.0})
+
+    # first two observations - insufficient window
+    assert policy.decide({"ref_price": 100.0}, _ctx(1)) == []
+    assert policy.decide({"ref_price": 101.0}, _ctx(2)) == []
+
+    # third observation triggers BUY
+    orders = policy.decide({"ref_price": 103.0}, _ctx(3))
+    assert len(orders) == 1
+    o = orders[0]
+    assert o.side == Side.BUY
+    assert o.quantity == Decimal("1")
+
+    # price drops below average -> SELL
+    orders = policy.decide({"ref_price": 90.0}, _ctx(4))
+    assert len(orders) == 1
+    o = orders[0]
+    assert o.side == Side.SELL
+    assert o.quantity == Decimal("1")


### PR DESCRIPTION
## Summary
- refactor MomentumStrategy to use BaseSignalPolicy and issue Orders
- add unit test ensuring buy/sell signals after warmup window

## Testing
- `ruff --isolated check strategies/momentum.py tests/test_momentum_policy.py strategies/__init__.py`
- `mypy --config-file=/tmp/mypy.ini --ignore-missing-imports --follow-imports=skip strategies/momentum.py strategies/__init__.py tests/test_momentum_policy.py`
- `python check_imports.py`
- `PYTHONPATH=/root/.pyenv/versions/3.12.10/lib/python3.12:/workspace/TradingBot pytest -c /tmp/pytest.ini tests/test_momentum_policy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be85b61168832fafdb65a055eb13a3