### PR TITLE
Add liquidity/latency seasonality metrics and dashboard

### DIFF
--- a/scripts/seasonality_dashboard.py
+++ b/scripts/seasonality_dashboard.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Visualize deviations from historical liquidity/latency distributions.
+
+The script aggregates simulator logs by hour of week and compares observed
+liquidity and latency values against historical multipliers. It then outputs a
+PNG chart for quick inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def _hour_of_week(ts_ms: int) -> int:
+    """Return hour-of-week index (0..167) for a timestamp in milliseconds."""
+    return (int(ts_ms) // 3_600_000 + 72) % 168
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seasonality deviation dashboard")
+    parser.add_argument("--log", required=True, help="Path to simulator log (csv or parquet)")
+    parser.add_argument(
+        "--multipliers", required=True, help="Path to liquidity_latency_seasonality.json"
+    )
+    parser.add_argument("--out", default="seasonality.png", help="Output PNG file")
+    args = parser.parse_args()
+
+    log_path = Path(args.log)
+    if log_path.suffix == ".parquet":
+        df = pd.read_parquet(log_path)
+    else:
+        df = pd.read_csv(log_path)
+    df["hour"] = df["ts_ms"].apply(_hour_of_week)
+    agg = df.groupby("hour").agg({"liquidity": "mean", "latency_ms": "mean"}).fillna(0)
+
+    with open(args.multipliers, "r", encoding="utf-8") as f:
+        hist = json.load(f)
+    liq_mult = hist.get("liquidity", [1.0] * 168)
+    lat_mult = hist.get("latency", [1.0] * 168)
+
+    fig, axes = plt.subplots(2, 1, figsize=(10, 6), sharex=True)
+
+    axes[0].plot(liq_mult, label="historical")
+    if "liquidity" in agg:
+        liq_ratio = agg["liquidity"] / max(agg["liquidity"].mean(), 1e-9)
+        axes[0].plot(liq_ratio.to_list(), label="run")
+    axes[0].set_ylabel("Liquidity multiplier")
+    axes[0].legend()
+
+    axes[1].plot(lat_mult, label="historical")
+    if "latency_ms" in agg:
+        lat_ratio = agg["latency_ms"] / max(agg["latency_ms"].mean(), 1e-9)
+        axes[1].plot(lat_ratio.to_list(), label="run")
+    axes[1].set_ylabel("Latency multiplier")
+    axes[1].set_xlabel("Hour of week")
+    axes[1].legend()
+
+    fig.tight_layout()
+    fig.savefig(args.out)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Track hourly liquidity multipliers and resulting values inside execution simulator
- Wrap latency model to collect hourly multipliers and latency stats
- Add analysis script to visualize liquidity/latency deviations from historical distributions

## Testing
- `pytest tests/test_latency_seasonality.py tests/test_logging_columns.py tests/test_execution_profile_logging_and_metrics.py -q`
- `pytest -q` *(fails: assert [] == [1] and other mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68c18c95d2a0832faabce92d14f4068e