### PR TITLE
Add spread seasonality multipliers

### DIFF
--- a/docs/seasonality.md
+++ b/docs/seasonality.md
@@ -1,23 +1,24 @@
 # Hour-of-Week Seasonality
 
-Certain hours of the week exhibit systematic patterns in market depth and order-processing delays. To capture this behaviour, the simulator supports **hour-of-week multipliers** that scale baseline liquidity and latency parameters. Multipliers are indexed from `0` (Monday 00:00 UTC) to `167` (Sunday 23:00 UTC).
+Certain hours of the week exhibit systematic patterns in market depth, bid-ask spreads and order-processing delays. To capture this behaviour, the simulator supports **hour-of-week multipliers** that scale baseline liquidity, spread and latency parameters. Multipliers are indexed from `0` (Monday 00:00 UTC) to `167` (Sunday 23:00 UTC).
 
 ## `liquidity_latency_seasonality.json` format
 
-The JSON file contains up to two arrays with 168 floating-point numbers each:
+The JSON file contains up to three arrays with 168 floating-point numbers each:
 
 ```json
 {
   "liquidity": [1.0, 1.1, ...],
-  "latency":   [1.0, 0.9, ...]
+  "latency":   [1.0, 0.9, ...],
+  "spread":    [1.0, 0.8, ...]
 }
 ```
 
-`liquidity` multiplies available volume while `latency` scales simulated execution delays. Missing arrays or indices default to `1.0`.
+`liquidity` multiplies available volume, `latency` scales simulated execution delays while `spread` adjusts the baseline bid-ask spread (in bps). Missing arrays or indices default to `1.0`.
 
 ## Regenerating multipliers from historical data
 
-1. Prepare a CSV or Parquet file with columns such as `ts_ms`, `quantity` or `latency_ms`.
+1. Prepare a CSV or Parquet file with columns such as `ts_ms`, `quantity`, `latency_ms` or `spread_bps`.
 2. Run the helper script to compute averages for each hour of week and normalise them:
 
    ```bash

--- a/scripts/build_hourly_seasonality.py
+++ b/scripts/build_hourly_seasonality.py
@@ -1,3 +1,10 @@
+"""Utility helpers for deriving hour-of-week multipliers.
+
+The script scans a trade/latency log and computes relative multipliers for
+liquidity, latency and bid-ask spread.  The output JSON can then be consumed by
+the simulator to modulate these parameters during backtests.
+"""
+
 import argparse
 import json
 from pathlib import Path
@@ -23,7 +30,8 @@ def compute_multipliers(df: pd.DataFrame) -> dict[str, np.ndarray]:
     cols_map = {
         'liquidity': ['liquidity', 'order_size', 'qty', 'quantity'],
         'latency': ['latency_ms'],
-        'spread': ['spread_bps'],
+        # Some datasets may label spread either in absolute terms or in bps.
+        'spread': ['spread', 'spread_bps'],
     }
     for key, candidates in cols_map.items():
         col = next((c for c in candidates if c in df.columns), None)

--- a/scripts/validate_seasonality.py
+++ b/scripts/validate_seasonality.py
@@ -28,7 +28,7 @@ def _historical_multipliers(df: pd.DataFrame) -> Dict[str, np.ndarray]:
     metrics: Dict[str, np.ndarray] = {}
     cols_map = {
         "liquidity": ["liquidity", "order_size", "qty", "quantity"],
-        "spread_bps": ["spread_bps"],
+        "spread_bps": ["spread_bps", "spread"],
         "latency_ms": ["latency_ms"],
     }
     for key, candidates in cols_map.items():
@@ -47,7 +47,10 @@ def _historical_multipliers(df: pd.DataFrame) -> Dict[str, np.ndarray]:
 
 def _simulate(multipliers: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
     base_dt = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
-    sim = ExecutionSimulator(liquidity_seasonality=multipliers.get("liquidity"))
+    sim = ExecutionSimulator(
+        liquidity_seasonality=multipliers.get("liquidity"),
+        spread_seasonality=multipliers.get("spread"),
+    )
     sim_liq, sim_spread = [], []
     for hour in range(168):
         ts = int(base_dt.timestamp() * 1000 + hour * 3_600_000)

--- a/tests/test_liquidity_seasonality.py
+++ b/tests/test_liquidity_seasonality.py
@@ -13,13 +13,18 @@ spec_exec.loader.exec_module(exec_mod)
 ExecutionSimulator = exec_mod.ExecutionSimulator
 
 
-def test_liquidity_seasonality_multiplier():
-    multipliers = [1.0] * 168
+def test_liquidity_and_spread_seasonality_multiplier():
+    liq_mult = [1.0] * 168
+    spr_mult = [1.0] * 168
     hour_idx = 10
-    multipliers[hour_idx] = 2.0
-    sim = ExecutionSimulator(liquidity_seasonality=multipliers)
+    liq_mult[hour_idx] = 2.0
+    spr_mult[hour_idx] = 3.0
+    sim = ExecutionSimulator(
+        liquidity_seasonality=liq_mult,
+        spread_seasonality=spr_mult,
+    )
     base_dt = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
     ts_ms = int(base_dt.timestamp() * 1000 + hour_idx * 3_600_000)
     sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=5.0, spread_bps=1.0, ts_ms=ts_ms)
     assert sim._last_liquidity == 10.0
-    assert sim._last_spread_bps == 2.0
+    assert sim._last_spread_bps == 3.0


### PR DESCRIPTION
## Summary
- extend hourly seasonality script to derive spread multipliers
- scale spread with independent hour-of-week multipliers in execution simulator
- verify spread distribution against historical data in validation script and update docs

## Testing
- `pytest -q`
- `pytest tests/test_liquidity_seasonality.py::test_liquidity_and_spread_seasonality_multiplier -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1823fe2f8832f8a1de6f92af62b06