### PR TITLE
Validate custom no-trade windows

### DIFF
--- a/no_trade.py
+++ b/no_trade.py
@@ -55,14 +55,24 @@ def _in_funding_buffer(ts_ms: np.ndarray, buf_min: int) -> np.ndarray:
 def _in_custom_window(ts_ms: np.ndarray, windows: List[Dict[str, int]]) -> np.ndarray:
     if not windows:
         return np.zeros_like(ts_ms, dtype=bool)
+
     mask = np.zeros_like(ts_ms, dtype=bool)
     for w in windows:
         try:
-            s = int(w.get("start_ts_ms"))
-            e = int(w.get("end_ts_ms"))
-            mask |= (ts_ms >= s) & (ts_ms <= e)
-        except Exception:
-            continue
+            s = int(w["start_ts_ms"])
+            e = int(w["end_ts_ms"])
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError(
+                f"Invalid custom window {w}: expected integer 'start_ts_ms' and 'end_ts_ms'"
+            ) from exc
+
+        if s >= e:
+            raise ValueError(
+                f"Invalid custom window {w}: start_ts_ms ({s}) must be < end_ts_ms ({e})"
+            )
+
+        mask |= (ts_ms >= s) & (ts_ms <= e)
+
     return mask
 
 

--- a/sandbox/backtest_adapter.py
+++ b/sandbox/backtest_adapter.py
@@ -281,12 +281,21 @@ class BacktestAdapter:
     def _in_custom_window(self, ts_ms: int) -> bool:
         for w in (self._no_trade.custom_ms or []):
             try:
-                s = int(w.get("start_ts_ms"))
-                e = int(w.get("end_ts_ms"))
-                if s <= int(ts_ms) <= e:
-                    return True
-            except Exception:
-                continue
+                s = int(w["start_ts_ms"])
+                e = int(w["end_ts_ms"])
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ValueError(
+                    f"Invalid custom window {w}: expected integer 'start_ts_ms' and 'end_ts_ms'"
+                ) from exc
+
+            if s >= e:
+                raise ValueError(
+                    f"Invalid custom window {w}: start_ts_ms ({s}) must be < end_ts_ms ({e})"
+                )
+
+            if s <= int(ts_ms) <= e:
+                return True
+
         return False
 
     def _no_trade_block(self, ts_ms: int) -> bool:

--- a/tests/test_no_trade_helpers.py
+++ b/tests/test_no_trade_helpers.py
@@ -30,13 +30,26 @@ def test_in_funding_buffer_with_midnight_and_day_marks():
 
 
 def test_in_custom_window_respects_ranges():
-    ts_minutes = np.array([0, 4, 5, 10, 11], dtype=np.int64)
+    ts_minutes = np.array([0, 4, 5, 10, 12], dtype=np.int64)
     ts_ms = ts_minutes * 60_000
     windows = [
         {"start_ts_ms": 0, "end_ts_ms": 5 * 60_000},
-        {"start_ts_ms": 10 * 60_000, "end_ts_ms": 10 * 60_000},
-        {"start_ts_ms": "bad", "end_ts_ms": 20},
+        {"start_ts_ms": 10 * 60_000, "end_ts_ms": 11 * 60_000},
     ]
     mask = _in_custom_window(ts_ms, windows)
     expected = np.array([True, True, True, True, False])
     np.testing.assert_array_equal(mask, expected)
+
+
+@pytest.mark.parametrize(
+    "windows,match",
+    [
+        ([{"start_ts_ms": "bad", "end_ts_ms": 20}], "integer"),
+        ([{"start_ts_ms": 10, "end_ts_ms": 5}], "must be <"),
+        ([{"start_ts_ms": 10, "end_ts_ms": 10}], "must be <"),
+    ],
+)
+def test_in_custom_window_invalid_windows_raise(windows, match):
+    ts_ms = np.array([0], dtype=np.int64)
+    with pytest.raises(ValueError, match=match):
+        _in_custom_window(ts_ms, windows)


### PR DESCRIPTION
## Summary
- ensure custom no-trade windows use integer timestamps with `start_ts_ms < end_ts_ms`
- raise descriptive `ValueError` when invalid windows are encountered
- add tests covering valid and invalid custom window configurations

## Testing
- `pytest tests/test_no_trade_helpers.py -q`
- `pytest -q` *(fails: ActionProto __init__ unexpected keyword 'abs_price'; Missing optional dependency 'pyarrow')*


------
https://chatgpt.com/codex/tasks/task_e_68c0649a6588832fb459ed6e4343c3f9