### PR TITLE
Add no-trade mask enforcement to TradingEnv

### DIFF
--- a/tests/test_no_trade_mask.py
+++ b/tests/test_no_trade_mask.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import types
+import numpy as np
+import pandas as pd
+
+sys.path.append(os.getcwd())
+
+infra_pkg = types.ModuleType("infra")
+event_bus_stub = types.ModuleType("event_bus")
+event_bus_stub.publish = lambda *a, **k: None
+event_bus_stub.Topics = object
+time_provider_stub = types.ModuleType("time_provider")
+time_provider_stub.TimeProvider = object
+time_provider_stub.RealTimeProvider = object
+sys.modules["infra"] = infra_pkg
+sys.modules["infra.event_bus"] = event_bus_stub
+sys.modules["infra.time_provider"] = time_provider_stub
+lob_state_stub = types.ModuleType("lob_state_cython")
+lob_state_stub.N_FEATURES = 1
+sys.modules["lob_state_cython"] = lob_state_stub
+
+mediator_stub = types.ModuleType("mediator")
+class _Mediator:
+    def __init__(self, env):
+        self.env = env
+        self.calls = []
+    def step(self, proto):
+        self.calls.append(proto)
+        return np.zeros(1), 0.0, False, False, {}
+    def reset(self):
+        return np.zeros(1, dtype=np.float32), {}
+mediator_stub.Mediator = _Mediator
+sys.modules["mediator"] = mediator_stub
+
+from trading_patchnew import TradingEnv
+from action_proto import ActionProto, ActionType
+
+def _make_df(ts_minutes):
+    ts = np.array(ts_minutes, dtype=np.int64) * 60_000
+    return pd.DataFrame(
+        {
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": 1.0,
+            "price": 1.0,
+            "quote_asset_volume": 1.0,
+            "ts_ms": ts,
+        }
+    )
+
+def test_funding_buffer_blocks_orders():
+    df = _make_df([360, 410, 470])  # minutes since midnight
+    env = TradingEnv(df, no_trade={"funding_buffer_min": 30})
+    env.reset()
+    act = ActionProto(ActionType.MARKET, 1.0)
+    for i in range(len(df)):
+        env.state.step_idx = i
+        env.step(act)
+    calls = env._mediator.calls
+    assert calls[1].action_type == ActionType.MARKET
+    assert calls[2].action_type == ActionType.HOLD
+    assert env.no_trade_blocks == 1
+
+def test_custom_window_blocks_orders():
+    df = _make_df([0, 20, 40])
+    env = TradingEnv(
+        df,
+        no_trade={"custom_ms": [{"start_ts_ms": 19 * 60_000, "end_ts_ms": 21 * 60_000}]},
+    )
+    env.reset()
+    act = ActionProto(ActionType.MARKET, 1.0)
+    env.state.step_idx = 0
+    env.step(act)
+    env.state.step_idx = 1
+    env.step(act)
+    calls = env._mediator.calls
+    assert calls[1].action_type == ActionType.HOLD
+    assert env.no_trade_blocks == 1


### PR DESCRIPTION
## Summary
- parse no-trade config in `TradingEnv` and precompute mask for timestamps
- block actions during no-trade windows and track blocked step count
- add unit tests for funding buffer and custom window no-trade rules

## Testing
- `pytest tests/test_no_trade_mask.py -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68c04ff4ee7c832fbd438abe2e6cf6ef