### PR TITLE
Add seasonal latency multipliers and timestamp-aware sampling

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -745,7 +745,11 @@ class ExecutionSimulator:
         remaining = self.latency_steps
         if self.latency is not None:
             try:
-                d = self.latency.sample()
+                ts = int(now_ts) if now_ts is not None else 0
+                try:
+                    d = self.latency.sample(ts)
+                except TypeError:  # fallback for models without ts_ms
+                    d = self.latency.sample()  # type: ignore[call-arg]
                 lat_ms = int(d.get("total_ms", 0))
                 timeout = bool(d.get("timeout", False))
                 spike = bool(d.get("spike", False))
@@ -1475,7 +1479,10 @@ class ExecutionSimulator:
                     lat_ms = 0
                     lat_spike = False
                     if self.latency is not None:
-                        d = self.latency.sample()
+                        try:
+                            d = self.latency.sample(int(ts_fill))
+                        except TypeError:  # fallback for non-seasonal models
+                            d = self.latency.sample()  # type: ignore[call-arg]
                         lat_ms = int(d.get("total_ms", 0))
                         lat_spike = bool(d.get("spike", False))
                         if bool(d.get("timeout", False)):

--- a/tests/test_latency_seasonality.py
+++ b/tests/test_latency_seasonality.py
@@ -1,0 +1,57 @@
+import importlib.util
+import pathlib
+import sys
+import json
+import datetime
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+
+# Load latency module
+spec_lat = importlib.util.spec_from_file_location("latency", BASE / "latency.py")
+lat_module = importlib.util.module_from_spec(spec_lat)
+sys.modules["latency"] = lat_module
+spec_lat.loader.exec_module(lat_module)
+
+# Load impl_latency module
+spec_impl = importlib.util.spec_from_file_location("impl_latency", BASE / "impl_latency.py")
+impl_module = importlib.util.module_from_spec(spec_impl)
+sys.modules["impl_latency"] = impl_module
+spec_impl.loader.exec_module(impl_module)
+
+LatencyImpl = impl_module.LatencyImpl
+
+
+def test_latency_seasonality(tmp_path):
+    multipliers = [1.0] * 168
+    hour_high = 5
+    hour_low = 10
+    multipliers[hour_high] = 2.0
+    multipliers[hour_low] = 0.5
+    path = tmp_path / "latency.json"
+    path.write_text(json.dumps(multipliers))
+
+    cfg = {
+        "base_ms": 100,
+        "jitter_ms": 0,
+        "spike_p": 0.0,
+        "timeout_ms": 1000,
+        "seasonality_path": str(path),
+    }
+    impl = LatencyImpl.from_dict(cfg)
+
+    class Dummy:
+        pass
+
+    sim = Dummy()
+    impl.attach_to(sim)
+    lat = sim.latency
+
+    base_dt = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    ts_high = int(base_dt.timestamp() * 1000 + hour_high * 3_600_000)
+    ts_low = int(base_dt.timestamp() * 1000 + hour_low * 3_600_000)
+
+    d_high = lat.sample(ts_high)
+    d_low = lat.sample(ts_low)
+
+    assert d_high["total_ms"] == 200
+    assert d_low["total_ms"] == 50


### PR DESCRIPTION
## Summary
- allow latency configuration to load hour-of-week multipliers from JSON
- wrap latency model to scale timings by seasonal multiplier
- propagate timestamps to latency sampling calls
- add test confirming seasonality

## Testing
- `pytest tests/test_latency_seasonality.py::test_latency_seasonality -q`
- `pytest tests/test_execution_sim_maker_fee.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1787066dc832f9ced29c1af116851