### PR TITLE
Add dataset metadata and log during simulator start

### DIFF
--- a/binance_filters.json
+++ b/binance_filters.json
@@ -1,40 +1,47 @@
 {
-  "BTCUSDT": {
-    "PRICE_FILTER": {
-      "minPrice": "0.01",
-      "maxPrice": "1000000",
-      "tickSize": "0.01"
-    },
-    "LOT_SIZE": {
-      "minQty": "0.00001",
-      "maxQty": "1000",
-      "stepSize": "0.00001"
-    },
-    "MIN_NOTIONAL": {
-      "minNotional": "10"
-    },
-    "PERCENT_PRICE_BY_SIDE": {
-      "multiplierUp": "1.2",
-      "multiplierDown": "0.8"
-    }
+  "metadata": {
+    "generated_at": "2024-01-01T00:00:00Z",
+    "source_dataset": "binance_exchange_filters",
+    "version": 1
   },
-  "ETHUSDT": {
-    "PRICE_FILTER": {
-      "minPrice": "0.01",
-      "maxPrice": "1000000",
-      "tickSize": "0.01"
+  "filters": {
+    "BTCUSDT": {
+      "PRICE_FILTER": {
+        "minPrice": "0.01",
+        "maxPrice": "1000000",
+        "tickSize": "0.01"
+      },
+      "LOT_SIZE": {
+        "minQty": "0.00001",
+        "maxQty": "1000",
+        "stepSize": "0.00001"
+      },
+      "MIN_NOTIONAL": {
+        "minNotional": "10"
+      },
+      "PERCENT_PRICE_BY_SIDE": {
+        "multiplierUp": "1.2",
+        "multiplierDown": "0.8"
+      }
     },
-    "LOT_SIZE": {
-      "minQty": "0.0001",
-      "maxQty": "100000",
-      "stepSize": "0.0001"
-    },
-    "MIN_NOTIONAL": {
-      "minNotional": "10"
-    },
-    "PERCENT_PRICE_BY_SIDE": {
-      "multiplierUp": "1.2",
-      "multiplierDown": "0.8"
+    "ETHUSDT": {
+      "PRICE_FILTER": {
+        "minPrice": "0.01",
+        "maxPrice": "1000000",
+        "tickSize": "0.01"
+      },
+      "LOT_SIZE": {
+        "minQty": "0.0001",
+        "maxQty": "100000",
+        "stepSize": "0.0001"
+      },
+      "MIN_NOTIONAL": {
+        "minNotional": "10"
+      },
+      "PERCENT_PRICE_BY_SIDE": {
+        "multiplierUp": "1.2",
+        "multiplierDown": "0.8"
+      }
     }
   }
 }

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -372,9 +372,11 @@ class ExecutionSimulator:
         self.strict_filters = bool(strict_filters)
         try:
             if Quantizer is not None and filters_path:
-                filters = load_filters(filters_path)
+                filters, meta = load_filters(filters_path)
                 if filters:
                     self.quantizer = Quantizer(filters, strict=strict_filters)
+                if meta:
+                    logger.info("Loaded filter metadata: %s", meta)
         except Exception:
             # не ломаемся, если файл отсутствует; квантизация просто не активна
             self.quantizer = None

--- a/fetch_binance_filters.py
+++ b/fetch_binance_filters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from datetime import datetime
 from typing import Dict, Any, List
 
 from binance_public import BinancePublicClient
@@ -21,9 +22,17 @@ def main():
     except Exception as e:
         print(f"ERROR: failed to fetch exchangeInfo: {e}", file=sys.stderr)
         sys.exit(1)
+
+    meta = {
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "source_dataset": "binance_exchange_filters",
+        "version": 1,
+    }
+    payload = {"metadata": meta, "filters": normalized}
+
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
     with open(out_path, "w", encoding="utf-8") as f:
-        json.dump(normalized, f, ensure_ascii=False, indent=2, sort_keys=True)
+        json.dump(payload, f, ensure_ascii=False, indent=2, sort_keys=True)
     print(f"Wrote {len(normalized)} symbols to {out_path}")
 
 

--- a/impl_quantizer.py
+++ b/impl_quantizer.py
@@ -27,7 +27,7 @@ class QuantizerImpl:
         self.cfg = cfg
         self._quantizer = None
         if Quantizer is not None and cfg.path:
-            filters = Quantizer.load_filters(cfg.path)
+            filters, _meta = Quantizer.load_filters(cfg.path)
             if filters:
                 self._quantizer = Quantizer(filters, strict=bool(cfg.strict))
 

--- a/mediator.py
+++ b/mediator.py
@@ -167,7 +167,7 @@ class Mediator:
         self.enforce_ppbs = bool(qcfg.get("enforce_percent_price_by_side", True))
         if Quantizer is not None and filters_path:
             try:
-                filters = load_filters(filters_path)
+                filters, _meta = load_filters(filters_path)
                 if filters:
                     self.quantizer = Quantizer(filters, strict=strict)
             except Exception:

--- a/sandbox/backtest_adapter.py
+++ b/sandbox/backtest_adapter.py
@@ -1,6 +1,7 @@
 # sandbox/backtest_adapter.py
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass, replace
 from typing import Any, Dict, List, Optional, Sequence
@@ -104,7 +105,9 @@ class BacktestAdapter:
         self._last_ref_by_symbol: Dict[str, float] = {}
 
         # спецификации биржи
-        self._specs = load_specs(exchange_specs_path or "")
+        self._specs, self._specs_meta = load_specs(exchange_specs_path or "")
+        if self._specs_meta:
+            logging.getLogger(__name__).info("Loaded exchange specs metadata: %s", self._specs_meta)
 
         # состояние гвардов
         self._hist_bars: Dict[str, int] = {}

--- a/service_fetch_exchange_specs.py
+++ b/service_fetch_exchange_specs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime
 from typing import Dict, Sequence
 
 import requests
@@ -61,9 +62,16 @@ def run(
             "minNotional": min_notional,
         }
 
+    meta = {
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "source_dataset": f"binance_exchangeInfo_{market}",
+        "version": 1,
+    }
+    payload = {"metadata": meta, "specs": by_symbol}
+
     _ensure_dir(out)
     with open(out, "w", encoding="utf-8") as f:
-        json.dump(by_symbol, f, ensure_ascii=False, indent=2)
+        json.dump(payload, f, ensure_ascii=False, indent=2)
     print(f"Saved {len(by_symbol)} symbols to {out}")
     return by_symbol
 


### PR DESCRIPTION
## Summary
- include `generated_at`, `source_dataset`, and `version` metadata in filter/spec JSON outputs
- load JSON metadata in quantizer/exchange spec helpers and log during simulator/backtest init

## Testing
- `pytest tests/test_mediator_quantization.py tests/test_execution_rules.py -q` *(fails: unquantized limit handling)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fb1b0aec832f8ad66107857d3569