### PR TITLE
Clarify hour-of-week indexing and align seasonality scripts

### DIFF
--- a/configs/liquidity_latency_seasonality.json
+++ b/configs/liquidity_latency_seasonality.json
@@ -338,5 +338,6 @@
     1.0,
     1.0,
     1.0
-  ]
+  ],
+  "hour_of_week_definition": "0=Monday 00:00 UTC"
 }

--- a/scripts/validate_seasonality.py
+++ b/scripts/validate_seasonality.py
@@ -1,3 +1,8 @@
+"""Validate hourly seasonality multipliers against historical data.
+
+The hour-of-week index used throughout assumes ``0 = Monday 00:00 UTC``.
+"""
+
 import argparse
 import json
 import datetime as dt
@@ -8,6 +13,7 @@ from typing import Dict, Tuple
 import numpy as np
 import pandas as pd
 
+from utils.time import hour_of_week
 from execution_sim import ExecutionSimulator
 from latency import LatencyModel, SeasonalLatencyModel
 
@@ -20,8 +26,9 @@ def _load_dataset(path: Path) -> pd.DataFrame:
     ts_col = "ts_ms" if "ts_ms" in df.columns else "ts"
     if ts_col not in df.columns:
         raise ValueError("ts or ts_ms column required")
-    ts = pd.to_datetime(df[ts_col], unit="ms", utc=True)
-    df = df.assign(hour_of_week=ts.dt.dayofweek * 24 + ts.dt.hour)
+    ts_ms = df[ts_col].to_numpy(dtype=np.int64)
+    # ``hour_of_week`` indexes 0=Monday 00:00 UTC
+    df = df.assign(hour_of_week=hour_of_week(ts_ms))
     return df
 
 

--- a/tests/test_hour_of_week.py
+++ b/tests/test_hour_of_week.py
@@ -2,31 +2,36 @@ from datetime import datetime, timezone, timedelta
 import numpy as np
 import pathlib, sys
 
+import pytest
+
 BASE = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(BASE))
 from utils.time import hour_of_week
+from utils_time import hour_of_week as hour_of_week_dt
 
 
-def test_hour_of_week_known_timestamps():
+@pytest.mark.parametrize("func", [hour_of_week, hour_of_week_dt])
+def test_hour_of_week_known_timestamps(func):
     base = datetime(2024, 1, 1, tzinfo=timezone.utc)
     ts0 = int(base.timestamp() * 1000)
     ts1 = int((base + timedelta(hours=37)).timestamp() * 1000)  # Tuesday 13:00
     ts_last = int((base + timedelta(days=6, hours=23)).timestamp() * 1000)  # Sunday 23:00
 
-    assert hour_of_week(ts0) == 0
-    assert hour_of_week(ts1) == 37
-    assert hour_of_week(ts_last) == 167
+    assert func(ts0) == 0
+    assert func(ts1) == 37
+    assert func(ts_last) == 167
 
     arr = np.array([ts0, ts1, ts_last])
-    np.testing.assert_array_equal(hour_of_week(arr), np.array([0, 37, 167]))
+    np.testing.assert_array_equal(func(arr), np.array([0, 37, 167]))
 
 
-def test_hour_of_week_week_boundary():
+@pytest.mark.parametrize("func", [hour_of_week, hour_of_week_dt])
+def test_hour_of_week_week_boundary(func):
     base = datetime(2024, 1, 1, tzinfo=timezone.utc)
     ts_last = int((base + timedelta(days=6, hours=23)).timestamp() * 1000)
     ts_next = ts_last + 3_600_000
 
-    assert hour_of_week(ts_last) == 167
-    assert hour_of_week(ts_next) == 0
+    assert func(ts_last) == 167
+    assert func(ts_next) == 0
     arr = np.array([ts_last, ts_next])
-    np.testing.assert_array_equal(hour_of_week(arr), np.array([167, 0]))
+    np.testing.assert_array_equal(func(arr), np.array([167, 0]))

--- a/utils/time.py
+++ b/utils/time.py
@@ -5,14 +5,23 @@ import numpy as np
 
 HOUR_MS = 3_600_000
 HOURS_IN_WEEK = 168
-_EPOCH_HOW = 72  # Hour-of-week for Unix epoch (Thursday 00:00 UTC)
+# 1970-01-01 00:00 UTC was a Thursday, which is hour 72 of the week
+_EPOCH_HOW = 72  # Hour-of-week for Unix epoch (0 = Monday 00:00 UTC)
 
 def hour_of_week(ts_ms: Union[int, Sequence[int], np.ndarray]) -> Union[int, np.ndarray]:
-    """Return hour-of-week (0-167) for UTC timestamps in milliseconds."""
+    """Return hour-of-week index where ``0`` is Monday 00:00 UTC.
+
+    Parameters
+    ----------
+    ts_ms:
+        UTC timestamp(s) in milliseconds.
+    """
     arr = np.asarray(ts_ms, dtype=np.int64)
 
     def _calc(ts: int) -> int:
-        return int((ts // HOUR_MS + _EPOCH_HOW) % HOURS_IN_WEEK)
+        idx = int((ts // HOUR_MS + _EPOCH_HOW) % HOURS_IN_WEEK)
+        assert 0 <= idx < HOURS_IN_WEEK
+        return idx
 
     if arr.shape == ():
         return _calc(int(arr))

--- a/utils_time.py
+++ b/utils_time.py
@@ -1,4 +1,8 @@
-# data/utils_time.py
+"""Assorted time utilities.
+
+The hour-of-week index assumes ``0 = Monday 00:00 UTC``.
+"""
+
 from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional, Sequence, Union
@@ -22,7 +26,7 @@ HOURS_IN_WEEK = 168
 
 
 def hour_of_week(ts_ms: Union[int, Sequence[int], np.ndarray]) -> Union[int, np.ndarray]:
-    """Return hour-of-week (0-167) for timestamps in milliseconds.
+    """Return hour-of-week index where ``0`` is Monday 00:00 UTC.
 
     The calculation uses :func:`datetime.utcfromtimestamp` to avoid any
     dependence on the local timezone.


### PR DESCRIPTION
## Summary
- document hour-of-week index as 0 = Monday 00:00 UTC and add range checks
- validate hour-of-week boundaries with new parameterized tests
- align seasonality scripts and JSON outputs with shared hour-of-week utility

## Testing
- `pytest tests/test_hour_of_week.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c29e9cf974832fb591edd93a1807bf