### PR TITLE
Run reality check after simulations

### DIFF
--- a/script_backtest.py
+++ b/script_backtest.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
 
 from core_config import load_config
 from service_backtest import from_config
@@ -15,11 +19,58 @@ def main() -> None:
         default="configs/config_sim.yaml",
         help="Путь к YAML-конфигу запуска",
     )
+    p.add_argument(
+        "--rc-historical-trades",
+        help="Путь к историческому логу сделок для проверки реалистичности",
+    )
+    p.add_argument(
+        "--rc-benchmark",
+        help="Путь к эталонной кривой капитала",
+    )
+    p.add_argument(
+        "--rc-thresholds",
+        default="benchmarks/sim_kpi_thresholds.json",
+        help="JSON с допустимыми диапазонами KPI",
+    )
     args = p.parse_args()
 
     cfg = load_config(args.config)
     reports = from_config(cfg, snapshot_config_path=args.config)
     print(f"Produced {len(reports)} reports")
+
+    if args.rc_historical_trades and args.rc_benchmark:
+        run_id = cfg.run_id or "sim"
+        logs_dir = Path(cfg.logs_dir)
+        trades_path = logs_dir / f"log_trades_{run_id}.csv"
+        equity_path = logs_dir / f"report_equity_{run_id}.csv"
+        cmd = [
+            sys.executable,
+            "scripts/sim_reality_check.py",
+            "--trades",
+            trades_path.as_posix(),
+            "--historical-trades",
+            args.rc_historical_trades,
+            "--benchmark",
+            args.rc_benchmark,
+            "--equity",
+            equity_path.as_posix(),
+            "--kpi-thresholds",
+            args.rc_thresholds,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.stdout:
+            print(proc.stdout)
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr)
+        rc_json = trades_path.parent / "sim_reality_check.json"
+        flags = {}
+        try:
+            with open(rc_json, "r", encoding="utf-8") as fh:
+                flags = json.load(fh).get("flags", {})
+        except Exception:
+            pass
+        if any(v == "нереалистично" for v in flags.values()):
+            raise SystemExit("Reality check flagged 'нереалистично' KPIs")
 
 
 if __name__ == "__main__":

--- a/script_eval.py
+++ b/script_eval.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
 
 from core_config import load_config
 from service_eval import from_config
@@ -23,6 +27,23 @@ def main() -> None:
         action="store_true",
         help="Оценить все профили из конфигурации",
     )
+    p.add_argument(
+        "--rc-historical-trades",
+        help="Путь к историческому логу сделок для проверки реалистичности",
+    )
+    p.add_argument(
+        "--rc-benchmark",
+        help="Путь к эталонной кривой капитала",
+    )
+    p.add_argument(
+        "--rc-equity",
+        help="Путь к логу капитальной кривой симуляции; если не задан, строится из сделок",
+    )
+    p.add_argument(
+        "--rc-thresholds",
+        default="benchmarks/sim_kpi_thresholds.json",
+        help="JSON с допустимыми диапазонами KPI",
+    )
     args = p.parse_args()
 
     cfg = load_config(args.config)
@@ -33,6 +54,38 @@ def main() -> None:
         all_profiles=args.all_profiles,
     )
     print(metrics)
+
+    if args.rc_historical_trades and args.rc_benchmark:
+        trades_path = Path(cfg.input.trades_path)
+        equity_path = Path(args.rc_equity) if args.rc_equity else getattr(cfg.input, "equity_path", None)
+        cmd = [
+            sys.executable,
+            "scripts/sim_reality_check.py",
+            "--trades",
+            trades_path.as_posix(),
+            "--historical-trades",
+            args.rc_historical_trades,
+            "--benchmark",
+            args.rc_benchmark,
+            "--kpi-thresholds",
+            args.rc_thresholds,
+        ]
+        if equity_path:
+            cmd.extend(["--equity", Path(equity_path).as_posix()])
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.stdout:
+            print(proc.stdout)
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr)
+        rc_json = trades_path.parent / "sim_reality_check.json"
+        flags = {}
+        try:
+            with open(rc_json, "r", encoding="utf-8") as fh:
+                flags = json.load(fh).get("flags", {})
+        except Exception:
+            pass
+        if any(v == "нереалистично" for v in flags.values()):
+            raise SystemExit("Reality check flagged 'нереалистично' KPIs")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- allow evaluation script to run sim_reality_check and fail when unrealistic KPIs are flagged
- add similar reality check step to backtest runner

## Testing
- `pytest` *(fails: ActionProto.__init__ got unexpected keyword argument 'abs_price')*


------
https://chatgpt.com/codex/tasks/task_e_68c14b943f64832f819859ae3696972e