### PR TITLE
Hook real Binance quantizer and filters

### DIFF
--- a/binance_filters.json
+++ b/binance_filters.json
@@ -1,1 +1,40 @@
-{}
+{
+  "BTCUSDT": {
+    "PRICE_FILTER": {
+      "minPrice": "0.01",
+      "maxPrice": "1000000",
+      "tickSize": "0.01"
+    },
+    "LOT_SIZE": {
+      "minQty": "0.00001",
+      "maxQty": "1000",
+      "stepSize": "0.00001"
+    },
+    "MIN_NOTIONAL": {
+      "minNotional": "10"
+    },
+    "PERCENT_PRICE_BY_SIDE": {
+      "multiplierUp": "1.2",
+      "multiplierDown": "0.8"
+    }
+  },
+  "ETHUSDT": {
+    "PRICE_FILTER": {
+      "minPrice": "0.01",
+      "maxPrice": "1000000",
+      "tickSize": "0.01"
+    },
+    "LOT_SIZE": {
+      "minQty": "0.0001",
+      "maxQty": "100000",
+      "stepSize": "0.0001"
+    },
+    "MIN_NOTIONAL": {
+      "minNotional": "10"
+    },
+    "PERCENT_PRICE_BY_SIDE": {
+      "multiplierUp": "1.2",
+      "multiplierDown": "0.8"
+    }
+  }
+}

--- a/fetch_binance_filters.py
+++ b/fetch_binance_filters.py
@@ -6,38 +6,7 @@ import os
 import sys
 from typing import Dict, Any, List
 
-import urllib.request
-import urllib.error
-import urllib.parse
-
-
-def _fetch_exchange_info(symbols: List[str]|None=None) -> Dict[str, Any]:
-    base = "https://api.binance.com/api/v3/exchangeInfo"
-    if symbols:
-        sym_param = "[" + ",".join(symbols) + "]"
-        url = base + "?symbols=" + urllib.parse.quote(sym_param)
-    else:
-        url = base
-    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        data = json.loads(resp.read().decode("utf-8"))
-    return data
-
-
-def _normalize_filters(raw: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
-    out: Dict[str, Dict[str, Any]] = {}
-    symbols = raw.get("symbols") or []
-    for s in symbols:
-        sym = s.get("symbol")
-        filts = s.get("filters") or []
-        d: Dict[str, Any] = {}
-        for f in filts:
-            ftype = f.get("filterType")
-            if not ftype:
-                continue
-            d[ftype] = {k: v for k, v in f.items() if k != "filterType"}
-        out[sym] = d
-    return out
+from binance_public import BinancePublicClient
 
 
 def main():
@@ -46,12 +15,12 @@ def main():
         sys.exit(2)
     out_path = sys.argv[1]
     symbols = sys.argv[2:] if len(sys.argv) > 2 else None
+    client = BinancePublicClient()
     try:
-        data = _fetch_exchange_info(symbols)
+        normalized = client.get_exchange_filters(symbols=symbols)
     except Exception as e:
         print(f"ERROR: failed to fetch exchangeInfo: {e}", file=sys.stderr)
         sys.exit(1)
-    normalized = _normalize_filters(data)
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(normalized, f, ensure_ascii=False, indent=2, sort_keys=True)

--- a/impl_quantizer.py
+++ b/impl_quantizer.py
@@ -10,10 +10,9 @@ from dataclasses import dataclass
 from typing import Optional, Dict, Any
 
 try:
-    from quantizer import Quantizer, load_filters
+    from quantizer import Quantizer
 except Exception as e:  # pragma: no cover
     Quantizer = None  # type: ignore
-    load_filters = None  # type: ignore
 
 
 @dataclass
@@ -27,8 +26,8 @@ class QuantizerImpl:
     def __init__(self, cfg: QuantizerConfig) -> None:
         self.cfg = cfg
         self._quantizer = None
-        if Quantizer is not None and load_filters is not None and cfg.path:
-            filters = load_filters(cfg.path)
+        if Quantizer is not None and cfg.path:
+            filters = Quantizer.load_filters(cfg.path)
             if filters:
                 self._quantizer = Quantizer(filters, strict=bool(cfg.strict))
 
@@ -36,13 +35,12 @@ class QuantizerImpl:
     def quantizer(self):
         return self._quantizer
 
-    def attach_to(self, sim) -> None:
-        """
-        Подключает к симулятору:
-          - sim.quantizer = Quantizer(...)
-          - sim.enforce_ppbs = cfg.enforce_percent_price_by_side
-          - sim.strict_filters = cfg.strict
-        """
+    def attach_to(self, sim, *, strict: Optional[bool] = None, enforce_percent_price_by_side: Optional[bool] = None) -> None:
+        """Подключает квантайзер к симулятору."""
+        if strict is not None:
+            self.cfg.strict = bool(strict)
+        if enforce_percent_price_by_side is not None:
+            self.cfg.enforce_percent_price_by_side = bool(enforce_percent_price_by_side)
         if self._quantizer is not None:
             setattr(sim, "quantizer", self._quantizer)
         setattr(sim, "enforce_ppbs", bool(self.cfg.enforce_percent_price_by_side))

--- a/impl_sim_executor.py
+++ b/impl_sim_executor.py
@@ -62,7 +62,7 @@ class SimExecutor(TradeExecutor):
 
         # последовательное подключение компонентов к симулятору
         if quantizer is not None:
-            quantizer.attach_to(self._sim)
+            quantizer.attach_to(self._sim, strict=True, enforce_percent_price_by_side=True)
         if risk is not None:
             risk.attach_to(self._sim)
         if latency is not None:

--- a/quantizer.py
+++ b/quantizer.py
@@ -165,15 +165,17 @@ class Quantizer:
             data = json.load(f)
         return cls(data, strict=strict)
 
+    @staticmethod
+    def load_filters(path: str) -> Dict[str, Dict[str, Any]]:
+        """Загружает словарь фильтров из JSON. Возвращает {} если файл отсутствует."""
+        if not path:
+            return {}
+        if not os.path.exists(path):
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
 
+
+# для обратной совместимости
 def load_filters(path: str) -> Dict[str, Dict[str, Any]]:
-    """
-    Загружает словарь фильтров из JSON.
-    Возвращает {} если файл отсутствует.
-    """
-    if not path:
-        return {}
-    if not os.path.exists(path):
-        return {}
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+    return Quantizer.load_filters(path)


### PR DESCRIPTION
## Summary
- add static filter loading in quantizer and expose Quantizer.load_filters
- allow QuantizerImpl to enforce strict filters and percent-price-by-side on attach
- expose Binance exchange filter fetch and script to dump filters
- add example binance filter definitions

## Testing
- `python -m py_compile impl_quantizer.py quantizer.py binance_public.py fetch_binance_filters.py impl_sim_executor.py`
- `python fetch_binance_filters.py binance_filters.json BTCUSDT ETHUSDT` *(fails: CONNECT tunnel failed 403)*
- `pytest` *(fails: Expected '=' after a key in a key/value pair)*

------
https://chatgpt.com/codex/tasks/task_e_68bf42050ba4832f84fd65348085f1a6