### PR TITLE
Integrate market regime calibration and config-driven simulator

### DIFF
--- a/MarketSimulator.h
+++ b/MarketSimulator.h
@@ -87,6 +87,8 @@ private:
         double mu;         // средний дрейф лог-доходности
         double sigma;      // волатильность лог-доходности
         double kappa;      // сила возврата к среднему (для CHOPPY_FLAT)
+        double avg_volume; // средний объём
+        double avg_spread; // средний спред
     };
     std::array<RegimeParams, 4> m_params;
 
@@ -101,6 +103,7 @@ private:
     bool m_shocks_enabled;
     double m_shock_p;
     std::vector<int> m_shock_marks; // -1,0,+1
+    std::vector<double> m_shock_mags; // распределение величины шока
 
     // "Черные лебеди" (флаги по шагам)
     std::vector<int> m_black_swan_marks; // -1 crash, +1 mania, 0 none

--- a/configs/market_regimes.json
+++ b/configs/market_regimes.json
@@ -1,0 +1,13 @@
+{
+  "regimes": {
+    "NORMAL": {"mu": 0.0000, "sigma": 0.0100, "kappa": 0.0, "avg_volume": 1000.0, "avg_spread": 0.0005},
+    "CHOPPY_FLAT": {"mu": 0.0000, "sigma": 0.0040, "kappa": 0.5, "avg_volume": 800.0, "avg_spread": 0.0007},
+    "STRONG_TREND": {"mu": 0.0008, "sigma": 0.0120, "kappa": 0.0, "avg_volume": 1200.0, "avg_spread": 0.0004},
+    "ILLIQUID": {"mu": 0.0000, "sigma": 0.0200, "kappa": 0.0, "avg_volume": 500.0, "avg_spread": 0.0010}
+  },
+  "regime_probs": [0.25, 0.25, 0.25, 0.25],
+  "flash_shock": {
+    "probability": 0.01,
+    "magnitudes": [0.005, 0.01, 0.015, 0.02]
+  }
+}

--- a/scripts/calibrate_regimes.py
+++ b/scripts/calibrate_regimes.py
@@ -1,0 +1,89 @@
+import argparse
+import json
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+
+def load_ohlcv(path: Path) -> pd.DataFrame:
+    """Load historical OHLCV data from CSV/Parquet."""
+    if path.suffix == ".parquet":
+        return pd.read_parquet(path)
+    return pd.read_csv(path)
+
+
+def label_regimes(df: pd.DataFrame) -> pd.Series:
+    """Label market regimes using volatility and trend filters."""
+    df = df.copy()
+    df["ret"] = np.log(df["close"]).diff()
+    df["vol"] = df["ret"].rolling(24).std()
+    df["trend"] = df["ret"].rolling(24).mean()
+    vol_hi = df["vol"] > df["vol"].quantile(0.66)
+    vol_lo = df["vol"] < df["vol"].quantile(0.33)
+    trend_hi = df["trend"].abs() > df["trend"].abs().quantile(0.66)
+    liq_lo = df["volume"].rolling(24).mean() < df["volume"].rolling(24).mean().quantile(0.25)
+    regime = pd.Series("NORMAL", index=df.index)
+    regime[trend_hi] = "STRONG_TREND"
+    regime[vol_lo & ~trend_hi] = "CHOPPY_FLAT"
+    regime[liq_lo] = "ILLIQUID"
+    return regime
+
+
+def estimate_params(df: pd.DataFrame, regime: pd.Series) -> dict:
+    out = {}
+    total = len(df)
+    returns = np.log(df["close"]).diff()
+    spread = df.get("spread")
+    if spread is None:
+        spread = (df["high"] - df["low"]) / df["close"]
+    for name in ["NORMAL", "CHOPPY_FLAT", "STRONG_TREND", "ILLIQUID"]:
+        mask = regime == name
+        r = returns[mask].dropna()
+        if len(r) < 2:
+            mu = sigma = kappa = 0.0
+        else:
+            mu = r.mean()
+            sigma = r.std()
+            prev = r.shift(1).dropna()
+            corr = np.corrcoef(prev, r.loc[prev.index])[0, 1]
+            kappa = max(0.0, -np.log(abs(corr))) if np.isfinite(corr) and abs(corr) < 1 else 0.0
+        avg_vol = df.loc[mask, "volume"].mean()
+        avg_spread = spread.loc[mask].mean()
+        out[name] = {
+            "mu": float(mu),
+            "sigma": float(sigma),
+            "kappa": float(kappa),
+            "avg_volume": float(avg_vol if pd.notna(avg_vol) else 0.0),
+            "avg_spread": float(avg_spread if pd.notna(avg_spread) else 0.0),
+        }
+    counts = regime.value_counts()
+    probs = [float(counts.get(name, 0) / total) for name in ["NORMAL", "CHOPPY_FLAT", "STRONG_TREND", "ILLIQUID"]]
+    out["regime_probs"] = probs
+    # flash shocks
+    shock_threshold = returns.std() * 5
+    shocks = returns[np.abs(returns) > shock_threshold]
+    out["flash_shock"] = {
+        "probability": float(len(shocks) / max(len(returns), 1)),
+        "magnitudes": np.abs(shocks).dropna().tolist(),
+    }
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--data", required=True, help="Path to OHLCV data (csv or parquet)")
+    p.add_argument("--out", default="configs/market_regimes.json", help="Output JSON path")
+    args = p.parse_args()
+    df = load_ohlcv(Path(args.data))
+    regime = label_regimes(df)
+    params = estimate_params(df, regime)
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump({"regimes": {k: v for k, v in params.items() if k not in {"regime_probs", "flash_shock"}},
+                   "regime_probs": params["regime_probs"],
+                   "flash_shock": params["flash_shock"]}, f, indent=2)
+    print(f"Saved regime parameters to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -627,7 +627,10 @@ def objective(trial: optuna.Trial,
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", default="configs/config_train.yaml", help="Path to YAML config")
+    parser.add_argument("--market-regimes", default="configs/market_regimes.json", help="Path to market regime parameters")
     args, unknown = parser.parse_known_args()
+
+    os.environ["MARKET_REGIMES_JSON"] = args.market_regimes
 
     cfg = load_config(args.config)
 


### PR DESCRIPTION
## Summary
- add scripts/calibrate_regimes.py to compute regime params and flash shock stats
- load configs/market_regimes.json in MarketSimulator and expose flash shock distribution
- allow specifying market regimes config via train_model_multi_patch.py CLI and fallback stub

## Testing
- `pytest -q` *(fails: ActionProto.__init__() got an unexpected keyword argument 'abs_price')*


------
https://chatgpt.com/codex/tasks/task_e_68c0acef58a8832f9352d2879ad53c84