### PR TITLE
Handle limit order TTLs and expand tests

### DIFF
--- a/tests/test_limit_order_ttl.py
+++ b/tests/test_limit_order_ttl.py
@@ -21,3 +21,17 @@ def test_limit_order_ttl_expires():
     report2 = sim.pop_ready(ref_price=100.0)
     assert report2.cancelled_ids == [oid]
     assert report2.trades == []
+
+
+def test_limit_order_ttl_survives():
+    sim = ExecutionSimulator()
+    proto = ActionProto(action_type=ActionType.LIMIT, volume_frac=1.0, abs_price=100.0, ttl_steps=3)
+    oid = sim.submit(proto)
+    report1 = sim.pop_ready(ref_price=100.0)
+    assert report1.new_order_ids == [oid]
+    report2 = sim.pop_ready(ref_price=100.0)
+    assert report2.cancelled_ids == []
+    report3 = sim.pop_ready(ref_price=100.0)
+    assert report3.cancelled_ids == []
+    report4 = sim.pop_ready(ref_price=100.0)
+    assert report4.cancelled_ids == [oid]


### PR DESCRIPTION
## Summary
- call `_process_ttl_queue` and native TTL decay each step
- forward limit-order TTL to LOB via `set_order_ttl`
- test that orders expire or persist based on TTL

## Testing
- `pytest tests/test_limit_order_ttl.py -q -c /dev/null` *(fails: No module named 'compat_shims')*

------
https://chatgpt.com/codex/tasks/task_e_68c01aaa6c5c832fbb970b0af2a96e25