### PR TITLE
Add liquidity seasonality adjustments to ExecutionSimulator

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -8,6 +8,9 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+
+# Optional path to 168 hourly liquidity multipliers
+liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 input:
   trades_path: "data/trades.csv"
 components:

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -8,6 +8,8 @@ api:
 data:
   symbols: ["BTCUSDT"]
   timeframe: "1m"
+# Optional path to 168 hourly liquidity multipliers
+liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 components:
   market_data:
     target: impl_binance_public:BinancePublicBarSource

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -9,6 +9,9 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
+# Optional path to 168 hourly liquidity multipliers
+liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+
 market: spot
 spot_symbols: ["BTCUSDT"]
 futures_symbols: ["BTCUSDT"]

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -10,6 +10,9 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
+# Optional path to 168 hourly liquidity multipliers
+liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+
 market: spot  # or futures
 spot_symbols: &spot_symbols ["BTCUSDT"]
 futures_symbols: &futures_symbols ["BTCUSDT"]

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -9,6 +9,9 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
+# Optional path to 168 hourly liquidity multipliers
+liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+
 market: spot
 spot_symbols: ["BTCUSDT"]
 futures_symbols: ["BTCUSDT"]

--- a/core_config.py
+++ b/core_config.py
@@ -41,6 +41,7 @@ class CommonRunConfig(BaseModel):
     logs_dir: str = Field(default="logs")
     artifacts_dir: str = Field(default="artifacts")
     timezone: Optional[str] = None
+    liquidity_seasonality_path: Optional[str] = Field(default=None)
     components: Components
 
 

--- a/tests/test_liquidity_seasonality.py
+++ b/tests/test_liquidity_seasonality.py
@@ -1,0 +1,25 @@
+import importlib.util
+import pathlib
+import sys
+import datetime
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+
+spec_exec = importlib.util.spec_from_file_location("execution_sim", BASE / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec_exec)
+sys.modules["execution_sim"] = exec_mod
+spec_exec.loader.exec_module(exec_mod)
+
+ExecutionSimulator = exec_mod.ExecutionSimulator
+
+
+def test_liquidity_seasonality_multiplier():
+    multipliers = [1.0] * 168
+    hour_idx = 10
+    multipliers[hour_idx] = 2.0
+    sim = ExecutionSimulator(liquidity_seasonality=multipliers)
+    base_dt = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    ts_ms = int(base_dt.timestamp() * 1000 + hour_idx * 3_600_000)
+    sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=5.0, spread_bps=1.0, ts_ms=ts_ms)
+    assert sim._last_liquidity == 10.0
+    assert sim._last_spread_bps == 2.0


### PR DESCRIPTION
## Summary
- allow ExecutionSimulator to load optional 168-hour liquidity seasonality multipliers
- scale liquidity and spread by hourly multiplier when setting market snapshot
- surface `liquidity_seasonality_path` in run configs and add unit test

## Testing
- `pytest -q`
- `pytest tests/test_liquidity_seasonality.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c176b23644832fbdc0658946741ae5