### PR TITLE
feat: type-aware DI container and SignalPolicy resolution

### DIFF
--- a/di_registry.py
+++ b/di_registry.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Type, TypeVar, get_type_hints
 
 from core_errors import ConfigError
 from core_config import ComponentSpec, Components, CommonRunConfig
@@ -31,7 +31,10 @@ def _load_class(dotted: str):
     return cls
 
 
-def _instantiate(target_cls, params: Dict[str, Any], container: Dict[str, Any]) -> Any:
+T = TypeVar("T")
+
+
+def _instantiate(target_cls, params: Dict[str, Any], container: Mapping[Any, Any]) -> Any:
     """
     Создание экземпляра с учётом DI:
       - сопоставляем сигнатуру конструктора аргументам
@@ -39,7 +42,11 @@ def _instantiate(target_cls, params: Dict[str, Any], container: Dict[str, Any]) 
       - при конфликте приоритет у явного params
     """
     sig = inspect.signature(target_cls.__init__)
-    kwargs = {}
+    try:
+        hints = get_type_hints(target_cls.__init__)
+    except Exception:
+        hints = {}
+    kwargs: Dict[str, Any] = {}
     for name, p in sig.parameters.items():
         if name == "self":
             continue
@@ -48,26 +55,46 @@ def _instantiate(target_cls, params: Dict[str, Any], container: Dict[str, Any]) 
         elif name in container:
             kwargs[name] = container[name]
         else:
-            # пропускаем, если есть дефолт или параметр вариативный
-            if p.default is not inspect._empty or p.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
-                continue
-            # оставляем незаполненным — конструктор может это принять
+            ann = hints.get(name)
+            if ann in container:
+                kwargs[name] = container[ann]
+            else:
+                if p.default is not inspect._empty or p.kind in (
+                    inspect.Parameter.VAR_KEYWORD,
+                    inspect.Parameter.VAR_POSITIONAL,
+                ):
+                    continue
+                # оставляем незаполненным — конструктор может это принять
     return target_cls(**kwargs)
 
 
-def build_component(name: str, spec: ComponentSpec, container: Dict[str, Any]) -> Any:
+def build_component(name: str, spec: ComponentSpec, container: Dict[Any, Any]) -> Any:
     cls = _load_class(spec.target)
     instance = _instantiate(cls, spec.params or {}, container)
     container[name] = instance
+    for base in inspect.getmro(cls):
+        if base is object or base.__module__.startswith("typing"):
+            continue
+        container[base] = instance
     return instance
 
 
-def build_graph(components: Components, run_config: Optional[CommonRunConfig] = None) -> Dict[str, Any]:
+_GLOBAL_CONTAINER: Dict[Any, Any] | None = None
+
+
+def resolve(key: Type[T], container: Mapping[Any, Any] | None = None) -> T:
+    cont = container if container is not None else _GLOBAL_CONTAINER
+    if cont is None or key not in cont:
+        raise KeyError(key)
+    return cont[key]
+
+
+def build_graph(components: Components, run_config: Optional[CommonRunConfig] = None) -> Dict[Any, Any]:
     """
     Сборка графа в последовательности: market_data → feature_pipe → policy → risk_guards → executor → backtest_engine
     (BacktestEngine опционален.)
     """
-    container: Dict[str, Any] = {}
+    container: Dict[Any, Any] = {}
     build_component("market_data", components.market_data, container)
     build_component("feature_pipe", components.feature_pipe, container)
     build_component("policy", components.policy, container)
@@ -79,4 +106,6 @@ def build_graph(components: Components, run_config: Optional[CommonRunConfig] = 
     # пробрасываем конфиг как зависимость, если кому-то понадобится
     if run_config is not None:
         container["run_config"] = run_config
+    global _GLOBAL_CONTAINER
+    _GLOBAL_CONTAINER = container
     return container

--- a/tests/test_di_registry_resolve.py
+++ b/tests/test_di_registry_resolve.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from core_contracts import PolicyCtx, SignalPolicy
+from di_registry import build_component, resolve
+from strategies.base import BaseSignalPolicy
+
+
+class DummyPolicy(BaseSignalPolicy):
+    def decide(self, features, ctx: PolicyCtx):
+        return []
+
+
+class PolicyAdapter(BaseSignalPolicy):
+    def __init__(self, policy: SignalPolicy) -> None:
+        super().__init__()
+        self._policy = policy
+
+    def decide(self, features, ctx: PolicyCtx):
+        return list(self._policy.decide(features, ctx) or [])
+
+
+def _spec(target: str, params: dict | None = None):
+    return SimpleNamespace(target=target, params=params or {})
+
+
+def test_resolve_direct_policy():
+    container = {}
+    spec = _spec("tests.test_di_registry_resolve:DummyPolicy")
+    build_component("policy", spec, container)
+    assert resolve(SignalPolicy, container) is container["policy"]
+
+
+def test_resolve_policy_adapter():
+    container: dict = {}
+    base_spec = _spec("tests.test_di_registry_resolve:DummyPolicy")
+    build_component("base_policy", base_spec, container)
+    adapter_spec = _spec("tests.test_di_registry_resolve:PolicyAdapter")
+    build_component("policy", adapter_spec, container)
+    assert resolve(SignalPolicy, container) is container["policy"]


### PR DESCRIPTION
## Summary
- extend DI container to register components under their classes and base interfaces
- enable constructor injection by type annotations and add `resolve` helper
- add tests verifying that SignalPolicy and its adapters resolve correctly

## Testing
- `python - <<'PY'
import sys, pathlib
if sys.path[0] == '':
    sys.path.pop(0)
import logging
sys.path.insert(0, str(pathlib.Path('.').resolve()))
import pytest
pytest.main(['-q', '-c', '/tmp/pytest.ini', 'tests'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68beee76bda8832fab6193c9749dfbbd