### PR TITLE
Ensure timezone-aware datetimes are converted to UTC

### DIFF
--- a/impl_offline_data.py
+++ b/impl_offline_data.py
@@ -159,5 +159,7 @@ def to_ms(dt: Any) -> int:
     if isinstance(dt, datetime):
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
         return int(dt.timestamp() * 1000)
     raise TypeError(f"Unsupported datetime type: {type(dt)}")


### PR DESCRIPTION
## Summary
- Normalize tz-aware datetimes to UTC in `to_ms`
- Test CSV bar streaming with non-UTC datetime inputs

## Testing
- `pytest tests/test_offline_csv_bar_source.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1586761cc832f86f6df9b9cb08eba