### PR TITLE
Add leak guard timestamp validation to TradingEnv

### DIFF
--- a/tests/test_leak_guard_env.py
+++ b/tests/test_leak_guard_env.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import types
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(os.getcwd())
+
+# stub minimal infra modules required for import
+infra_pkg = types.ModuleType("infra")
+event_bus_stub = types.ModuleType("event_bus")
+event_bus_stub.publish = lambda *a, **k: None
+event_bus_stub.Topics = object
+time_provider_stub = types.ModuleType("time_provider")
+time_provider_stub.TimeProvider = object
+time_provider_stub.RealTimeProvider = object
+sys.modules["infra"] = infra_pkg
+sys.modules["infra.event_bus"] = event_bus_stub
+sys.modules["infra.time_provider"] = time_provider_stub
+lob_state_stub = types.ModuleType("lob_state_cython")
+lob_state_stub.N_FEATURES = 1
+sys.modules["lob_state_cython"] = lob_state_stub
+mediator_stub = types.ModuleType("mediator")
+class _Mediator:
+    def __init__(self, env):
+        self.env = env
+        self.exec = None
+    def step(self, proto):
+        return np.zeros(1), 0.0, False, False, {}
+    def reset(self):
+        return np.zeros(1, dtype=np.float32), {}
+mediator_stub.Mediator = _Mediator
+sys.modules["mediator"] = mediator_stub
+
+from trading_patchnew import TradingEnv
+from action_proto import ActionProto, ActionType
+
+
+def test_feature_timestamp_validation():
+    df_bad = pd.DataFrame({
+        "ts_ms": [0],
+        "open": [1.0],
+        "price": [1.0],
+        "atr_pct": [0.0],
+        "liq_roll": [0.0],
+        "feat_ts": [2000],
+        "quote_asset_volume": [1.0],
+    })
+    env = TradingEnv(df_bad, decision_delay_ms=1000)
+    env.reset()
+    with pytest.raises(AssertionError):
+        env.step(ActionProto(ActionType.HOLD, 0.0))
+
+    df_ok = df_bad.copy()
+    df_ok["feat_ts"] = [500]
+    env_ok = TradingEnv(df_ok, decision_delay_ms=1000)
+    env_ok.reset()
+    env_ok.step(ActionProto(ActionType.HOLD, 0.0))


### PR DESCRIPTION
## Summary
- instantiate LeakGuard in `TradingEnv` and attach decision timestamps
- ensure step validates feature timestamps against `decision_ts`
- add unit test for timestamp leak detection

## Testing
- `pytest -c /dev/null tests/test_close_shift.py tests/test_leak_guard_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04cb0c104832fb6acb47a1a05263d