### PR TITLE
Enhance simulation reality check with bucketed slippage stats

### DIFF
--- a/scripts/sim_reality_check.py
+++ b/scripts/sim_reality_check.py
@@ -2,6 +2,8 @@ import argparse
 import json
 from pathlib import Path
 
+import pandas as pd
+
 from services.metrics import (
     read_any,
     calculate_metrics,
@@ -10,12 +12,55 @@ from services.metrics import (
 )
 
 
+def _bucket_stats(df: pd.DataFrame, quantiles: int) -> pd.DataFrame:
+    """Return per-order-size bucket spread/slippage statistics."""
+    required = {"order_size", "spread_bps", "slippage_bps"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"missing required columns: {sorted(missing)}")
+
+    labels, bins = pd.qcut(
+        df["order_size"], quantiles, labels=False, retbins=True, duplicates="drop"
+    )
+    df = df.assign(_bucket=labels)
+    stats = (
+        df.groupby("_bucket")[{"spread_bps", "slippage_bps"}]
+        .agg(["mean", "median"])
+        .rename(
+            columns={
+                ("spread_bps", "mean"): "spread_bps_mean",
+                ("spread_bps", "median"): "spread_bps_median",
+                ("slippage_bps", "mean"): "slippage_bps_mean",
+                ("slippage_bps", "median"): "slippage_bps_median",
+            }
+        )
+    )
+    stats.columns = stats.columns.droplevel(0)
+    stats = stats.reset_index(drop=True)
+    mids = (bins[:-1] + bins[1:]) / 2
+    stats["order_size_mid"] = mids[: len(stats)]
+    return stats[
+        [
+            "order_size_mid",
+            "spread_bps_mean",
+            "spread_bps_median",
+            "slippage_bps_mean",
+            "slippage_bps_median",
+        ]
+    ]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Generate reality check report for simulated vs benchmark logs"
+        description="Generate reality check report for simulated vs benchmark logs",
     )
     parser.add_argument(
-        "--trades", required=True, help="Path to simulated trade log (CSV or Parquet)"
+        "--trades", required=True, help="Path to simulated trade log (CSV or Parquet)",
+    )
+    parser.add_argument(
+        "--historical-trades",
+        required=True,
+        help="Path to historical trade log (CSV or Parquet)",
     )
     parser.add_argument(
         "--equity",
@@ -27,10 +72,17 @@ def main() -> None:
         required=True,
         help="Path to benchmark equity log (CSV or Parquet)",
     )
+    parser.add_argument(
+        "--quantiles",
+        type=int,
+        default=10,
+        help="Number of order size quantiles for bucket stats",
+    )
     args = parser.parse_args()
 
     trades_path = Path(args.trades)
     trades_df = read_any(trades_path.as_posix())
+    hist_trades_df = read_any(args.historical_trades)
 
     equity_df = read_any(args.equity) if args.equity else equity_from_trades(trades_df)
     benchmark_df = read_any(args.benchmark)
@@ -38,11 +90,44 @@ def main() -> None:
     sim_metrics = calculate_metrics(trades_df, equity_df)
     benchmark_metrics = compute_equity_metrics(benchmark_df).to_dict()
 
-    summary = {"simulation": sim_metrics, "benchmark": benchmark_metrics}
+    sim_buckets = _bucket_stats(trades_df, args.quantiles)
+    sim_buckets.insert(0, "dataset", "simulation")
+    hist_buckets = _bucket_stats(hist_trades_df, args.quantiles)
+    hist_buckets.insert(0, "dataset", "historical")
+    bucket_df = pd.concat([sim_buckets, hist_buckets], ignore_index=True)
 
     out_dir = trades_path.parent
     out_base = out_dir / "sim_reality_check"
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    bucket_base = out_dir / "sim_reality_check_buckets"
+    bucket_csv = bucket_base.with_suffix(".csv")
+    bucket_json = bucket_base.with_suffix(".json")
+    bucket_png = bucket_base.with_suffix(".png")
+
+    bucket_df.to_csv(bucket_csv, index=False)
+    bucket_df.to_json(bucket_json, orient="records", indent=2)
+
+    try:
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+        for name, grp in bucket_df.groupby("dataset"):
+            axes[0].plot(grp["order_size_mid"], grp["spread_bps_mean"], label=name)
+            axes[1].plot(grp["order_size_mid"], grp["slippage_bps_mean"], label=name)
+        axes[0].set_xlabel("order size")
+        axes[0].set_ylabel("spread (bps)")
+        axes[1].set_xlabel("order size")
+        axes[1].set_ylabel("slippage (bps)")
+        for ax in axes:
+            ax.legend()
+        fig.tight_layout()
+        fig.savefig(bucket_png)
+        plt.close(fig)
+    except Exception:
+        pass
+
+    summary = {"simulation": sim_metrics, "benchmark": benchmark_metrics}
 
     json_path = out_base.with_suffix(".json")
     with open(json_path, "w") as f:
@@ -62,7 +147,9 @@ def main() -> None:
             f.write(f"- {k}: {v}\n")
 
     print(f"Saved reports to {json_path} and {md_path}")
+    print(f"Saved bucket stats to {bucket_csv} and {bucket_png}")
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- bucket orders by size to compute spread and slippage statistics
- compare simulated and historical trades across quantiles
- export bucketed data and optional plots for downstream analysis

## Testing
- `python -m scripts.sim_reality_check --help`
- `pytest` *(fails: ActionProto unexpected keyword 'abs_price')*


------
https://chatgpt.com/codex/tasks/task_e_68c140dd2328832f9f6197a53576ad07