### PR TITLE
Add tests for hourly aggregation and CSV bar validation

### DIFF
--- a/tests/test_agg_klines_validation.py
+++ b/tests/test_agg_klines_validation.py
@@ -55,3 +55,10 @@ def test_drop_partial():
     df = _mk([60_000, 120_000, 180_000, 240_000, 300_000, 360_000, 420_000])
     out = _agg(df, "3m", drop_partial=True)
     assert out["ts_ms"].tolist() == [180_000]
+
+
+def test_hourly_aggregation_alignment():
+    df = _mk(list(range(0, 2 * 3_600_000, 60_000)))
+    out = _agg(df, "1h")
+    assert out["ts_ms"].tolist() == [0, 3_600_000]
+    assert all(ts % 3_600_000 == 0 for ts in out["ts_ms"])


### PR DESCRIPTION
## Summary
- verify `_agg` aggregates 1m bars to 1h buckets with aligned timestamps
- ensure `OfflineCSVBarSource` flags duplicate or missing hourly bars

## Testing
- `pytest tests/test_agg_klines_validation.py::test_hourly_aggregation_alignment tests/test_offline_csv_bar_source.py::test_duplicate_hour_bar_raises tests/test_offline_csv_bar_source.py::test_missing_hour_bar_raises -q`

------
https://chatgpt.com/codex/tasks/task_e_68c15a783cec832f83d196a62812f492