### PR TITLE
Add KPI thresholds and realism checks to simulation reports

### DIFF
--- a/benchmarks/sim_kpi_thresholds.json
+++ b/benchmarks/sim_kpi_thresholds.json
@@ -1,0 +1,15 @@
+{
+  "equity": {
+    "sharpe": {"min": -1.0, "max": 5.0},
+    "max_drawdown": {"min": -0.5, "max": 0.0}
+  },
+  "trades": {
+    "win_rate": {"min": 0.0, "max": 1.0}
+  },
+  "latency_ms": {
+    "p95_ms": {"min": 0.0, "max": 1000.0}
+  },
+  "order_fill": {
+    "fraction_unfilled": {"min": 0.0, "max": 0.5}
+  }
+}


### PR DESCRIPTION
## Summary
- add `benchmarks/sim_kpi_thresholds.json` with KPI tolerance ranges
- enhance `scripts/sim_reality_check.py` to load KPI thresholds and flag unrealistic metrics
- include flag report in generated JSON/markdown outputs

## Testing
- `pytest -q` *(fails: TypeError: ActionProto.__init__() got an unexpected keyword argument 'abs_price')*

------
https://chatgpt.com/codex/tasks/task_e_68c145fae8cc832f99ad5b0a1c33da71