### PR TITLE
Enable VWAP_CURRENT_H1 profile without VWAP algo config

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -447,6 +447,9 @@ class ExecutionSimulator:
         if profile == "MKT_OPEN_NEXT_H1" and MarketOpenH1Executor is not None:
             self._executor = MarketOpenH1Executor()
             return
+        if profile == "VWAP_CURRENT_H1" and VWAPExecutor is not None:
+            self._executor = VWAPExecutor()
+            return
         cfg = dict(self._execution_cfg or {})
         algo = str(cfg.get("algo", "TAKER")).upper()
         if algo == "TWAP":

--- a/tests/test_execution_profiles.py
+++ b/tests/test_execution_profiles.py
@@ -116,11 +116,8 @@ def test_mkt_open_next_h1_profile(base_sim):
 
 
 def test_vwap_current_h1_profile(base_sim):
-    sim = ExecutionSimulator(execution_config={"algo": "VWAP"}, execution_profile="VWAP_CURRENT_H1")
-    sim.set_symbol("BTCUSDT")
-    sim.set_quantizer(DummyQuantizer())
-    sim.fees = DummyFees()
-    sim.risk = DummyRisk()
+    sim = base_sim
+    sim.set_execution_profile("VWAP_CURRENT_H1")
     proto = ActionProto(action_type=ActionType.MARKET, volume_frac=2.0)
     rep = sim.run_step(
         ts=1_800_000,
@@ -165,7 +162,7 @@ def test_limit_mid_bps_profile(base_sim):
 
 
 def test_executor_switching():
-    sim = ExecutionSimulator(execution_config={"algo": "VWAP"}, execution_profile="VWAP_CURRENT_H1")
+    sim = ExecutionSimulator(execution_profile="VWAP_CURRENT_H1")
     assert isinstance(sim._executor, VWAPExecutor)
     sim.set_execution_profile("MKT_OPEN_NEXT_H1")
     assert isinstance(sim._executor, MarketOpenH1Executor)


### PR DESCRIPTION
## Summary
- Support `VWAP_CURRENT_H1` execution profile by selecting `VWAPExecutor`
- Remove need for `"algo": "VWAP"` in execution_config
- Adjust execution profile tests accordingly

## Testing
- `pytest tests/test_execution_profiles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15e7b7d74832f98d8f25b0eca51de