### PR TITLE
Quantize mediator limit orders and add tests

### DIFF
--- a/tests/test_mediator_quantization.py
+++ b/tests/test_mediator_quantization.py
@@ -1,0 +1,92 @@
+import types
+import importlib.util
+import pathlib
+import sys
+
+base = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(base))
+
+spec_med = importlib.util.spec_from_file_location("mediator", base / "mediator.py")
+med_mod = importlib.util.module_from_spec(spec_med)
+sys.modules["mediator"] = med_mod
+spec_med.loader.exec_module(med_mod)
+Mediator = med_mod.Mediator
+
+spec_ap = importlib.util.spec_from_file_location("action_proto", base / "action_proto.py")
+ap_mod = importlib.util.module_from_spec(spec_ap)
+sys.modules["action_proto"] = ap_mod
+spec_ap.loader.exec_module(ap_mod)
+ActionProto = ap_mod.ActionProto
+ActionType = ap_mod.ActionType
+
+spec_quant = importlib.util.spec_from_file_location("quantizer", base / "quantizer.py")
+quant_mod = importlib.util.module_from_spec(spec_quant)
+sys.modules["quantizer"] = quant_mod
+spec_quant.loader.exec_module(quant_mod)
+Quantizer = quant_mod.Quantizer
+
+spec_const = importlib.util.spec_from_file_location("core_constants", base / "core_constants.py")
+const_mod = importlib.util.module_from_spec(spec_const)
+sys.modules["core_constants"] = const_mod
+spec_const.loader.exec_module(const_mod)
+PRICE_SCALE = const_mod.PRICE_SCALE
+
+class DummyLOB:
+    def __init__(self):
+        self.next_id = 1
+    def add_limit_order(self, is_buy_side, price_ticks, volume, timestamp, taker_is_agent=True):
+        oid = self.next_id
+        self.next_id += 1
+        return oid, 0
+    def remove_order(self, is_buy_side, price_ticks, order_id):
+        return True
+    def match_market_order(self, is_buy_side, volume, timestamp, taker_is_agent, out_prices=None, out_volumes=None,
+                           out_is_buy=None, out_is_self=None, out_ids=None, max_len: int = 0):
+        return 0, 0.0
+
+class DummyState:
+    def __init__(self):
+        self.units = 0.0
+        self.cash = 0.0
+        self.max_position = 10.0
+
+class DummyEnv:
+    def __init__(self, lob, symbol="BTCUSDT"):
+        self.state = DummyState()
+        self.lob = lob
+        self.symbol = symbol
+        self.last_mid = 100.0
+        self.run_config = types.SimpleNamespace()
+
+filters = {
+    "BTCUSDT": {
+        "PRICE_FILTER": {"minPrice": "0", "maxPrice": "1000000", "tickSize": "0.5"},
+        "LOT_SIZE": {"minQty": "0.1", "maxQty": "1000", "stepSize": "0.1"},
+        "MIN_NOTIONAL": {"minNotional": "5"},
+        "PERCENT_PRICE_BY_SIDE": {"multiplierUp": "1000", "multiplierDown": "0"},
+    }
+}
+
+quantizer = Quantizer(filters, strict=True)
+
+
+def make_mediator():
+    env = DummyEnv(DummyLOB())
+    med = Mediator(env, use_exec_sim=False)
+    med.quantizer = quantizer
+    med.enforce_ppbs = True
+    return med
+
+
+def test_unquantized_order_rejected():
+    med = make_mediator()
+    price = int(100.3 * PRICE_SCALE)
+    oid, qpos = med.add_limit_order(is_buy_side=True, price_ticks=price, volume=0.25, timestamp=0)
+    assert (oid, qpos) == (0, 0)
+
+
+def test_quantized_order_accepted():
+    med = make_mediator()
+    price = int(100.5 * PRICE_SCALE)
+    oid, qpos = med.add_limit_order(is_buy_side=True, price_ticks=price, volume=0.2, timestamp=0)
+    assert oid != 0


### PR DESCRIPTION
## Summary
- integrate shared Quantizer into mediator
- quantize and validate limit orders before sending to LOB
- add regression tests ensuring unquantized orders are rejected

## Testing
- `pytest tests/test_mediator_quantization.py -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68c01ebe1208832f95a88dd663603541