### PR TITLE
Add no-trade block ratio estimation with validation

### DIFF
--- a/tests/test_no_trade_ratio.py
+++ b/tests/test_no_trade_ratio.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from no_trade import (
+    compute_no_trade_mask,
+    estimate_block_ratio,
+    load_no_trade_config,
+)
+
+
+def test_blocked_share_matches_legacy_config():
+    cfg = load_no_trade_config("configs/legacy_sandbox.yaml")
+    ts = np.arange(0, 24 * 60, dtype=np.int64) * 60_000
+    df = pd.DataFrame({"ts_ms": ts})
+    mask = compute_no_trade_mask(df, sandbox_yaml_path="configs/legacy_sandbox.yaml")
+    est = estimate_block_ratio(df, cfg)
+    expected = 28 / 1440
+    assert est == pytest.approx(expected, abs=1e-6)
+    assert mask.mean() == pytest.approx(expected, abs=1e-6)


### PR DESCRIPTION
## Summary
- add `estimate_block_ratio` helper to compute expected no-trade fraction
- warn in `apply_no_trade_mask` when observed block share differs from estimate
- regression test ensuring sandbox config produces expected blocked share

## Testing
- `pytest -c /dev/null tests/test_no_trade_mask.py tests/test_no_trade_ratio.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c052b37204832f8e97fc41d0c57959