### PR TITLE
Handle seasonality file errors gracefully

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -469,12 +469,19 @@ class ExecutionSimulator:
                 path = "configs/liquidity_seasonality.json"
             if path and (liq_arr is None or spread_arr is None):
                 if os.path.exists(path):
-                    file_liq = load_hourly_seasonality(
-                        path, "liquidity", "multipliers", expected_hash=expected_hash
-                    )
-                    file_spread = load_hourly_seasonality(
-                        path, "spread", "latency", expected_hash=expected_hash
-                    )
+                    try:
+                        file_liq = load_hourly_seasonality(
+                            path, "liquidity", "multipliers", expected_hash=expected_hash
+                        )
+                        file_spread = load_hourly_seasonality(
+                            path, "spread", "latency", expected_hash=expected_hash
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Error loading seasonality multipliers from %s; using defaults.",
+                            path,
+                        )
+                        file_liq = file_spread = None
                     if liq_arr is None:
                         liq_arr = file_liq
                     if spread_arr is None:
@@ -521,12 +528,18 @@ class ExecutionSimulator:
                     ) or getattr(run_config, "seasonality_override_path", None)
             if override_path and (liq_override is None or spread_override is None):
                 if os.path.exists(override_path):
-                    file_liq = load_hourly_seasonality(
-                        override_path, "liquidity", "multipliers"
-                    )
-                    file_spread = load_hourly_seasonality(
-                        override_path, "spread", "latency"
-                    )
+                    try:
+                        file_liq = load_hourly_seasonality(
+                            override_path, "liquidity", "multipliers"
+                        )
+                        file_spread = load_hourly_seasonality(
+                            override_path, "spread", "latency"
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Error loading seasonality override %s; ignoring.", override_path
+                        )
+                        file_liq = file_spread = None
                     if liq_override is None:
                         liq_override = file_liq
                     if spread_override is None:

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -135,9 +135,15 @@ class LatencyImpl:
         path = cfg.seasonality_path or "configs/liquidity_latency_seasonality.json"
         self._has_seasonality = bool(cfg.use_seasonality)
         if self._has_seasonality:
-            arr = load_hourly_seasonality(
-                path, "latency", expected_hash=cfg.seasonality_hash
-            )
+            try:
+                arr = load_hourly_seasonality(
+                    path, "latency", expected_hash=cfg.seasonality_hash
+                )
+            except Exception:
+                logger.warning(
+                    "Error loading latency seasonality config %s; using defaults.", path
+                )
+                arr = None
             if arr is not None:
                 self.latency = [float(x) for x in arr]
             else:
@@ -154,7 +160,13 @@ class LatencyImpl:
             override = cfg.seasonality_override
             o_path = cfg.seasonality_override_path
             if override is None and o_path:
-                override = load_hourly_seasonality(o_path, "latency")
+                try:
+                    override = load_hourly_seasonality(o_path, "latency")
+                except Exception:
+                    logger.warning(
+                        "Error loading latency override %s; ignoring.", o_path
+                    )
+                    override = None
                 if override is None:
                     logger.warning(
                         "Latency override %s not found or invalid; ignoring.", o_path

--- a/tests/test_latency_seasonality.py
+++ b/tests/test_latency_seasonality.py
@@ -90,6 +90,26 @@ def test_latency_seasonality_disabled(tmp_path):
     assert d_low["total_ms"] == 100
 
 
+def test_latency_missing_file(tmp_path):
+    cfg = {
+        "base_ms": 100,
+        "jitter_ms": 0,
+        "spike_p": 0.0,
+        "timeout_ms": 1000,
+        "seasonality_path": str(tmp_path / "missing.json"),
+    }
+    impl = LatencyImpl.from_dict(cfg)
+
+    class Dummy:
+        pass
+
+    sim = Dummy()
+    impl.attach_to(sim)
+    lat = sim.latency
+
+    assert lat.sample()["total_ms"] == 100
+
+
 def test_latency_seasonality_override(tmp_path):
     base_mult = [1.0] * 168
     hour_high = 5

--- a/tests/test_liquidity_seasonality.py
+++ b/tests/test_liquidity_seasonality.py
@@ -104,3 +104,13 @@ def test_seasonality_override_applied():
     sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=4.0, spread_bps=1.0, ts_ms=ts_ms)
     assert sim._last_liquidity == pytest.approx(4.0 * 2.0 * 0.75)
     assert sim._last_spread_bps == pytest.approx(1.0 * 3.0 * 0.5)
+
+
+def test_seasonality_file_missing(tmp_path):
+    missing = tmp_path / "missing.json"
+    sim = ExecutionSimulator(liquidity_seasonality_path=str(missing))
+    base_dt = datetime.datetime(2024, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+    ts_ms = int(base_dt.timestamp() * 1000 + 5 * 3_600_000)
+    sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=5.0, spread_bps=1.0, ts_ms=ts_ms)
+    assert sim._last_liquidity == 5.0
+    assert sim._last_spread_bps == 1.0


### PR DESCRIPTION
## Summary
- Safeguard execution simulator and latency implementation against seasonality file read/parse failures by falling back to all-ones multipliers with warning logs
- Add regression tests confirming simulator and latency model function without seasonality files

## Testing
- `pytest tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c29ced6490832f940e8ce8321ad359