### PR TITLE
Add seasonality placeholders to config templates

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -11,11 +11,14 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
-# Optional SHA256 hash of the above multipliers for integrity checking
+# Optional SHA256 hash of the above liquidity multipliers for integrity checking
 liquidity_seasonality_hash: null
-# Optional path to 168 hourly overrides multiplied with the above multipliers
+# Optional path to 168 hourly liquidity overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
-use_seasonality: true  # set false to ignore liquidity/spread multipliers
+# Optional path to 168 hourly latency multipliers (indexed by UTC hour-of-week)
+latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Set false to ignore liquidity and latency multipliers
+use_seasonality: true
 input:
   trades_path: "data/trades.csv"
 
@@ -27,10 +30,6 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
-  seasonality_override_path: null
-  seasonality_hash: null
-  use_seasonality: true
 components:
   market_data:
     target: impl_offline_data:OfflineCSVBarSource

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -10,11 +10,14 @@ data:
   timeframe: "1m"
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
-# Optional SHA256 hash of the above multipliers for integrity checking
+# Optional SHA256 hash of the above liquidity multipliers for integrity checking
 liquidity_seasonality_hash: null
-# Optional path to 168 hourly overrides multiplied with the above multipliers
+# Optional path to 168 hourly liquidity overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
-use_seasonality: true  # set false to ignore liquidity/spread multipliers
+# Optional path to 168 hourly latency multipliers (indexed by UTC hour-of-week)
+latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Set false to ignore liquidity and latency multipliers
+use_seasonality: true
 latency:
   base_ms: 250
   jitter_ms: 50
@@ -23,10 +26,6 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
-  seasonality_override_path: null
-  seasonality_hash: null
-  use_seasonality: true
 components:
   market_data:
     target: impl_binance_public:BinancePublicBarSource

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -11,11 +11,14 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
-# Optional SHA256 hash of the above multipliers for integrity checking
+# Optional SHA256 hash of the above liquidity multipliers for integrity checking
 liquidity_seasonality_hash: null
-# Optional path to 168 hourly overrides multiplied with the above multipliers
+# Optional path to 168 hourly liquidity overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
-use_seasonality: true  # set false to ignore liquidity/spread multipliers
+# Optional path to 168 hourly latency multipliers (indexed by UTC hour-of-week)
+latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Set false to ignore liquidity and latency multipliers
+use_seasonality: true
 
 market: spot
 spot_symbols: ["BTCUSDT"]
@@ -55,10 +58,6 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
-  seasonality_override_path: null
-  seasonality_hash: null
-  use_seasonality: true
 
 risk:
   enabled: true

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -10,13 +10,16 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 
-# Optional path to 168 hourly liquidity and latency multipliers (indexed by UTC hour-of-week)
+# Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
-# Optional SHA256 hash of the above multipliers for integrity checking
+# Optional SHA256 hash of the above liquidity multipliers for integrity checking
 liquidity_seasonality_hash: null
-# Optional path to 168 hourly overrides multiplied with the above multipliers
+# Optional path to 168 hourly liquidity overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
-use_seasonality: true  # set false to ignore liquidity/spread multipliers
+# Optional path to 168 hourly latency multipliers (indexed by UTC hour-of-week)
+latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Set false to ignore liquidity and latency multipliers
+use_seasonality: true
 
 market: spot  # or futures
 spot_symbols: &spot_symbols ["BTCUSDT"]
@@ -56,10 +59,6 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"  # optional hourly latency multipliers (UTC hour-of-week)
-  seasonality_override_path: null  # optional hourly latency overrides
-  seasonality_hash: null
-  use_seasonality: true  # set false to ignore latency multipliers
 
 risk:
   enabled: true

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -11,11 +11,14 @@ execution_params:
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week)
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"
-# Optional SHA256 hash of the above multipliers for integrity checking
+# Optional SHA256 hash of the above liquidity multipliers for integrity checking
 liquidity_seasonality_hash: null
-# Optional path to 168 hourly overrides multiplied with the above multipliers
+# Optional path to 168 hourly liquidity overrides multiplied with the above multipliers
 liquidity_seasonality_override_path: null
-use_seasonality: true  # set false to ignore liquidity/spread multipliers
+# Optional path to 168 hourly latency multipliers (indexed by UTC hour-of-week)
+latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
+# Set false to ignore liquidity and latency multipliers
+use_seasonality: true
 
 market: spot
 spot_symbols: ["BTCUSDT"]
@@ -55,10 +58,6 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
-  seasonality_path: "configs/liquidity_latency_seasonality.json"  # UTC hour-of-week
-  seasonality_override_path: null
-  seasonality_hash: null
-  use_seasonality: true
 
 risk:
   enabled: true


### PR DESCRIPTION
## Summary
- expose liquidity and latency seasonality paths in config templates
- document global `use_seasonality` flag across configs

## Testing
- `pytest` *(fails: tests/test_execution_rules.py::test_unquantized_limit_rejected_sim, tests/test_execution_rules.py::test_ttl_two_steps_sim, tests/test_limit_mid_bps_profile.py::test_limit_mid_bps_profile, tests/test_limit_order_ttl.py::test_limit_order_ttl_expires, tests/test_limit_order_ttl.py::test_limit_order_ttl_survives, tests/test_limit_order_ttl.py::test_limit_order_ioc_partial_cancel, tests/test_limit_order_ttl.py::test_limit_order_fok_partial_cancel, tests/test_market_open_h1.py::test_market_open_next_h1_slippage, tests/test_market_open_h1.py::test_market_open_next_h1_snapshot_price, tests/test_no_trade_mask.py::test_funding_buffer_blocks_orders, tests/test_no_trade_mask.py::test_custom_window_blocks_orders)*

------
https://chatgpt.com/codex/tasks/task_e_68c29b4d74fc832f8aabe7fbe90276d3