### PR TITLE
refactor: centralize seasonality multipliers

### DIFF
--- a/docs/seasonality.md
+++ b/docs/seasonality.md
@@ -219,3 +219,19 @@ use_seasonality=True: 0.195s
 Lookup now avoids `time.gmtime` and uses precomputed NumPy arrays for the
 168 multipliers, reducing datetime conversions and keeping the cost of
 seasonality modest.
+
+## Helper functions
+
+``utils_time.py`` provides convenience helpers to fetch the appropriate
+hour-of-week multiplier for a given UTC timestamp. Modules can import
+``get_liquidity_multiplier`` or ``get_latency_multiplier`` instead of
+manually indexing arrays:
+
+```python
+from utils_time import get_liquidity_multiplier, get_latency_multiplier
+m_liq = get_liquidity_multiplier(ts_ms, liquidity_array)
+m_lat = get_latency_multiplier(ts_ms, latency_array)
+```
+
+These helpers ensure consistent hour-of-week calculations and will be
+reused across future modules.

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -30,12 +30,20 @@ import os
 import logging
 try:
     from utils.time import HOUR_MS, HOURS_IN_WEEK, hour_of_week
-    from utils_time import load_seasonality
+    from utils_time import (
+        load_seasonality,
+        get_hourly_multiplier,
+        get_liquidity_multiplier,
+    )
 except Exception:  # pragma: no cover - fallback when running as standalone file
     import pathlib, sys
     sys.path.append(str(pathlib.Path(__file__).resolve().parent))
     from utils.time import HOUR_MS, HOURS_IN_WEEK, hour_of_week
-    from utils_time import load_seasonality
+    from utils_time import (
+        load_seasonality,
+        get_hourly_multiplier,
+        get_liquidity_multiplier,
+    )
 
 logger = logging.getLogger(__name__)
 seasonality_logger = logger.getChild("seasonality")
@@ -599,8 +607,8 @@ class ExecutionSimulator:
         else:
             how = hour_of_week(int(ts_ms))
             if self.use_seasonality:
-                liq_mult = float(self._liq_seasonality[how])
-                spread_mult = float(self._spread_seasonality[how])
+                liq_mult = get_liquidity_multiplier(int(ts_ms), self._liq_seasonality)
+                spread_mult = get_hourly_multiplier(int(ts_ms), self._spread_seasonality)
 
         sbps: Optional[float]
         if spread_bps is not None:

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -25,12 +25,12 @@ logging = importlib.util.module_from_spec(_logging_spec)
 _logging_spec.loader.exec_module(logging)
 
 try:
-    from utils_time import load_seasonality
+    from utils_time import load_seasonality, get_latency_multiplier
 except Exception:  # pragma: no cover - fallback
     try:
         import pathlib, sys
         sys.path.append(str(pathlib.Path(__file__).resolve().parent))
-        from utils_time import load_seasonality
+        from utils_time import load_seasonality, get_latency_multiplier
     except Exception:  # pragma: no cover
         load_seasonality = lambda *a, **k: {}  # type: ignore
 
@@ -78,7 +78,7 @@ class _LatencyWithSeasonality:
         if ts_ms is None:
             return self._model.sample()
         hour = hour_of_week(int(ts_ms)) % len(self._mult)
-        m = float(self._mult[hour])
+        m = get_latency_multiplier(int(ts_ms), self._mult)
         base, jitter, timeout = (
             self._model.base_ms,
             self._model.jitter_ms,


### PR DESCRIPTION
## Summary
- share `get_hourly_multiplier` helpers in `utils_time`
- use seasonality helpers in `execution_sim` and latency implementation
- document helper functions for future modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b654d904832fb6d0f55d2b577d0d