### PR TITLE
Refactor runner to use SignalPolicy

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -17,7 +17,7 @@ components:
   feature_pipe:
     target: feature_pipe:FeaturePipe
     params: {}
-  strategy:
+  policy:
     target: strategies.momentum:MomentumStrategy
     params: {}
   risk_guards:

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -20,7 +20,7 @@ components:
   feature_pipe:
     target: feature_pipe:FeaturePipe
     params: {}
-  strategy:
+  policy:
     target: strategies.momentum:MomentumStrategy
     params: {}
   risk_guards:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -18,7 +18,7 @@ components:
   feature_pipe:
     target: feature_pipe:FeaturePipe
     params: {}
-  strategy:
+  policy:
     target: strategies.momentum:MomentumStrategy
     params: {}
   risk_guards:

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -21,7 +21,7 @@ components:
   feature_pipe:
     target: feature_pipe:FeaturePipe
     params: {}
-  strategy:
+  policy:
     target: strategies.momentum:MomentumStrategy
     params: {}
   risk_guards:

--- a/configs/legacy_realtime.yaml
+++ b/configs/legacy_realtime.yaml
@@ -23,7 +23,7 @@ guards:
   gap_cooldown_bars: 10
   gap_threshold_ms: 90000
 
-strategy:
+policy:
   module: "strategies.momentum"
   class: "MomentumStrategy"
   params:

--- a/configs/legacy_sandbox.yaml
+++ b/configs/legacy_sandbox.yaml
@@ -28,7 +28,7 @@ no_trade:
     - "16:00-16:05"
   custom_ms: []   # список явных окон [{start_ts_ms: ..., end_ts_ms: ...}]
 
-strategy:
+policy:
   module: "strategies.momentum"
   class: "MomentumStrategy"
   params:

--- a/core_config.py
+++ b/core_config.py
@@ -29,7 +29,7 @@ class Components(BaseModel):
     market_data: ComponentSpec
     executor: ComponentSpec
     feature_pipe: ComponentSpec
-    strategy: ComponentSpec
+    policy: ComponentSpec
     risk_guards: ComponentSpec
     backtest_engine: Optional[ComponentSpec] = None
 

--- a/di_registry.py
+++ b/di_registry.py
@@ -64,13 +64,13 @@ def build_component(name: str, spec: ComponentSpec, container: Dict[str, Any]) -
 
 def build_graph(components: Components, run_config: Optional[CommonRunConfig] = None) -> Dict[str, Any]:
     """
-    Сборка графа в последовательности: market_data → feature_pipe → strategy → risk_guards → executor → backtest_engine
+    Сборка графа в последовательности: market_data → feature_pipe → policy → risk_guards → executor → backtest_engine
     (BacktestEngine опционален.)
     """
     container: Dict[str, Any] = {}
     build_component("market_data", components.market_data, container)
     build_component("feature_pipe", components.feature_pipe, container)
-    build_component("strategy", components.strategy, container)
+    build_component("policy", components.policy, container)
     build_component("risk_guards", components.risk_guards, container)
     build_component("executor", components.executor, container)
     if components.backtest_engine:

--- a/legacy_sandbox_config.py
+++ b/legacy_sandbox_config.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 import yaml
 
 
-class StrategyConfig(BaseModel):
+class PolicyConfig(BaseModel):
     module: str = "strategies.momentum"
     class_name: str = Field("MomentumStrategy", alias="class")
     params: Dict[str, Any] = Field(default_factory=dict)
@@ -27,7 +27,7 @@ class SandboxConfig(BaseModel):
     sim_guards: Dict[str, Any] = Field(default_factory=dict)
     min_signal_gap_s: int = 0
     no_trade: Dict[str, Any] = Field(default_factory=dict)
-    strategy: StrategyConfig = StrategyConfig()
+    policy: PolicyConfig = PolicyConfig()
     data: DataConfig
     dynamic_spread: Dict[str, Any] = Field(default_factory=dict)
     out_reports: Optional[str] = None


### PR DESCRIPTION
## Summary
- rename strategy dependency to SignalPolicy across configs and DI
- log orders and submit via policy-driven ServiceSignalRunner
- update configs to use new `policy` component

## Testing
- `python - <<'PY'
import sys, logging
sys.path.append('TradingBot')
import pytest
raise SystemExit(pytest.main(['TradingBot/tests/test_momentum_policy.py','TradingBot/tests/test_market_utils.py','-q','-c','/dev/null']))
PY`
- `python script_live.py --config configs/config_live.yaml` *(fails: module 'logging' has no attribute 'getLogger' due to execution_sim indentation)*

------
https://chatgpt.com/codex/tasks/task_e_68bee87b3134832fa6b8a992431f7973