### PR TITLE
feat: support per-hour seasonality overrides

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -11,6 +11,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional path to 168 hourly overrides multiplied with the above multipliers
+liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
 input:
   trades_path: "data/trades.csv"
@@ -24,6 +26,7 @@ latency:
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_override_path: null
   use_seasonality: true
 components:
   market_data:

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -10,6 +10,8 @@ data:
   timeframe: "1m"
 # Optional path to 168 hourly liquidity multipliers
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional path to 168 hourly overrides multiplied with the above multipliers
+liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
 latency:
   base_ms: 250
@@ -20,6 +22,7 @@ latency:
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_override_path: null
   use_seasonality: true
 components:
   market_data:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -11,6 +11,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional path to 168 hourly overrides multiplied with the above multipliers
+liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
 
 market: spot
@@ -52,6 +54,7 @@ latency:
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_override_path: null
   use_seasonality: true
 
 risk:

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -12,6 +12,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity and latency multipliers
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional path to 168 hourly overrides multiplied with the above multipliers
+liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
 
 market: spot  # or futures
@@ -53,6 +55,7 @@ latency:
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"  # optional hourly latency multipliers
+  seasonality_override_path: null  # optional hourly latency overrides
   use_seasonality: true  # set false to ignore latency multipliers
 
 risk:

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -11,6 +11,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional path to 168 hourly overrides multiplied with the above multipliers
+liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
 
 market: spot
@@ -52,6 +54,7 @@ latency:
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_override_path: null
   use_seasonality: true
 
 risk:

--- a/docs/seasonality.md
+++ b/docs/seasonality.md
@@ -45,6 +45,36 @@ latency:
   seasonality_path: "configs/liquidity_latency_seasonality.json"
 ```
 
+## Manual overrides
+
+In some cases you may want to tweak the computed multipliers. Both
+`ExecutionSimulator` and `LatencyImpl` accept **override arrays** of 168
+values that are multiplied element-wise with the base multipliers. The
+override file shares the same structure as
+`liquidity_latency_seasonality.json`:
+
+```json
+{
+  "liquidity": [1.0, 0.8, ...],
+  "latency":   [1.0, 1.2, ...],
+  "spread":    [1.0, 1.1, ...]
+}
+```
+
+Overrides can be supplied via constructor arguments
+(`liquidity_seasonality_override`, `spread_seasonality_override` or
+`seasonality_override`) or by specifying paths in config files
+(`liquidity_seasonality_override_path`, `latency.seasonality_override_path`).
+Precedence is as follows:
+
+1. Arrays passed directly to constructors.
+2. Arrays embedded in config objects.
+3. Arrays loaded from `*_override_path` files.
+4. Base multipliers from `liquidity_latency_seasonality.json`.
+5. Default multipliers of `1.0`.
+
+Missing entries default to `1.0`, so partial overrides are permitted.
+
 ## Disabling seasonality
 
 Hourly multipliers are enabled by default. To ignore them, set the


### PR DESCRIPTION
## Summary
- allow `ExecutionSimulator` and `LatencyImpl` to apply per-hour override arrays on top of seasonality multipliers
- document override format and precedence
- expose override path options in config templates and add tests for override behaviour

## Testing
- `pytest tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py`
- `pytest` *(fails: assert [] == [1], TypeError: Unsupported action type, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b820fed4832f93c33ba480dbbe13