### PR TITLE
Pass market quotes to execution simulator

### DIFF
--- a/mediator.py
+++ b/mediator.py
@@ -353,6 +353,20 @@ class Mediator:
         # если есть ExecutionSimulator — используем его
         if self._use_exec and self.exec is not None:
             try:
+                bid = getattr(self.env, "last_bid", None)
+                ask = getattr(self.env, "last_ask", None)
+                if bid is not None and ask is not None:
+                    try:
+                        self.exec.set_market_snapshot(bid=bid, ask=ask)  # type: ignore[union-attr]
+                    except Exception:
+                        pass
+                    mid = getattr(self.env, "last_mid", None)
+                    if mid is None:
+                        mid = (float(bid) + float(ask)) / 2.0
+                    try:
+                        self.exec.set_ref_price(float(mid))  # type: ignore[union-attr]
+                    except Exception:
+                        pass
                 cli_id = self.exec.submit(proto)  # type: ignore[union-attr]
                 # в простом варианте считаем, что latency=0 и сразу «поп» (если latency>0 — поп произойдёт на тик)
                 report: ExecReport = self.exec.pop_ready()  # type: ignore  # ExecReport — это alias на SimStepReport


### PR DESCRIPTION
## Summary
- forward environment bid/ask quotes to the execution simulator before submitting actions
- update reference price using mid quote

## Testing
- `pytest -q` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*

------
https://chatgpt.com/codex/tasks/task_e_68bffa0504e4832f8bdff54531ae4a37