### PR TITLE
Include market metrics in simulation logs

### DIFF
--- a/logging.py
+++ b/logging.py
@@ -101,7 +101,11 @@ class LogWriter:
             funding_cashflow=Decimal(str(getattr(report, "funding_cashflow", 0.0))) if getattr(report, "funding_cashflow", None) is not None else None,
             cash=Decimal(str(getattr(report, "cash", 0.0))) if getattr(report, "cash", None) is not None else None,
         )
-        self._reports_buf.append(eq.to_dict())
+        eq_dict = eq.to_dict()
+        eq_dict["spread_bps"] = getattr(report, "spread_bps", None)
+        eq_dict["vol_factor"] = getattr(report, "vol_factor", None)
+        eq_dict["liquidity"] = getattr(report, "liquidity", None)
+        self._reports_buf.append(eq_dict)
 
         # авто-сброс
         if (len(self._trades_buf) + len(self._reports_buf)) >= max(1, int(self.cfg.flush_every)):


### PR DESCRIPTION
## Summary
- extend SimStepReport with spread, volatility, and liquidity metrics
- propagate these metrics through ExecutionSimulator and LogWriter
- log snapshot spread, vol_factor, and liquidity for each step

## Testing
- `python - <<'PY'
from execution_sim import ExecutionSimulator
sim = ExecutionSimulator(logging_config={'enabled': False})
sim.set_market_snapshot(bid=99.0, ask=101.0, spread_bps=20.0, vol_factor=1.2, liquidity=500.0)
rep = sim.pop_ready(now_ts=0, ref_price=100.0)
print('Report fields:', rep.spread_bps, rep.vol_factor, rep.liquidity)
PY`
- `python - <<'PY'
import logging
from execution_sim import ExecutionSimulator

sim = ExecutionSimulator(logging_config={'enabled': False})
# Step 1
sim.set_market_snapshot(bid=99.0, ask=101.0, spread_bps=20.0, vol_factor=1.2, liquidity=500.0)
rep1 = sim.pop_ready(now_ts=0, ref_price=100.0)
# Step 2
sim.set_market_snapshot(bid=100.0, ask=102.0, spread_bps=25.0, vol_factor=1.5, liquidity=700.0)
rep2 = sim.pop_ready(now_ts=1, ref_price=101.0)

lw = logging.LogWriter(logging.LogConfig(format='csv', trades_path='test_trades.csv', reports_path='test_reports.csv', flush_every=1), run_id='sim')
lw.append(rep1, symbol='BTC', ts_ms=0)
lw.append(rep2, symbol='BTC', ts_ms=1)
print('reports path', lw.cfg.reports_path)
PY`
- `cat test_reports.csv`
- `pytest` *(fails: Expected '=' after a key in a key/value pair (pyproject.toml))*

------
https://chatgpt.com/codex/tasks/task_e_68bf4b521990832f96bcfd458609f1b1