### PR TITLE
Document seasonality multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ python train_model_multi_patch.py --config configs/config_train.yaml --slippage.
 `liquidity_latency_seasonality.json` содержит массивы `liquidity` и
 `latency` для 168 часов недели.
 
+Сезонные множители позволяют масштабировать базовые значения ликвидности и
+задержек для каждого часа недели (от понедельника 00:00 до воскресенья
+23:00 UTC). Формат файла и процесс пересчёта коэффициентов из исторических
+данных описаны в [docs/seasonality.md](docs/seasonality.md).
+
 Те же значения можно задать в YAML‑конфиге:
 
 ```yaml


### PR DESCRIPTION
## Summary
- add dedicated docs explaining hour-of-week multipliers, JSON layout, regeneration, and config usage
- reference seasonality docs from README

## Testing
- `pytest tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c181196eec832fb44666f38cf6882d