### PR TITLE
Warn when snapshot timestamps missing

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -624,11 +624,14 @@ class ExecutionSimulator:
         liq_mult = 1.0
         spread_mult = 1.0
         how: Optional[int] = None
-        if ts_ms is not None:
+        if ts_ms is None:
+            if self.use_seasonality:
+                logger.warning("ts_ms is None; seasonality multipliers not applied")
+        else:
             how = hour_of_week(int(ts_ms))
-        if self.use_seasonality and how is not None:
-            liq_mult = float(self._liq_seasonality[how])
-            spread_mult = float(self._spread_seasonality[how])
+            if self.use_seasonality:
+                liq_mult = float(self._liq_seasonality[how])
+                spread_mult = float(self._spread_seasonality[how])
 
         sbps: Optional[float]
         if spread_bps is not None:


### PR DESCRIPTION
## Summary
- warn and skip seasonality multipliers when set_market_snapshot is invoked without a timestamp
- add test ensuring warning and original values when ts_ms is None

## Testing
- `pytest -q` *(fails: tests/test_execution_rules.py::test_unquantized_limit_rejected_sim, tests/test_execution_rules.py::test_ttl_two_steps_sim, tests/test_limit_mid_bps_profile.py::test_limit_mid_bps_profile, tests/test_limit_order_ttl.py::test_limit_order_ttl_expires, tests/test_limit_order_ttl.py::test_limit_order_ttl_survives, tests/test_limit_order_ttl.py::test_limit_order_ioc_partial_cancel, tests/test_limit_order_ttl.py::test_limit_order_fok_partial_cancel, tests/test_market_open_h1.py::test_market_open_next_h1_slippage, tests/test_market_open_h1.py::test_market_open_next_h1_snapshot_price, tests/test_no_trade_mask.py::test_funding_buffer_blocks_orders, tests/test_no_trade_mask.py::test_custom_window_blocks_orders)*
- `pytest tests/test_liquidity_seasonality.py::test_ts_ms_none_skips_multipliers_and_logs_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2ab403058832f8b71f3ccfdc9678a