### PR TITLE
feat: enrich slippage calibration with spread stats

### DIFF
--- a/configs/slippage_calibrate.yaml
+++ b/configs/slippage_calibrate.yaml
@@ -1,0 +1,7 @@
+# Example configuration for slippage calibration service
+trades: "trades.parquet"
+format: "parquet"  # or csv
+# Strategy for default spread calculation: "median" or "mean"
+default_spread_mode: "median"
+# Lower quantile for minimal half-spread clipping
+min_half_spread_quantile: 0.05


### PR DESCRIPTION
## Summary
- compute default spread and minimal half-spread from trade data
- export k, default_spread_bps and min_half_spread_bps in calibration report
- add sample slippage calibration config with customizable strategies

## Testing
- `pytest -q` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*


------
https://chatgpt.com/codex/tasks/task_e_68bf68380794832faff0f26f99452db5