### PR TITLE
Add cancellation reason tracking across simulation and analysis

### DIFF
--- a/logging.py
+++ b/logging.py
@@ -95,7 +95,9 @@ class LogWriter:
                     Decimal(str(row.get("price", 0.0))) * Decimal(str(row.get("quantity", 0.0)))
                 )
             self._trades_buf.append(row)
+        cancel_map = rep_dict.get("cancelled_reasons", {}) or {}
         for cid in rep_dict.get("cancelled_ids", []):
+            reason = cancel_map.get(cid) or cancel_map.get(str(cid)) or "OTHER"
             er_cancel = ExecReport(
                 ts=int(ts_ms),
                 run_id=self._run_id,
@@ -116,6 +118,7 @@ class LogWriter:
                     "mark_price": float(getattr(report, "mark_price", 0.0)),
                     "equity": float(getattr(report, "equity", 0.0)),
                     "drawdown": float(getattr(report, "drawdown", 0.0)) if getattr(report, "drawdown", None) is not None else None,
+                    "reason": str(reason),
                 },
             )
             row_cancel = TradeLogRow.from_exec(er_cancel).to_dict()

--- a/tests/test_execution_rules.py
+++ b/tests/test_execution_rules.py
@@ -90,6 +90,7 @@ def test_ttl_two_steps_sim():
     assert rep2.cancelled_ids == []
     rep3 = sim.pop_ready(ref_price=100.0)
     assert rep3.cancelled_ids == [oid]
+    assert rep3.cancelled_reasons == {oid: "TTL"}
 
 
 # --- C++ LOB tests (using stub) ---

--- a/tests/test_limit_order_ttl.py
+++ b/tests/test_limit_order_ttl.py
@@ -20,6 +20,7 @@ def test_limit_order_ttl_expires():
     assert report1.new_order_ids == [oid]
     report2 = sim.pop_ready(ref_price=100.0)
     assert report2.cancelled_ids == [oid]
+    assert report2.cancelled_reasons == {oid: "TTL"}
     assert report2.trades == []
 
 
@@ -35,6 +36,7 @@ def test_limit_order_ttl_survives():
     assert report3.cancelled_ids == []
     report4 = sim.pop_ready(ref_price=100.0)
     assert report4.cancelled_ids == [oid]
+    assert report4.cancelled_reasons == {oid: "TTL"}
 
 
 from fast_lob import CythonLOB
@@ -58,6 +60,7 @@ def test_limit_order_ioc_partial_cancel():
     report = sim.pop_ready(ref_price=100.0)
     assert [t.qty for t in report.trades] == [5.0]
     assert report.cancelled_ids == [oid]
+    assert report.cancelled_reasons == {oid: "IOC"}
     assert report.new_order_ids == []
 
 
@@ -69,4 +72,5 @@ def test_limit_order_fok_partial_cancel():
     report = sim.pop_ready(ref_price=100.0)
     assert report.trades == []
     assert report.cancelled_ids == [oid]
+    assert report.cancelled_reasons == {oid: "FOK"}
     assert report.new_order_ids == []


### PR DESCRIPTION
## Summary
- Track cancellation reasons (TTL, IOC, FOK, OTHER) in `SimStepReport` and simulation logic
- Persist cancellation reasons in trade logs via `LogWriter`
- Extend reality check script to compute cancellation reason statistics

## Testing
- `pytest tests/test_execution_rules.py tests/test_limit_order_ttl.py -q` *(fails: assertions on order handling)*
- `pip install gymnasium==0.29.1`

------
https://chatgpt.com/codex/tasks/task_e_68c14405b5a4832f9f31d920c145b741