### PR TITLE
Add reusable hour-of-week utility

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -29,11 +29,13 @@ import time
 import os
 import logging
 try:
-    from utils_time import HOUR_MS, HOURS_IN_WEEK, hour_of_week, load_hourly_seasonality
+    from utils.time import HOUR_MS, HOURS_IN_WEEK, hour_of_week
+    from utils_time import load_hourly_seasonality
 except Exception:  # pragma: no cover - fallback when running as standalone file
     import pathlib, sys
     sys.path.append(str(pathlib.Path(__file__).resolve().parent))
-    from utils_time import HOUR_MS, HOURS_IN_WEEK, hour_of_week, load_hourly_seasonality
+    from utils.time import HOUR_MS, HOURS_IN_WEEK, hour_of_week
+    from utils_time import load_hourly_seasonality
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_hour_of_week.py
+++ b/tests/test_hour_of_week.py
@@ -1,16 +1,10 @@
 from datetime import datetime, timezone, timedelta
 import numpy as np
-import importlib.util
-import pathlib
-import sys
+import pathlib, sys
 
 BASE = pathlib.Path(__file__).resolve().parents[1]
-spec = importlib.util.spec_from_file_location("utils_time", BASE / "utils_time.py")
-mod = importlib.util.module_from_spec(spec)
-sys.modules["utils_time"] = mod
-spec.loader.exec_module(mod)
-
-hour_of_week = mod.hour_of_week
+sys.path.insert(0, str(BASE))
+from utils.time import hour_of_week
 
 
 def test_hour_of_week_known_timestamps():
@@ -25,3 +19,14 @@ def test_hour_of_week_known_timestamps():
 
     arr = np.array([ts0, ts1, ts_last])
     np.testing.assert_array_equal(hour_of_week(arr), np.array([0, 37, 167]))
+
+
+def test_hour_of_week_week_boundary():
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts_last = int((base + timedelta(days=6, hours=23)).timestamp() * 1000)
+    ts_next = ts_last + 3_600_000
+
+    assert hour_of_week(ts_last) == 167
+    assert hour_of_week(ts_next) == 0
+    arr = np.array([ts_last, ts_next])
+    np.testing.assert_array_equal(hour_of_week(arr), np.array([167, 0]))

--- a/trading_patchnew.py
+++ b/trading_patchnew.py
@@ -32,11 +32,8 @@ from no_trade import (
 
 logger = logging.getLogger(__name__)
 from no_trade_config import get_no_trade_config
-from utils_time import (
-    hour_of_week as _hour_of_week,
-    load_hourly_seasonality,
-    HOURS_IN_WEEK,
-)
+from utils.time import hour_of_week as _hour_of_week, HOURS_IN_WEEK
+from utils_time import load_hourly_seasonality
 
 try:  # existing dynamic-spread config (pydantic model)
     from trainingtcost import DynSpreadCfg

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+from .time import hour_of_week, HOUR_MS, HOURS_IN_WEEK
+
+__all__ = ["hour_of_week", "HOUR_MS", "HOURS_IN_WEEK"]

--- a/utils/time.py
+++ b/utils/time.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+import numpy as np
+
+HOUR_MS = 3_600_000
+HOURS_IN_WEEK = 168
+_EPOCH_HOW = 72  # Hour-of-week for Unix epoch (Thursday 00:00 UTC)
+
+def hour_of_week(ts_ms: Union[int, Sequence[int], np.ndarray]) -> Union[int, np.ndarray]:
+    """Return hour-of-week (0-167) for UTC timestamps in milliseconds."""
+    arr = np.asarray(ts_ms, dtype=np.int64)
+
+    def _calc(ts: int) -> int:
+        return int((ts // HOUR_MS + _EPOCH_HOW) % HOURS_IN_WEEK)
+
+    if arr.shape == ():
+        return _calc(int(arr))
+
+    vec = np.vectorize(_calc, otypes=[int])
+    return vec(arr)


### PR DESCRIPTION
## Summary
- add `utils.time.hour_of_week` helper for integer hour-of-week calculation
- use the helper in latency model and update imports in execution and trading modules
- extend unit tests to check hour-of-week across week boundaries

## Testing
- `pytest tests/test_hour_of_week.py::test_hour_of_week_known_timestamps -q`
- `pytest tests/test_hour_of_week.py::test_hour_of_week_week_boundary -q`
- `pytest tests/test_latency_seasonality.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c29934bbd0832f9d87348c86f52e15