### PR TITLE
Log extended trade metadata

### DIFF
--- a/core_models.py
+++ b/core_models.py
@@ -381,6 +381,11 @@ class TradeLogRow:
     equity: Optional[Decimal] = None           # equity после трейда
     notional: Optional[Decimal] = None         # absolute price*quantity
     drawdown: Optional[Decimal] = None         # drawdown после трейда
+    slippage_bps: Optional[Decimal] = None     # slippage в bps
+    spread_bps: Optional[Decimal] = None       # спред в bps
+    latency_ms: Optional[int] = None           # латентность запроса
+    tif: Optional[str] = None                  # Time in force
+    ttl_steps: Optional[int] = None            # TTL в шагах
     meta: Dict[str, Any] = field(default_factory=dict)
 
     @staticmethod
@@ -405,6 +410,11 @@ class TradeLogRow:
             mark_price=to_decimal_opt(er.meta.get("mark_price")),
             equity=to_decimal_opt(er.meta.get("equity")),
             drawdown=to_decimal_opt(er.meta.get("drawdown")),
+            slippage_bps=to_decimal_opt(er.meta.get("slippage_bps")),
+            spread_bps=to_decimal_opt(er.meta.get("spread_bps")),
+            latency_ms=int(er.meta.get("latency_ms", 0)) if er.meta.get("latency_ms") is not None else None,
+            tif=str(er.meta.get("tif")) if er.meta.get("tif") is not None else None,
+            ttl_steps=int(er.meta.get("ttl_steps", 0)) if er.meta.get("ttl_steps") is not None else None,
             meta=dict(er.meta),
         )
 

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -156,6 +156,8 @@ class ExecTrade:
     spread_bps: float = 0.0
     latency_ms: int = 0
     latency_spike: bool = False
+    tif: str = "GTC"
+    ttl_steps: int = 0
 
 
 @dataclass
@@ -688,6 +690,8 @@ class ExecutionSimulator:
         for p in ready:
             proto = p.proto
             atype = int(getattr(proto, "action_type", ActionType.HOLD))
+            ttl_steps = int(getattr(proto, "ttl_steps", 0))
+            tif = str(getattr(proto, "tif", "GTC")).upper()
             # HOLD
             if atype == ActionType.HOLD:
                 continue
@@ -827,6 +831,8 @@ class ExecutionSimulator:
                         spread_bps=float(sbps if sbps is not None else (self.slippage_cfg.default_spread_bps if self.slippage_cfg is not None else 0.0)),
                         latency_ms=int(p.lat_ms),
                         latency_spike=bool(p.spike),
+                        tif=tif,
+                        ttl_steps=ttl_steps,
                     ))
                 continue
             # Определение направления и базовой цены для прочих типов
@@ -885,6 +891,8 @@ class ExecutionSimulator:
                 spread_bps=float(sbps if sbps is not None else (self.slippage_cfg.default_spread_bps if self.slippage_cfg is not None else 0.0)),
                 latency_ms=int(p.lat_ms),
                 latency_spike=bool(p.spike),
+                tif=tif,
+                ttl_steps=ttl_steps,
             ))
             continue
 
@@ -893,8 +901,6 @@ class ExecutionSimulator:
                 is_buy = bool(getattr(proto, "volume_frac", 0.0) > 0.0)
                 side = "BUY" if is_buy else "SELL"
                 qty_raw = abs(float(getattr(proto, "volume_frac", 0.0)))
-                ttl_steps = int(getattr(proto, "ttl_steps", 0))
-                tif = str(getattr(proto, "tif", "GTC")).upper()
 
                 # Определяем лимитную цену
                 abs_price = getattr(proto, "abs_price", None)
@@ -967,6 +973,8 @@ class ExecutionSimulator:
                         spread_bps=float(sbps if sbps is not None else (self.slippage_cfg.default_spread_bps if self.slippage_cfg is not None else 0.0)),
                         latency_ms=int(p.lat_ms),
                         latency_spike=bool(p.spike),
+                        tif=tif,
+                        ttl_steps=ttl_steps,
                     ))
                     if exec_qty + 1e-12 < qty_q:
                         if tif == "IOC":
@@ -1002,6 +1010,8 @@ class ExecutionSimulator:
                         spread_bps=float(sbps if sbps is not None else (self.slippage_cfg.default_spread_bps if self.slippage_cfg is not None else 0.0)),
                         latency_ms=int(p.lat_ms),
                         latency_spike=bool(p.spike),
+                        tif=tif,
+                        ttl_steps=ttl_steps,
                     ))
                     continue
 
@@ -1170,6 +1180,8 @@ class ExecutionSimulator:
                 is_buy = bool(vol > 0.0)
                 side = "BUY" if is_buy else "SELL"
                 qty_raw = abs(float(vol))
+                ttl_steps = int(getattr(proto, "ttl_steps", 0))
+                tif = str(getattr(proto, "tif", "GTC")).upper()
                 ref = self._last_ref_price
                 if ref is None:
                     cancelled_ids.append(int(cli_id))
@@ -1299,6 +1311,8 @@ class ExecutionSimulator:
                         spread_bps=float(sbps if sbps is not None else (self.slippage_cfg.default_spread_bps if self.slippage_cfg is not None else 0.0)),
                         latency_ms=int(lat_ms),
                         latency_spike=bool(lat_spike),
+                        tif=tif,
+                        ttl_steps=ttl_steps,
                     ))
             else:
                 # пока другие типы не поддержаны — отменяем

--- a/logging.py
+++ b/logging.py
@@ -68,7 +68,19 @@ class LogWriter:
         rep_dict = report.to_dict() if hasattr(report, "to_dict") else {}
         for t in rep_dict.get("trades", []):
             er = trade_dict_to_core_exec_report(t, parent=rep_dict, symbol=str(symbol), run_id=self._run_id)
+            for k in ["slippage_bps", "spread_bps", "latency_ms", "tif", "ttl_steps"]:
+                v = t.get(k)
+                if v is not None:
+                    er.meta[k] = v
             row = TradeLogRow.from_exec(er).to_dict()
+            if row.get("slippage_bps") is not None:
+                row["slippage_bps"] = float(row["slippage_bps"])
+            if row.get("spread_bps") is not None:
+                row["spread_bps"] = float(row["spread_bps"])
+            if row.get("latency_ms") is not None:
+                row["latency_ms"] = int(row["latency_ms"])
+            if row.get("ttl_steps") is not None:
+                row["ttl_steps"] = int(row["ttl_steps"])
             row["mark_price"] = float(getattr(report, "mark_price", row.get("mark_price", 0.0)))
             row["equity"] = float(getattr(report, "equity", row.get("equity", 0.0)))
             row["drawdown"] = (

--- a/tests/test_logging_columns.py
+++ b/tests/test_logging_columns.py
@@ -1,0 +1,47 @@
+import importlib.util
+import pathlib
+import sys
+
+import pandas as pd
+
+BASE = pathlib.Path(__file__).resolve().parent.parent
+
+spec_exec = importlib.util.spec_from_file_location("execution_sim", BASE / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec_exec)
+sys.modules["execution_sim"] = exec_mod
+spec_exec.loader.exec_module(exec_mod)
+
+spec_log = importlib.util.spec_from_file_location("logging", BASE / "logging.py")
+log_mod = importlib.util.module_from_spec(spec_log)
+sys.modules["logging"] = log_mod
+spec_log.loader.exec_module(log_mod)
+
+ActionType = exec_mod.ActionType
+ExecutionSimulator = exec_mod.ExecutionSimulator
+LogWriter = log_mod.LogWriter
+LogConfig = log_mod.LogConfig
+
+
+def test_logging_extended_columns(tmp_path):
+    trades_path = tmp_path / "trades.csv"
+    reports_path = tmp_path / "reports.csv"
+    sim = ExecutionSimulator()
+    sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=1.0)
+    class Proto:
+        def __init__(self):
+            self.action_type = ActionType.MARKET
+            self.volume_frac = 1.0
+            self.ttl_steps = 5
+            self.tif = "IOC"
+    proto = Proto()
+    sim.submit(proto)
+    rep = sim.pop_ready(ref_price=100.5)
+    log = LogWriter(LogConfig(trades_path=str(trades_path), reports_path=str(reports_path), flush_every=1))
+    log.append(rep, symbol="BTCUSDT", ts_ms=0)
+    log.flush()
+    df = pd.read_csv(trades_path)
+    for col in ["slippage_bps", "spread_bps", "latency_ms", "tif", "ttl_steps"]:
+        assert col in df.columns
+    row = df.iloc[0]
+    assert row["tif"] == "IOC"
+    assert row["ttl_steps"] == 5


### PR DESCRIPTION
## Summary
- Track slippage, spread, latency, TIF and TTL in TradeLogRow and log writer
- Capture extended trade metadata within execution simulator reports
- Test that CSV logs contain the new columns

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c13f111b20832f9b1ef3d146f62f97