### PR TITLE
Apply default BNB fee discount multipliers

### DIFF
--- a/impl_fees.py
+++ b/impl_fees.py
@@ -20,8 +20,20 @@ class FeesConfig:
     maker_bps: float = 1.0
     taker_bps: float = 5.0
     use_bnb_discount: bool = False
-    maker_discount_mult: float = 1.0
-    taker_discount_mult: float = 1.0
+    maker_discount_mult: Optional[float] = None
+    taker_discount_mult: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.use_bnb_discount:
+            if self.maker_discount_mult is None:
+                self.maker_discount_mult = 0.75
+            if self.taker_discount_mult is None:
+                self.taker_discount_mult = 0.75
+        else:
+            if self.maker_discount_mult is None:
+                self.maker_discount_mult = 1.0
+            if self.taker_discount_mult is None:
+                self.taker_discount_mult = 1.0
 
 
 class FeesImpl:
@@ -45,10 +57,13 @@ class FeesImpl:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "FeesImpl":
+        use_bnb = bool(d.get("use_bnb_discount", False))
+        maker_mult = d.get("maker_discount_mult")
+        taker_mult = d.get("taker_discount_mult")
         return FeesImpl(FeesConfig(
             maker_bps=float(d.get("maker_bps", 1.0)),
             taker_bps=float(d.get("taker_bps", 5.0)),
-            use_bnb_discount=bool(d.get("use_bnb_discount", False)),
-            maker_discount_mult=float(d.get("maker_discount_mult", 1.0)),
-            taker_discount_mult=float(d.get("taker_discount_mult", 1.0)),
+            use_bnb_discount=use_bnb,
+            maker_discount_mult=float(maker_mult) if maker_mult is not None else None,
+            taker_discount_mult=float(taker_mult) if taker_mult is not None else None,
         ))

--- a/tests/test_fees_discount.py
+++ b/tests/test_fees_discount.py
@@ -1,0 +1,24 @@
+import pytest
+
+from impl_fees import FeesImpl
+
+
+def test_bnb_discount_applied_by_default():
+    price = 100.0
+    qty = 1.0
+
+    # базовая комиссия без скидки
+    base = FeesImpl.from_dict({})
+    fee_base_maker = base.model.compute(side="BUY", price=price, qty=qty, liquidity="maker")
+    fee_base_taker = base.model.compute(side="BUY", price=price, qty=qty, liquidity="taker")
+
+    # включаем BNB скидку без явных мультипликаторов
+    disc = FeesImpl.from_dict({"use_bnb_discount": True})
+    fee_disc_maker = disc.model.compute(side="BUY", price=price, qty=qty, liquidity="maker")
+    fee_disc_taker = disc.model.compute(side="BUY", price=price, qty=qty, liquidity="taker")
+
+    assert disc.cfg.maker_discount_mult == 0.75
+    assert disc.cfg.taker_discount_mult == 0.75
+    assert fee_disc_maker == pytest.approx(fee_base_maker * 0.75)
+    assert fee_disc_taker == pytest.approx(fee_base_taker * 0.75)
+


### PR DESCRIPTION
## Summary
- default discount multipliers to 0.75 when BNB discount is enabled and multipliers are omitted
- add regression test ensuring fees drop by 25%

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c012724af8832f82b6392384f6c306