### PR TITLE
Add optional no-trade weighting for training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@
 
 ```bash
 python script_backtest.py --config configs/config_sim.yaml
-python script_train.py --config configs/train.yaml --trainer-module mypackage.trainer:MyTrainer
+python script_train.py --config configs/train.yaml --trainer-module mypackage.trainer:MyTrainer --no-trade-mode weight
 python script_compare_runs.py run1 run2 run3            # сохранит compare_runs.csv
 python script_compare_runs.py run1 metrics.json --stdout  # вывод в stdout
 python script_fetch_exchange_specs.py --market futures --symbols BTCUSDT,ETHUSDT --out data/exchange_specs.json
 ```
+
+Флаг `--no-trade-mode` управляет применением **no‑trade** окон из конфигурации:
+`drop` удаляет такие строки из датасета, а `weight` оставляет их с
+добавленным столбцом `train_weight=0.0`.
 
 ## Профили исполнения
 

--- a/script_train.py
+++ b/script_train.py
@@ -39,6 +39,12 @@ def main() -> None:
         default=None,
         help="Dotted path to module providing trainer",
     )
+    p.add_argument(
+        "--no-trade-mode",
+        choices=["drop", "weight"],
+        default="drop",
+        help="How to handle no-trade windows: drop rows or assign train_weight=0",
+    )
     args = p.parse_args()
 
     cfg = load_config(args.config)
@@ -46,7 +52,7 @@ def main() -> None:
         trainer = _load_trainer(args.trainer_module)
     else:
         class DummyTrainer:
-            def fit(self, X, y=None):
+            def fit(self, X, y=None, sample_weight=None):
                 return None
 
             def save(self, path: str) -> str:
@@ -66,6 +72,8 @@ def main() -> None:
         input_format=fmt,
         artifacts_dir=cfg.artifacts_dir,
         snapshot_config_path=args.config,
+        no_trade_mode=args.no_trade_mode,
+        no_trade_config_path=args.config,
     )
 
     res = from_config(cfg, trainer=trainer, train_cfg=train_cfg)

--- a/tests/test_no_trade_modes.py
+++ b/tests/test_no_trade_modes.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pandas as pd
+import pytest
+import pathlib
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from service_train import ServiceTrain, TrainConfig
+
+
+class DummyFeaturePipe:
+    def warmup(self):
+        pass
+
+    def fit(self, df: pd.DataFrame):
+        pass
+
+    def transform_df(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df[["feat"]]
+
+    def make_targets(self, df: pd.DataFrame) -> pd.Series:
+        return df["target"]
+
+
+class CaptureTrainer:
+    def __init__(self):
+        self.X = None
+        self.y = None
+        self.sample_weight = None
+
+    def fit(self, X, y=None, sample_weight=None):
+        self.X = X
+        self.y = y
+        self.sample_weight = sample_weight
+
+    def save(self, path: str) -> str:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("dummy")
+        return path
+
+
+def _make_dataset(tmp_path: pathlib.Path) -> pathlib.Path:
+    ts = np.arange(0, 24 * 60, dtype=np.int64) * 60_000
+    df = pd.DataFrame({"ts_ms": ts, "feat": ts.astype(float), "target": np.ones_like(ts)})
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+    return path, df
+
+
+def test_drop_and_weight_modes_same_effective_samples(tmp_path):
+    data_path, df = _make_dataset(tmp_path)
+    fp = DummyFeaturePipe()
+
+    trainer_drop = CaptureTrainer()
+    cfg_drop = TrainConfig(
+        input_path=str(data_path),
+        input_format="csv",
+        artifacts_dir=str(tmp_path / "art_drop"),
+        no_trade_mode="drop",
+        no_trade_config_path="configs/legacy_sandbox.yaml",
+    )
+    service_drop = ServiceTrain(fp, trainer_drop, cfg_drop)
+    res_drop = service_drop.run()
+
+    trainer_weight = CaptureTrainer()
+    cfg_weight = TrainConfig(
+        input_path=str(data_path),
+        input_format="csv",
+        artifacts_dir=str(tmp_path / "art_weight"),
+        no_trade_mode="weight",
+        no_trade_config_path="configs/legacy_sandbox.yaml",
+    )
+    service_weight = ServiceTrain(fp, trainer_weight, cfg_weight)
+    res_weight = service_weight.run()
+
+    assert res_drop["effective_samples"] == pytest.approx(res_weight["effective_samples"])
+    assert trainer_weight.sample_weight is not None
+    assert int(trainer_weight.sample_weight.sum()) == res_weight["effective_samples"]
+    assert len(trainer_weight.X) == len(df)

--- a/tests/test_no_trade_ratio.py
+++ b/tests/test_no_trade_ratio.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pandas as pd
 import pytest
+import os
+import sys
+
+sys.path.append(os.getcwd())
 
 from no_trade import (
     compute_no_trade_mask,


### PR DESCRIPTION
## Summary
- allow training scripts to drop or weight no-trade rows via `--no-trade-mode`
- propagate no-trade mask through `ServiceTrain` and pass `train_weight` to trainers
- document new flag and add tests covering drop vs weight modes

## Testing
- `pytest tests/test_no_trade_modes.py tests/test_no_trade_ratio.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05587e5b8832fa1b1fc80ed925680