### PR TITLE
Expose multiplier checkpointing for ExecutionSimulator and LatencyImpl

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -703,6 +703,41 @@ class ExecutionSimulator:
             except Exception:
                 result["latency"] = None
         return result
+
+    def dump_seasonality_multipliers(self) -> Dict[str, List[float]]:
+        """Return current liquidity and spread seasonality multipliers.
+
+        The result is a JSON-serializable mapping with two keys:
+        ``liquidity`` and ``spread``. Each contains a list of 168 floats
+        representing multipliers for each hour of week.
+        """
+
+        return {
+            "liquidity": self._liq_seasonality.tolist(),
+            "spread": self._spread_seasonality.tolist(),
+        }
+
+    def load_seasonality_multipliers(self, data: Dict[str, Sequence[float]]) -> None:
+        """Load liquidity and spread seasonality multipliers from ``data``.
+
+        ``data`` should be a mapping with optional ``liquidity`` and ``spread``
+        keys, each mapping to a sequence of 168 floats. Missing keys are
+        ignored. Raises ``ValueError`` if provided arrays have invalid length.
+        """
+
+        liq = data.get("liquidity")
+        if liq is not None:
+            arr = np.asarray(liq, dtype=float)
+            if arr.size != HOURS_IN_WEEK:
+                raise ValueError("liquidity multipliers must have length 168")
+            self._liq_seasonality = arr.copy()
+
+        spread = data.get("spread")
+        if spread is not None:
+            arr = np.asarray(spread, dtype=float)
+            if arr.size != HOURS_IN_WEEK:
+                raise ValueError("spread multipliers must have length 168")
+            self._spread_seasonality = arr.copy()
     def _build_executor(self) -> None:
         """
         Построить исполнителя согласно self._execution_cfg.

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -222,6 +222,26 @@ class LatencyImpl:
             return None
         return self._wrapper.hourly_stats()
 
+    def dump_multipliers(self) -> List[float]:
+        """Return current latency seasonality multipliers as a list."""
+
+        return list(self.latency)
+
+    def load_multipliers(self, arr: Sequence[float]) -> None:
+        """Load latency seasonality multipliers from ``arr``.
+
+        ``arr`` must contain 168 float values. Raises ``ValueError`` if the
+        length is incorrect. If the implementation is already attached to a
+        simulator, the underlying wrapper is updated as well.
+        """
+
+        arr_list = [float(x) for x in arr]
+        if len(arr_list) != 168:
+            raise ValueError("multipliers array must have length 168")
+        self.latency = arr_list
+        if self._wrapper is not None:
+            self._wrapper._mult = np.asarray(self.latency, dtype=float)
+
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "LatencyImpl":
         return LatencyImpl(LatencyCfg(

--- a/tests/test_multiplier_checkpoint.py
+++ b/tests/test_multiplier_checkpoint.py
@@ -1,0 +1,52 @@
+import json
+import pathlib
+import sys
+import importlib.util
+
+import numpy as np
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+if str(BASE) not in sys.path:
+    sys.path.append(str(BASE))
+
+# Load execution_sim module
+spec_exec = importlib.util.spec_from_file_location("execution_sim", BASE / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec_exec)
+sys.modules["execution_sim"] = exec_mod
+spec_exec.loader.exec_module(exec_mod)
+ExecutionSimulator = exec_mod.ExecutionSimulator
+
+# Load impl_latency module
+spec_lat = importlib.util.spec_from_file_location("impl_latency", BASE / "impl_latency.py")
+lat_mod = importlib.util.module_from_spec(spec_lat)
+sys.modules["impl_latency"] = lat_mod
+spec_lat.loader.exec_module(lat_mod)
+LatencyImpl = lat_mod.LatencyImpl
+
+
+def test_execution_simulator_round_trip():
+    liq = [1.0 + i * 0.001 for i in range(168)]
+    spread = [0.5 + i * 0.0005 for i in range(168)]
+    sim = ExecutionSimulator(liquidity_seasonality=liq, spread_seasonality=spread)
+    dump = sim.dump_seasonality_multipliers()
+    data = json.loads(json.dumps(dump))
+    sim2 = ExecutionSimulator()
+    sim2.load_seasonality_multipliers(data)
+    assert sim2.dump_seasonality_multipliers() == dump
+
+
+def test_latency_impl_round_trip():
+    cfg = {
+        "base_ms": 100,
+        "jitter_ms": 0,
+        "spike_p": 0.0,
+        "timeout_ms": 1000,
+    }
+    impl = LatencyImpl.from_dict(cfg)
+    mult = [1.0 + i * 0.01 for i in range(168)]
+    impl.load_multipliers(mult)
+    dump = impl.dump_multipliers()
+    data = json.loads(json.dumps(dump))
+    impl2 = LatencyImpl.from_dict(cfg)
+    impl2.load_multipliers(data)
+    assert np.allclose(impl2.dump_multipliers(), dump)


### PR DESCRIPTION
## Summary
- add APIs to dump and reload seasonality multipliers in ExecutionSimulator
- add latency multiplier dump/load helpers to LatencyImpl
- cover serialization round-trip with unit tests

## Testing
- `pytest tests/test_multiplier_checkpoint.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c2af5e19d8832f838977401565f2a1