### PR TITLE
feat: add mask-only option to no-trade CLI

### DIFF
--- a/docs/no_trade.md
+++ b/docs/no_trade.md
@@ -26,7 +26,7 @@ no_trade:
 
 ## Applying the mask to datasets
 
-`no_trade` windows can be applied to datasets either by **dropping** offending rows or by **weighting** them with `train_weight=0`.
+`no_trade` windows can be applied to datasets either by **dropping** offending rows, **weighting** them with `train_weight=0`, or exporting a **mask** with the `--mask-only` flag.
 Use the `no-trade-mask` CLI (installed with this project) or pass `--no-trade-mode` to training scripts.
 
 ```bash
@@ -35,6 +35,9 @@ no-trade-mask --data raw.csv --sandbox_config configs/legacy_sandbox.yaml --mode
 
 # keep rows but set train_weight=0
 no-trade-mask --data raw.csv --sandbox_config configs/legacy_sandbox.yaml --mode weight
+
+# output mask only
+no-trade-mask --data raw.csv --sandbox_config configs/legacy_sandbox.yaml --mask-only
 ```
 
 Effect on a sample dataset:

--- a/tests/run_no_trade_mask_sample.py
+++ b/tests/run_no_trade_mask_sample.py
@@ -8,17 +8,22 @@ sys.path.append(REPO)
 from apply_no_trade_mask import main
 
 
-def run(mode: str) -> None:
+def run(mode: str | None) -> None:
+    out = f"/tmp/no_trade_sample_{mode or 'mask'}.csv"
     sys.argv = [
         "no-trade-mask",
         "--data", os.path.join(REPO, "tests/data/no_trade_sample.csv"),
-        "--out", f"/tmp/no_trade_sample_{mode}.csv",
+        "--out", out,
         "--sandbox_config", os.path.join(REPO, "configs/legacy_sandbox.yaml"),
-        "--mode", mode,
     ]
+    if mode:
+        sys.argv += ["--mode", mode]
+    else:
+        sys.argv += ["--mask-only"]
     main()
 
 
 if __name__ == "__main__":
     run("drop")
     run("weight")
+    run(None)


### PR DESCRIPTION
## Summary
- add `--mask-only` flag to `no-trade-mask` CLI
- allow `_write_table` to save boolean masks
- document mask-only usage and test sample script

## Testing
- `python tests/run_no_trade_mask_sample.py`
- `pytest tests/run_no_trade_mask_sample.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0681348f8832f8636ff7b12e08a09