### PR TITLE
Add seasonality toggle for simulator and latency

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -11,6 +11,7 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+use_seasonality: true  # set false to ignore liquidity/spread multipliers
 
 market: spot
 spot_symbols: ["BTCUSDT"]
@@ -50,6 +51,8 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0
+  seasonality_path: "configs/liquidity_latency_seasonality.json"
+  use_seasonality: true
 
 risk:
   enabled: true

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -12,6 +12,7 @@ execution_params:
 
 # Optional path to 168 hourly liquidity and latency multipliers
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+use_seasonality: true  # set false to ignore liquidity/spread multipliers
 
 market: spot  # or futures
 spot_symbols: &spot_symbols ["BTCUSDT"]
@@ -52,6 +53,7 @@ latency:
   retries: 1
   seed: 0
   seasonality_path: "configs/liquidity_latency_seasonality.json"  # optional hourly latency multipliers
+  use_seasonality: true  # set false to ignore latency multipliers
 
 risk:
   enabled: true

--- a/docs/seasonality.md
+++ b/docs/seasonality.md
@@ -44,3 +44,19 @@ liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 latency:
   seasonality_path: "configs/liquidity_latency_seasonality.json"
 ```
+
+## Disabling seasonality
+
+Hourly multipliers are enabled by default. To ignore them, set the
+`use_seasonality` flag to `false` either globally or within the latency
+section of your config:
+
+```yaml
+use_seasonality: false          # disable liquidity and spread multipliers
+
+latency:
+  use_seasonality: false        # disable latency multipliers
+```
+
+The same flag can be passed as a constructor argument to
+`ExecutionSimulator` or `LatencyImpl`.

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -27,6 +27,7 @@ class LatencyCfg:
     retries: int = 1
     seed: int = 0
     seasonality_path: str | None = None
+    use_seasonality: bool = True
 
 
 class LatencyImpl:
@@ -43,8 +44,8 @@ class LatencyImpl:
         ) if LatencyModel is not None else None
         self.latency: List[float] = [1.0] * 168
         path = cfg.seasonality_path or "configs/liquidity_latency_seasonality.json"
-        self._has_seasonality = bool(path)
-        if path:
+        self._has_seasonality = bool(cfg.use_seasonality)
+        if self._has_seasonality and path:
             try:
                 with open(path, "r") as f:
                     data = json.load(f)
@@ -90,4 +91,5 @@ class LatencyImpl:
             retries=int(d.get("retries", 1)),
             seed=int(d.get("seed", 0)),
             seasonality_path=d.get("seasonality_path"),
+            use_seasonality=bool(d.get("use_seasonality", True)),
         ))

--- a/tests/test_liquidity_seasonality.py
+++ b/tests/test_liquidity_seasonality.py
@@ -28,3 +28,21 @@ def test_liquidity_and_spread_seasonality_multiplier():
     sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=5.0, spread_bps=1.0, ts_ms=ts_ms)
     assert sim._last_liquidity == 10.0
     assert sim._last_spread_bps == 3.0
+
+
+def test_seasonality_toggle_off():
+    liq_mult = [1.0] * 168
+    spr_mult = [1.0] * 168
+    hour_idx = 8
+    liq_mult[hour_idx] = 2.0
+    spr_mult[hour_idx] = 3.0
+    sim = ExecutionSimulator(
+        liquidity_seasonality=liq_mult,
+        spread_seasonality=spr_mult,
+        use_seasonality=False,
+    )
+    base_dt = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    ts_ms = int(base_dt.timestamp() * 1000 + hour_idx * 3_600_000)
+    sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=5.0, spread_bps=1.0, ts_ms=ts_ms)
+    assert sim._last_liquidity == 5.0
+    assert sim._last_spread_bps == 1.0


### PR DESCRIPTION
## Summary
- add `use_seasonality` flag to ExecutionSimulator and LatencyImpl
- document how to disable seasonality via config or constructor
- test toggling multipliers on/off

## Testing
- `pytest tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py`


------
https://chatgpt.com/codex/tasks/task_e_68c18a180530832f9c4cfa99dfc2fe05