### PR TITLE
Expose regime and liquidity config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 
 ```bash
 python script_backtest.py --config configs/config_sim.yaml
-python train_model_multi_patch.py --config configs/config_train.yaml
+python train_model_multi_patch.py --config configs/config_train.yaml \
+  --regime-config configs/market_regimes.json \
+  --liquidity-seasonality configs/liquidity_seasonality.json
 python script_compare_runs.py run1 run2 run3            # сохранит compare_runs.csv
 python script_compare_runs.py run1 metrics.json --stdout  # вывод в stdout
 python script_fetch_exchange_specs.py --market futures --symbols BTCUSDT,ETHUSDT --out data/exchange_specs.json
@@ -25,6 +27,11 @@ python script_fetch_exchange_specs.py --market futures --symbols BTCUSDT,ETHUSDT
 ```bash
 python train_model_multi_patch.py --config configs/config_train.yaml --slippage.bps 5 --latency.mean_ms 50
 ```
+
+Дополнительно доступны опции `--regime-config` и `--liquidity-seasonality`,
+позволяющие указать пути к откалиброванным JSON‑файлам с параметрами
+рыночных режимов и сезонностью ликвидности соответственно. По умолчанию
+используются файлы из каталога `configs/`.
 
 Те же значения можно задать в YAML‑конфиге:
 


### PR DESCRIPTION
## Summary
- add `--regime-config` and `--liquidity-seasonality` options to training CLI
- thread calibrated paths through `TradingEnv` and `AdversarialCallback`
- document new flags with launch example

## Testing
- `python -m pytest` *(fails: No module named 'core_contracts')*

------
https://chatgpt.com/codex/tasks/task_e_68c0b6d21834832fa72d7f84184eb9ad