### PR TITLE
Validate aggregated timestamp alignment

### DIFF
--- a/tests/test_agg_klines_validation.py
+++ b/tests/test_agg_klines_validation.py
@@ -1,0 +1,39 @@
+import importlib.util
+import pathlib
+
+import pandas as pd
+import pytest
+
+_MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "agg_klines.py"
+spec = importlib.util.spec_from_file_location("agg_klines", _MODULE_PATH)
+_mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(_mod)  # type: ignore[assignment]
+_agg = _mod._agg
+
+
+def _mk(ts_list):
+    return pd.DataFrame({
+        "ts_ms": ts_list,
+        "symbol": ["BTCUSDT"] * len(ts_list),
+        "open": [1.0] * len(ts_list),
+        "high": [1.0] * len(ts_list),
+        "low": [1.0] * len(ts_list),
+        "close": [1.0] * len(ts_list),
+        "volume": [1.0] * len(ts_list),
+        "number_of_trades": [1] * len(ts_list),
+        "taker_buy_base": [0.0] * len(ts_list),
+        "taker_buy_quote": [0.0] * len(ts_list),
+    })
+
+
+def test_gap_detection_raises():
+    df = _mk([0, 120_000])
+    with pytest.raises(ValueError):
+        _agg(df, "1m")
+
+
+def test_valid_no_gap():
+    df = _mk([0, 60_000, 120_000])
+    out = _agg(df, "1m")
+    assert len(out) == 3


### PR DESCRIPTION
## Summary
- ensure aggregated kline timestamps align to the requested step and contain no gaps or duplicates
- add regression tests verifying validation behavior

## Testing
- `mv __init__.py __init__.py.bak && pytest -c /dev/null tests/test_agg_klines_validation.py -q && mv __init__.py.bak __init__.py`
- `mv __init__.py __init__.py.bak && pytest -c /dev/null tests -q && mv __init__.py.bak __init__.py` *(fails: No module named 'core_contracts')*


------
https://chatgpt.com/codex/tasks/task_e_68bf6243b7e8832f9d7eee5597251267