### PR TITLE
Handle naive ISO strings as UTC in offline data

### DIFF
--- a/impl_offline_data.py
+++ b/impl_offline_data.py
@@ -17,6 +17,7 @@ import pandas as pd  # предполагается в зависимостях
 
 from core_models import Bar, Tick
 from core_contracts import MarketDataSource
+from utils_time import parse_time_to_ms
 
 
 @dataclass
@@ -139,10 +140,7 @@ def to_ms(dt: Any) -> int:
     if isinstance(dt, float):
         return int(dt)
     if isinstance(dt, str):
-        try:
-            return int(datetime.fromisoformat(dt.replace("Z", "+00:00")).timestamp() * 1000)
-        except Exception as e:
-            raise ValueError(f"Cannot parse datetime string: {dt}") from e
+        return parse_time_to_ms(dt)
     if isinstance(dt, datetime):
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)

--- a/tests/test_market_utils.py
+++ b/tests/test_market_utils.py
@@ -1,6 +1,7 @@
 import datetime
 
 from utils_time import parse_time_to_ms
+from impl_offline_data import to_ms
 
 
 def test_numeric_seconds_to_ms():
@@ -21,3 +22,8 @@ def test_datetime_string_to_ms():
 def test_iso_string_to_ms():
     dt = datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc)
     assert parse_time_to_ms(dt.isoformat()) == 1672531200000
+
+
+def test_to_ms_naive_iso_treated_as_utc():
+    dt_str = "2023-01-01T00:00:00"
+    assert to_ms(dt_str) == 1672531200000


### PR DESCRIPTION
## Summary
- Treat ISO datetime strings without offsets as UTC in `to_ms`
- Reuse `parse_time_to_ms` and add regression test

## Testing
- `python - <<'PY'
import sys, pytest
sys.path.append('/workspace/TradingBot')
raise SystemExit(pytest.main(['/workspace/TradingBot/tests/test_market_utils.py','-q','-c','/dev/null']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bf572f2d24832f90dd4061ddb51f94