### PR TITLE
Add tests for no-trade utility helpers

### DIFF
--- a/tests/test_no_trade_helpers.py
+++ b/tests/test_no_trade_helpers.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import numpy as np
+import pytest
+
+sys.path.append(os.getcwd())
+
+from no_trade import _parse_daily_windows_min, _in_funding_buffer, _in_custom_window
+
+
+def test_parse_daily_windows_min_valid_and_invalid():
+    windows = ["00:00-01:00", "22:00-24:00", "bad", "23:00-22:00"]
+    assert _parse_daily_windows_min(windows) == [(0, 60), (1320, 1440)]
+
+
+def test_in_funding_buffer_with_midnight_and_day_marks():
+    ts_minutes = np.array([
+        0,          # exactly at midnight
+        5,          # within buffer after midnight
+        475,        # 7:55, 5 min before 8h mark
+        495,        # 8:15, outside 10 min buffer
+        951,        # 15:51, 9 min before 16h mark
+        971,        # 16:11, outside buffer
+        1435,       # 23:55, far from midnight mark
+    ], dtype=np.int64)
+    ts_ms = ts_minutes * 60_000
+    mask = _in_funding_buffer(ts_ms, 10)
+    expected = np.array([True, True, True, False, True, False, False])
+    np.testing.assert_array_equal(mask, expected)
+
+
+def test_in_custom_window_respects_ranges():
+    ts_minutes = np.array([0, 4, 5, 10, 11], dtype=np.int64)
+    ts_ms = ts_minutes * 60_000
+    windows = [
+        {"start_ts_ms": 0, "end_ts_ms": 5 * 60_000},
+        {"start_ts_ms": 10 * 60_000, "end_ts_ms": 10 * 60_000},
+        {"start_ts_ms": "bad", "end_ts_ms": 20},
+    ]
+    mask = _in_custom_window(ts_ms, windows)
+    expected = np.array([True, True, True, True, False])
+    np.testing.assert_array_equal(mask, expected)


### PR DESCRIPTION
## Summary
- add unit tests for `_parse_daily_windows_min`, `_in_funding_buffer`, and `_in_custom_window`
- cover edge cases like invalid window strings and midnight boundary handling

## Testing
- `pytest tests/test_no_trade_helpers.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c05c112c3c832f885b9815e4de685b