### PR TITLE
Add debug logging for seasonality multipliers

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -38,6 +38,7 @@ except Exception:  # pragma: no cover - fallback when running as standalone file
     from utils_time import load_hourly_seasonality
 
 logger = logging.getLogger(__name__)
+seasonality_logger = logger.getChild("seasonality")
 
 try:
     import numpy as np
@@ -645,6 +646,13 @@ class ExecutionSimulator:
         self._last_vol_factor = float(vol_factor) if vol_factor is not None else None
         liq_val = float(liquidity) if liquidity is not None else None
         self._last_liquidity = liq_val * liq_mult if liq_val is not None else None
+        if seasonality_logger.isEnabledFor(logging.DEBUG) and ts_ms is not None:
+            seasonality_logger.debug(
+                "snapshot h%03d mult=%.3f liquidity=%s",
+                how,
+                liq_mult,
+                self._last_liquidity,
+            )
         if how is not None and 0 <= how < HOURS_IN_WEEK:
             self._liq_mult_sum[how] += liq_mult
             if self._last_liquidity is not None:

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -35,6 +35,7 @@ except Exception:  # pragma: no cover - fallback
         load_hourly_seasonality = lambda *a, **k: None  # type: ignore
 
 logger = logging.getLogger(__name__)
+seasonality_logger = logger.getChild("seasonality")
 
 try:
     from latency import LatencyModel
@@ -101,6 +102,13 @@ class _LatencyWithSeasonality:
         self._mult_sum[hour] += m
         self._lat_sum[hour] += float(res.get("total_ms", 0))
         self._count[hour] += 1
+        if seasonality_logger.isEnabledFor(logging.DEBUG):
+            seasonality_logger.debug(
+                "latency sample h%03d mult=%.3f total_ms=%s",
+                hour,
+                m,
+                res.get("total_ms"),
+            )
         return res
 
     def stats(self):  # pragma: no cover - simple delegation


### PR DESCRIPTION
## Summary
- log hour-of-week multipliers and resulting liquidity in set_market_snapshot
- log hour-of-week multiplier and resulting latency for each sample
- use a dedicated seasonality logger so debug output can be filtered

## Testing
- `pytest -q` *(fails: 11 failed, 74 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ad89a5ec832f8d08cabe4b08eb08