### PR TITLE
Add mid-offset limit executor and extend limit order simulation for TIF

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ from .execution_algos import (
     TakerExecutor,
     TWAPExecutor,
     POVExecutor,
+    MidOffsetLimitExecutor,
 )
 from .latency import LatencyModel
 from .risk import RiskManager, RiskConfig, RiskEvent
@@ -40,6 +41,7 @@ __all__ = [
     "TakerExecutor",
     "TWAPExecutor",
     "POVExecutor",
+    "MidOffsetLimitExecutor",
     "LatencyModel",
     "RiskManager",
     "RiskConfig",

--- a/tests/test_limit_order_ttl.py
+++ b/tests/test_limit_order_ttl.py
@@ -48,3 +48,25 @@ def test_cpp_lob_ttl_expires():
     assert lob.contains_order(oid)
     assert lob.decay_ttl_and_cancel() == [oid]
     assert not lob.contains_order(oid)
+
+
+def test_limit_order_ioc_partial_cancel():
+    sim = ExecutionSimulator()
+    sim.set_market_snapshot(bid=99.0, ask=101.0, liquidity=5.0)
+    proto = ActionProto(action_type=ActionType.LIMIT, volume_frac=10.0, abs_price=101.0, tif="IOC")
+    oid = sim.submit(proto)
+    report = sim.pop_ready(ref_price=100.0)
+    assert [t.qty for t in report.trades] == [5.0]
+    assert report.cancelled_ids == [oid]
+    assert report.new_order_ids == []
+
+
+def test_limit_order_fok_partial_cancel():
+    sim = ExecutionSimulator()
+    sim.set_market_snapshot(bid=99.0, ask=101.0, liquidity=5.0)
+    proto = ActionProto(action_type=ActionType.LIMIT, volume_frac=10.0, abs_price=101.0, tif="FOK")
+    oid = sim.submit(proto)
+    report = sim.pop_ready(ref_price=100.0)
+    assert report.trades == []
+    assert report.cancelled_ids == [oid]
+    assert report.new_order_ids == []


### PR DESCRIPTION
## Summary
- implement MidOffsetLimitExecutor for mid-price anchored limit orders
- expose executor in package exports
- expand simulation LIMIT handling with TIF (GTC/IOC/FOK) and TTL logic
- add tests for TTL expiration and IOC/FOK partial fill scenarios

## Testing
- `pytest` *(fails: Expected '=' after a key in a key/value pair (at line 35, column 9))*
- `pytest tests/test_limit_order_ttl.py -c /tmp/pytest.ini` *(fails: assertion mismatches in TTL and TIF scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68c036d078fc832fa6e1ecdbd0559485