### PR TITLE
Add execution profile configuration

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -2,6 +2,12 @@ mode: eval
 run_id: eval-run
 logs_dir: logs
 artifacts_dir: artifacts
+execution_profile: MKT_OPEN_NEXT_H1
+execution_params:
+  slippage_bps: 0.0
+  limit_offset_bps: 0.0
+  ttl_steps: 0
+  tif: GTC
 input:
   trades_path: "data/trades.csv"
 components:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -2,6 +2,12 @@ mode: sim
 run_id: default-run
 logs_dir: logs
 artifacts_dir: artifacts
+execution_profile: MKT_OPEN_NEXT_H1
+execution_params:
+  slippage_bps: 0.0
+  limit_offset_bps: 0.0
+  ttl_steps: 0
+  tif: GTC
 
 market: spot
 spot_symbols: ["BTCUSDT"]

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -3,6 +3,12 @@ mode: train
 run_id: default-run
 logs_dir: logs
 artifacts_dir: artifacts
+execution_profile: MKT_OPEN_NEXT_H1
+execution_params:
+  slippage_bps: 0.0
+  limit_offset_bps: 0.0
+  ttl_steps: 0
+  tif: GTC
 
 market: spot  # or futures
 spot_symbols: &spot_symbols ["BTCUSDT"]

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -2,6 +2,12 @@ mode: train
 run_id: default-run
 logs_dir: logs
 artifacts_dir: artifacts
+execution_profile: MKT_OPEN_NEXT_H1
+execution_params:
+  slippage_bps: 0.0
+  limit_offset_bps: 0.0
+  ttl_steps: 0
+  tif: GTC
 
 market: spot
 spot_symbols: ["BTCUSDT"]


### PR DESCRIPTION
## Summary
- introduce ExecutionProfile enum with execution parameters
- propagate profile and params into Simulation, Train and Eval configs
- pass execution profile to simulator and executor, enabling limit orders at mid with offset

## Testing
- `python -m py_compile core_config.py impl_sim_executor.py execution_sim.py`
- `pytest -c /dev/null` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c02b2f2c1c832fb6987aff7ff4b9a1