### PR TITLE
feat: add seasonality hash logging and verification

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -11,6 +11,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional SHA256 hash of the above multipliers for integrity checking
+liquidity_seasonality_hash: null
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
@@ -27,6 +29,7 @@ latency:
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
+  seasonality_hash: null
   use_seasonality: true
 components:
   market_data:

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -10,6 +10,8 @@ data:
   timeframe: "1m"
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional SHA256 hash of the above multipliers for integrity checking
+liquidity_seasonality_hash: null
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
@@ -23,6 +25,7 @@ latency:
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
+  seasonality_hash: null
   use_seasonality: true
 components:
   market_data:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -11,6 +11,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional SHA256 hash of the above multipliers for integrity checking
+liquidity_seasonality_hash: null
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
@@ -55,6 +57,7 @@ latency:
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
+  seasonality_hash: null
   use_seasonality: true
 
 risk:

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -12,6 +12,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity and latency multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional SHA256 hash of the above multipliers for integrity checking
+liquidity_seasonality_hash: null
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
@@ -56,6 +58,7 @@ latency:
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"  # optional hourly latency multipliers (UTC hour-of-week)
   seasonality_override_path: null  # optional hourly latency overrides
+  seasonality_hash: null
   use_seasonality: true  # set false to ignore latency multipliers
 
 risk:

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -11,6 +11,8 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Optional SHA256 hash of the above multipliers for integrity checking
+liquidity_seasonality_hash: null
 # Optional path to 168 hourly overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
 use_seasonality: true  # set false to ignore liquidity/spread multipliers
@@ -55,6 +57,7 @@ latency:
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
   seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
   seasonality_override_path: null
+  seasonality_hash: null
   use_seasonality: true
 
 risk:

--- a/core_config.py
+++ b/core_config.py
@@ -42,6 +42,7 @@ class CommonRunConfig(BaseModel):
     artifacts_dir: str = Field(default="artifacts")
     timezone: Optional[str] = None
     liquidity_seasonality_path: Optional[str] = Field(default=None)
+    liquidity_seasonality_hash: Optional[str] = Field(default=None)
     components: Components
 
 

--- a/docs/seasonality.md
+++ b/docs/seasonality.md
@@ -148,6 +148,17 @@ Example crontab entry (UTC):
 ```
 
 
+## Operational checklist
+
+When deploying new multipliers:
+
+1. Compute and record the SHA256 hash of `liquidity_latency_seasonality.json`.
+2. Store the hash in configuration fields such as `liquidity_seasonality_hash`
+   and `latency.seasonality_hash`.
+3. At runtime, the loader logs the hash and warns if it differs from the
+   expected value.
+
+
 ## Performance
 
 Microbenchmarks repeatedly invoking `ExecutionSimulator.set_market_snapshot`

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -338,6 +338,7 @@ class ExecutionSimulator:
                  liquidity_seasonality: Optional[Sequence[float]] = None,
                  spread_seasonality: Optional[Sequence[float]] = None,
                  liquidity_seasonality_path: Optional[str] = None,
+                 liquidity_seasonality_hash: Optional[str] = None,
                  liquidity_seasonality_override: Optional[Sequence[float]] = None,
                  spread_seasonality_override: Optional[Sequence[float]] = None,
                  seasonality_override_path: Optional[str] = None,
@@ -454,14 +455,22 @@ class ExecutionSimulator:
             liq_arr: Optional[Sequence[float]] = liquidity_seasonality
             spread_arr: Optional[Sequence[float]] = spread_seasonality
             path = liquidity_seasonality_path
-            if path is None and run_config is not None:
-                path = getattr(run_config, "liquidity_seasonality_path", None)
+            expected_hash = liquidity_seasonality_hash
+            if run_config is not None:
+                if path is None:
+                    path = getattr(run_config, "liquidity_seasonality_path", None)
+                if expected_hash is None:
+                    expected_hash = getattr(run_config, "liquidity_seasonality_hash", None)
             if path is None:
                 path = "configs/liquidity_seasonality.json"
             if path and (liq_arr is None or spread_arr is None):
                 if os.path.exists(path):
-                    file_liq = load_hourly_seasonality(path, "liquidity", "multipliers")
-                    file_spread = load_hourly_seasonality(path, "spread", "latency")
+                    file_liq = load_hourly_seasonality(
+                        path, "liquidity", "multipliers", expected_hash=expected_hash
+                    )
+                    file_spread = load_hourly_seasonality(
+                        path, "spread", "latency", expected_hash=expected_hash
+                    )
                     if liq_arr is None:
                         liq_arr = file_liq
                     if spread_arr is None:


### PR DESCRIPTION
## Summary
- compute and log SHA256 hashes when loading seasonality multipliers
- allow optional expected hash in configs for runtime verification
- document operational checklist for maintaining multiplier integrity

## Testing
- `pytest` *(fails: assertion errors in several tests)*
- `pytest tests/test_liquidity_seasonality.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1c0d87edc832f9f49222ae108bb92