### PR TITLE
Expose latency statistics and reset capability

### DIFF
--- a/impl_latency.py
+++ b/impl_latency.py
@@ -38,6 +38,7 @@ class LatencyImpl:
             retries=int(cfg.retries),
             seed=int(cfg.seed),
         ) if LatencyModel is not None else None
+        self.attached_sim = None
 
     @property
     def model(self):
@@ -46,6 +47,16 @@ class LatencyImpl:
     def attach_to(self, sim) -> None:
         if self._model is not None:
             setattr(sim, "latency", self._model)
+        self.attached_sim = sim
+
+    def get_stats(self):
+        if self._model is None:
+            return None
+        return self._model.stats()
+
+    def reset_stats(self) -> None:
+        if self._model is not None:
+            self._model.reset_stats()
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "LatencyImpl":


### PR DESCRIPTION
## Summary
- track attached simulator in `LatencyImpl`
- expose latency statistics via `get_stats`
- allow clearing latency stats through `reset_stats`

## Testing
- `PYTHONPATH=/root/.pyenv/versions/3.12.10/lib/python3.12:/workspace/TradingBot python -m pytest -q /workspace/TradingBot/tests -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68c004d85a4c832fba10eb2ef7eea0f5