### PR TITLE
Add seasonality edge and regression tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,4 +58,7 @@ extra-compile-args = ["-O3", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
  # Include NumPy headers for this module
  include-dirs = ["numpy.get_include()"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [DONE]


### PR DESCRIPTION
## Summary
- add edge-hour seasonality tests with week wrap-around validation
- add regression tests for latency seasonality statistics
- configure pytest to run tests automatically

## Testing
- `pytest tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c18b806a30832fa3369f2f83718a59