### PR TITLE
Deprecate core strategy APIs

### DIFF
--- a/core_strategy.py
+++ b/core_strategy.py
@@ -1,6 +1,7 @@
 """Core strategy contract and protocol."""
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol, Sequence, runtime_checkable
 
@@ -9,7 +10,11 @@ from action_proto import ActionProto, ActionType
 
 @runtime_checkable
 class Strategy(Protocol):
-    """Trading strategy interface."""
+    """Trading strategy interface.
+
+    Deprecated:
+        Use :class:`SignalPolicy` instead.
+    """
 
     def setup(self, config: Dict[str, Any]) -> None:
         """Initialize strategy with configuration."""
@@ -27,6 +32,9 @@ class Strategy(Protocol):
 @dataclass(frozen=True)
 class Decision:
     """High level strategy decision.
+
+    Deprecated:
+        Use :class:`OrderIntent` instead.
 
     Parameters
     ----------
@@ -68,3 +76,9 @@ class Decision:
         )
 
 __all__ = ["Strategy", "Decision"]
+
+warnings.warn(
+    "core_strategy.Strategy and .Decision are deprecated; use SignalPolicy and OrderIntent instead",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,10 +1,8 @@
-from core_strategy import Decision
 from .base import BaseSignalPolicy, BaseStrategy
 from .momentum import MomentumStrategy
 
 __all__ = [
     "BaseStrategy",
     "BaseSignalPolicy",
-    "Decision",
     "MomentumStrategy",
 ]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Mapping, Sequence
 
 from core_contracts import PolicyCtx, SignalPolicy
 from core_models import Order, OrderType, Side, TimeInForce, to_decimal
-from core_strategy import Decision, Strategy
+from core_strategy import Strategy
 
 
 class BaseStrategy(Strategy):
@@ -118,4 +118,4 @@ class BaseSignalPolicy(SignalPolicy):
         )
 
 
-__all__ = ["BaseStrategy", "Decision", "BaseSignalPolicy"]
+__all__ = ["BaseStrategy", "BaseSignalPolicy"]


### PR DESCRIPTION
## Summary
- mark Strategy and Decision as deprecated and warn on import
- remove Decision re-exports from strategies package

## Testing
- `pytest` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68bef46c2d48832faca6ebd88e9ae205