### PR TITLE
Add liquidity seasonality support

### DIFF
--- a/MarketSimulator.cpp
+++ b/MarketSimulator.cpp
@@ -55,6 +55,9 @@ MarketSimulator::MarketSimulator(
     if (m_high) std::memset(m_high, 0, sizeof(double) * m_n);
     if (m_low) std::memset(m_low, 0, sizeof(double) * m_n);
     if (m_volume_usd) std::memset(m_volume_usd, 0, sizeof(double) * m_n);
+
+    // seasonality multipliers default to 1
+    m_liq_mult.fill(1.0);
 }
 
 void MarketSimulator::initialize_defaults() {
@@ -217,6 +220,10 @@ void MarketSimulator::apply_flash_shock_if_any(std::size_t i, double& close_ref)
     close_ref = close_ref * (1.0 + mag);
 }
 
+void MarketSimulator::set_liquidity_seasonality(const std::array<double, 168>& multipliers) {
+    m_liq_mult = multipliers;
+}
+
 void MarketSimulator::update_ohlc_and_volume(std::size_t i, double prev_close, double new_close) {
     // Простейшая модель формирования high/low вокруг open/close:
     double openv = prev_close;
@@ -237,6 +244,7 @@ void MarketSimulator::update_ohlc_and_volume(std::size_t i, double prev_close, d
     double base_vol = 1e3; // базовый условный объём
     double vol_mult = 1.0 + 25.0 * swing / std::max(1.0, openv);
     double vol_usd = std::max(0.0, base_vol * vol_mult);
+    vol_usd *= m_liq_mult[i % 168];
     if (m_volume_usd) m_volume_usd[i] = vol_usd;
 }
 

--- a/MarketSimulator.h
+++ b/MarketSimulator.h
@@ -48,6 +48,9 @@ public:
     // Зафиксировать принудительный режим на [start, start+duration).
     void force_market_regime(MarketRegime regime, std::size_t start, std::size_t duration);
 
+    // Установить сезонные коэффициенты ликвидности (168 часов недели).
+    void set_liquidity_seasonality(const std::array<double, 168>& multipliers);
+
     // Была ли на шаге i триггернута вспышка-шок? (-1: sell, +1: buy, 0: нет)
     int shock_triggered(std::size_t i) const;
 
@@ -134,6 +137,9 @@ private:
     std::mt19937_64 m_rng;
     std::normal_distribution<double> m_stdnorm;
     std::uniform_real_distribution<double> m_unif;
+
+    // Сезонные коэффициенты ликвидности по часам недели
+    std::array<double, 168> m_liq_mult;
 
     // --- внутренние методы ---
     void initialize_defaults();


### PR DESCRIPTION
## Summary
- add script to compute hourly liquidity multipliers from OHLCV data
- scale rolling liquidity in TradingEnv using hourly seasonality config
- extend MarketSimulator with hourly liquidity multipliers

## Testing
- `pytest tests/test_close_shift.py tests/test_no_trade_config_shared.py tests/test_no_trade_mask.py tests/test_leak_guard_env.py -q`
- `pytest -q` *(fails: ActionProto __init__ missing abs_price, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aea5ddc4832f990cbd88b620681d