### PR TITLE
Ensure sim executor receives run config and use cfg for backtest params

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,6 +143,8 @@ def run_backtest_from_yaml(cfg_path: str, default_out: str, logs_dir: str) -> st
     sim_cfg = load_config(cfg.sim_config_path)
 
     sb_cfg = BacktestConfig(
+        symbol=sim_cfg.symbols[0] if getattr(sim_cfg, "symbols", []) else "BTCUSDT",
+        timeframe=getattr(sim_cfg.data, "timeframe", "1m"),
         dynamic_spread_config=cfg.dynamic_spread,
         exchange_specs_path=cfg.exchange_specs_path,
         guards_config=cfg.sim_guards,

--- a/di_registry.py
+++ b/di_registry.py
@@ -99,13 +99,12 @@ def build_graph(components: Components, run_config: Optional[CommonRunConfig] = 
     build_component("feature_pipe", components.feature_pipe, container)
     build_component("policy", components.policy, container)
     build_component("risk_guards", components.risk_guards, container)
+    # пробрасываем конфиг до сборки executor, чтобы он мог получить run_config
+    if run_config is not None:
+        container["run_config"] = run_config
     build_component("executor", components.executor, container)
     if components.backtest_engine:
         build_component("backtest_engine", components.backtest_engine, container)
-
-    # пробрасываем конфиг как зависимость, если кому-то понадобится
-    if run_config is not None:
-        container["run_config"] = run_config
     global _GLOBAL_CONTAINER
     _GLOBAL_CONTAINER = container
     return container


### PR DESCRIPTION
## Summary
- Inject run_config into DI container before constructing executor so SimExecutor can access simulation settings
- Build BacktestConfig from CommonRunConfig, using cfg.no_trade and other blocks and requiring symbol/timeframe
- Adjust app's helper to pass symbol and timeframe to BacktestConfig

## Testing
- `python - <<'PY'
import sys
sys.path.append('/workspace/TradingBot')
import pytest
res = pytest.main(['-c','/dev/null','/workspace/TradingBot/tests'])
print('exit', res)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bf544afd58832f8e739cd4eaee9a59