### PR TITLE
docs: unify training config path and document overrides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,6 +83,22 @@ from core_config import load_config
 cfg = load_config("configs/config_sim.yaml")
 ```
 
+Отдельные параметры можно переопределить из командной строки. Например,
+так временно изменяются проскальзывание и задержка:
+
+```bash
+python train_model_multi_patch.py --config configs/config_train.yaml --slippage.bps 5 --latency.mean_ms 50
+```
+
+Те же значения можно указать напрямую в YAML:
+
+```yaml
+slippage:
+  bps: 5
+latency:
+  mean_ms: 50
+```
+
 ### Профили исполнения
 
 Конфигурация может содержать несколько профилей исполнения. Каждый профиль
@@ -129,6 +145,7 @@ profiles:
 флаг `--config` и запускают соответствующие сервисы через `from_config`:
 
 ```
+python train_model_multi_patch.py --config configs/config_train.yaml
 python script_live.py    --config configs/config_live.yaml
 python script_backtest.py --config configs/config_sim.yaml
 python script_eval.py    --config configs/config_eval.yaml --profile vwap

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ python script_compare_runs.py run1 metrics.json --stdout  # вывод в stdout
 python script_fetch_exchange_specs.py --market futures --symbols BTCUSDT,ETHUSDT --out data/exchange_specs.json
 ```
 
+Параметры симуляции можно временно переопределить через CLI:
+
+```bash
+python train_model_multi_patch.py --config configs/config_train.yaml --slippage.bps 5 --latency.mean_ms 50
+```
+
+Те же значения можно задать в YAML‑конфиге:
+
+```yaml
+slippage:
+  bps: 5
+latency:
+  mean_ms: 50
+```
+
 Обработка окон **no‑trade** описывается в конфигурации; подробности
 см. [docs/no_trade.md](docs/no_trade.md).
 

--- a/app.py
+++ b/app.py
@@ -624,11 +624,16 @@ with tabs[10]:
     if mode.startswith("A"):
         st.markdown("### Режим A — запуск твоего train_model_multi_patch")
 
-        st.caption("Введи точную команду запуска. Примеры: "
-                   "`python scripts/train_model_multi_patch.py --config configs/train.yaml` "
-                   "или `python train_model_multi_patch.py` "
-                   "или любая другая подходящая команда.")
-        custom_cmd = st.text_input("Команда запуска обучения", value="python scripts/train_model_multi_patch.py", key="mt_custom_cmd")
+        st.caption(
+            "Введи точную команду запуска. Пример: "
+            "`python train_model_multi_patch.py --config configs/config_train.yaml` "
+            "или любая другая подходящая команда."
+        )
+        custom_cmd = st.text_input(
+            "Команда запуска обучения",
+            value="python train_model_multi_patch.py --config configs/config_train.yaml",
+            key="mt_custom_cmd",
+        )
         custom_log = os.path.join(logs_dir, "train_custom.log")
         st.caption(f"Лог обучения: `{custom_log}`")
 


### PR DESCRIPTION
## Summary
- switch to `python train_model_multi_patch.py --config configs/config_train.yaml` in docs and UI
- document overriding simulation parameters via CLI or YAML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c0767f6070832f909fe5d31a9c8617