### PR TITLE
Seeded worker RNG and resilient cleanup in SharedMemoryVecEnv

### DIFF
--- a/tests/test_shared_memory_vec_env_seed.py
+++ b/tests/test_shared_memory_vec_env_seed.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pathlib, sys
+import pytest
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+try:
+    from gymnasium import Env, spaces
+    from shared_memory_vec_env import SharedMemoryVecEnv
+except ModuleNotFoundError:
+    pytest.skip("stable-baselines3 or gymnasium is not available", allow_module_level=True)
+
+class RNGEnv(Env):
+    def __init__(self):
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(1,), dtype=np.float32)
+        self.observation_space = spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32)
+
+    def reset(self, *, seed=None, options=None):
+        if seed is not None:
+            np.random.seed(seed)
+        return np.array([np.random.random()], dtype=np.float32), {}
+
+    def step(self, action):
+        obs = np.array([np.random.random()], dtype=np.float32)
+        return obs, 0.0, False, False, {}
+
+def test_independent_rng_per_worker():
+    vec_env = SharedMemoryVecEnv([lambda: RNGEnv(), lambda: RNGEnv()], base_seed=123)
+    obs, _ = vec_env.reset()
+    assert obs[0] != obs[1]
+    vec_env.step_async(np.zeros((2,1), dtype=np.float32))
+    obs2, _, _, _ = vec_env.step_wait()
+    assert obs2[0] != obs2[1]
+    vec_env.close()
+    for p in vec_env.processes:
+        assert not p.is_alive()


### PR DESCRIPTION
## Summary
- pass a base seed from the main process and derive per-worker seeds
- ensure close() joins workers and unlinks shared memory segments
- add test verifying independent RNG streams across workers

## Testing
- `pytest tests/test_shared_memory_vec_env_seed.py -q`
- `pytest tests/test_shared_memory_vec_env_copy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c097cdfc60832f87d35eac6b934e9d