### PR TITLE
feat: add limit mid-bps execution params

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -5,9 +5,9 @@ artifacts_dir: artifacts
 execution_profile: MKT_OPEN_NEXT_H1
 execution_params:
   slippage_bps: 0.0
-  limit_offset_bps: 0.0
-  ttl_steps: 0
-  tif: GTC
+  limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
+  ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
+  tif: GTC               # e.g. IOC or FOK
 input:
   trades_path: "data/trades.csv"
 components:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -5,9 +5,9 @@ artifacts_dir: artifacts
 execution_profile: MKT_OPEN_NEXT_H1
 execution_params:
   slippage_bps: 0.0
-  limit_offset_bps: 0.0
-  ttl_steps: 0
-  tif: GTC
+  limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
+  ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
+  tif: GTC               # e.g. IOC or FOK
 
 market: spot
 spot_symbols: ["BTCUSDT"]

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -6,9 +6,9 @@ artifacts_dir: artifacts
 execution_profile: MKT_OPEN_NEXT_H1
 execution_params:
   slippage_bps: 0.0
-  limit_offset_bps: 0.0
-  ttl_steps: 0
-  tif: GTC
+  limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
+  ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
+  tif: GTC               # e.g. IOC or FOK
 
 market: spot  # or futures
 spot_symbols: &spot_symbols ["BTCUSDT"]

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -5,9 +5,9 @@ artifacts_dir: artifacts
 execution_profile: MKT_OPEN_NEXT_H1
 execution_params:
   slippage_bps: 0.0
-  limit_offset_bps: 0.0
-  ttl_steps: 0
-  tif: GTC
+  limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
+  ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
+  tif: GTC               # e.g. IOC or FOK
 
 market: spot
 spot_symbols: ["BTCUSDT"]

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -383,8 +383,12 @@ class ExecutionSimulator:
 
     def set_execution_profile(self, profile: str, params: dict | None = None) -> None:
         """Установить профиль исполнения и параметры."""
-        self.execution_profile = str(profile)
+        self.execution_profile = str(profile).upper()
         self.execution_params = dict(params or {})
+        if self.execution_profile == "LIMIT_MID_BPS":
+            self.limit_offset_bps = float(self.execution_params.get("limit_offset_bps", 0.0))
+            self.ttl_steps = int(self.execution_params.get("ttl_steps", 0))
+            self.tif = str(self.execution_params.get("tif", "GTC")).upper()
         self._build_executor()
 
     def set_quantizer(self, q: Quantizer) -> None:

--- a/impl_sim_executor.py
+++ b/impl_sim_executor.py
@@ -179,8 +179,8 @@ class SimExecutor(TradeExecutor):
         if str(order.side).upper().endswith("SELL"):
             vol_frac = -vol_frac
 
-        tif = str(getattr(self._exec_params, "tif", "GTC"))
-        ttl_steps = int(getattr(self._exec_params, "ttl_steps", 0))
+        tif = str(self._exec_params.tif)
+        ttl_steps = int(self._exec_params.ttl_steps)
 
         profile = getattr(self, "_exec_profile", ExecutionProfile.MKT_OPEN_NEXT_H1)
 
@@ -198,7 +198,7 @@ class SimExecutor(TradeExecutor):
                     if bid is not None and ask is not None:
                         mid = (float(bid) + float(ask)) / 2.0
                 if mid is not None:
-                    off = float(getattr(self._exec_params, "limit_offset_bps", 0.0)) / 1e4
+                    off = float(self._exec_params.limit_offset_bps) / 1e4
                     if vol_frac > 0:
                         price = mid * (1 - off)
                     else:


### PR DESCRIPTION
## Summary
- propagate limit order parameters in simulator for LIMIT_MID_BPS profile
- read limit offset, TTL and TIF from ExecutionParams in SimExecutor
- document limit order parameters in example configs
- test limit mid bps params produce correct price and tif/ttl

## Testing
- `pytest tests/test_execution_profiles.py -q`
- `pytest -q` *(fail: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c161d6a11c832fb1added226ec611a