### PR TITLE
Use UTC for hour-of-week calculations

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -9,7 +9,7 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
-# Optional path to 168 hourly liquidity multipliers
+# Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
@@ -25,7 +25,7 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
   use_seasonality: true
 components:

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -8,7 +8,7 @@ api:
 data:
   symbols: ["BTCUSDT"]
   timeframe: "1m"
-# Optional path to 168 hourly liquidity multipliers
+# Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
@@ -21,7 +21,7 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
   use_seasonality: true
 components:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -9,7 +9,7 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
-# Optional path to 168 hourly liquidity multipliers
+# Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
@@ -53,7 +53,7 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
   use_seasonality: true
 

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -10,7 +10,7 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
-# Optional path to 168 hourly liquidity and latency multipliers
+# Optional path to 168 hourly liquidity and latency multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
@@ -54,7 +54,7 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"  # optional hourly latency multipliers
+  seasonality_path: "configs/liquidity_latency_seasonality.json"  # optional hourly latency multipliers (UTC hour-of-week)
   seasonality_override_path: null  # optional hourly latency overrides
   use_seasonality: true  # set false to ignore latency multipliers
 

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -9,7 +9,7 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
-# Optional path to 168 hourly liquidity multipliers
+# Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
@@ -53,7 +53,7 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"
+  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
   use_seasonality: true
 

--- a/docs/seasonality.md
+++ b/docs/seasonality.md
@@ -1,6 +1,6 @@
 # Hour-of-Week Seasonality
 
-Certain hours of the week exhibit systematic patterns in market depth, bid-ask spreads and order-processing delays. To capture this behaviour, the simulator supports **hour-of-week multipliers** that scale baseline liquidity, spread and latency parameters. Multipliers are indexed from `0` (Monday 00:00 UTC) to `167` (Sunday 23:00 UTC).
+Certain hours of the week exhibit systematic patterns in market depth, bid-ask spreads and order-processing delays. To capture this behaviour, the simulator supports **hour-of-week multipliers** that scale baseline liquidity, spread and latency parameters. Multipliers are indexed from `0` (Monday 00:00 UTC) to `167` (Sunday 23:00 UTC). All hour-of-week calculations use `datetime.utcfromtimestamp`, so timestamps must be interpreted as UTC.
 
 ## `liquidity_latency_seasonality.json` format
 

--- a/scripts/seasonality_dashboard.py
+++ b/scripts/seasonality_dashboard.py
@@ -14,11 +14,13 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
+from datetime import datetime
 
 
 def _hour_of_week(ts_ms: int) -> int:
     """Return hour-of-week index (0..167) for a timestamp in milliseconds."""
-    return (int(ts_ms) // 3_600_000 + 72) % 168
+    dt = datetime.utcfromtimestamp(int(ts_ms) / 1000)
+    return dt.weekday() * 24 + dt.hour
 
 
 def main() -> None:

--- a/tests/test_hour_of_week.py
+++ b/tests/test_hour_of_week.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timezone, timedelta
+import numpy as np
+import importlib.util
+import pathlib
+import sys
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("utils_time", BASE / "utils_time.py")
+mod = importlib.util.module_from_spec(spec)
+sys.modules["utils_time"] = mod
+spec.loader.exec_module(mod)
+
+hour_of_week = mod.hour_of_week
+
+
+def test_hour_of_week_known_timestamps():
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts0 = int(base.timestamp() * 1000)
+    ts1 = int((base + timedelta(hours=37)).timestamp() * 1000)  # Tuesday 13:00
+    ts_last = int((base + timedelta(days=6, hours=23)).timestamp() * 1000)  # Sunday 23:00
+
+    assert hour_of_week(ts0) == 0
+    assert hour_of_week(ts1) == 37
+    assert hour_of_week(ts_last) == 167
+
+    arr = np.array([ts0, ts1, ts_last])
+    np.testing.assert_array_equal(hour_of_week(arr), np.array([0, 37, 167]))


### PR DESCRIPTION
## Summary
- Ensure hour-of-week calculations use `datetime.utcfromtimestamp`
- Document UTC assumption in configs and seasonality docs
- Add tests covering expected hour-of-week mapping for known UTC timestamps

## Testing
- `pytest` *(fails: 4 errors during collection)*
- `pytest tests/test_hour_of_week.py tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1bb2094fc832f88445c8278493015