### PR TITLE
Add data policy and PII checks

### DIFF
--- a/docs/seasonality_data_policy.md
+++ b/docs/seasonality_data_policy.md
@@ -1,0 +1,19 @@
+# Seasonality Data Policy
+
+This repository uses aggregated exchange data to compute seasonality multipliers.
+The following rules apply to any data stored under `data/seasonality_source`:
+
+## Data Handling
+- Only market data derived from public sources may be stored.
+- Files must never contain personal identifying information (PII).
+- Retain at least 12 months of history for auditability.
+- Each file requires a matching `.sha256` checksum.
+
+## Usage Limitations
+- Seasonality data is for internal analytics and model training only.
+- Redistribution outside the organization is prohibited.
+- When sharing derived metrics, ensure that no raw snapshots are exposed.
+- Run `scripts/check_pii.py` before committing new snapshots to verify that no
+  PII patterns exist.
+
+Adhering to this policy helps maintain compliance and data privacy.

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -1,0 +1,35 @@
+import argparse
+import re
+from pathlib import Path
+
+PATTERNS = [
+    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    re.compile(r"\b(?:\+?\d{1,3}[- ]?)?\d{3}[- ]?\d{3}[- ]?\d{4}\b"),
+]
+
+
+def scan_path(path: Path) -> None:
+    text = path.read_text(errors="ignore")
+    for pattern in PATTERNS:
+        if pattern.search(text):
+            raise SystemExit(f"Possible PII detected in {path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scan files for common PII patterns")
+    parser.add_argument("root", nargs="?", default="data/seasonality_source", help="Directory to scan")
+    args = parser.parse_args()
+
+    root = Path(args.root)
+    if not root.exists():
+        raise SystemExit(f"Path {root} does not exist")
+
+    for file in root.rglob("*"):
+        if file.is_file() and not file.name.endswith(".sha256"):
+            scan_path(file)
+    print("No PII patterns found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pii_detection.py
+++ b/tests/test_pii_detection.py
@@ -1,0 +1,42 @@
+import importlib.util
+import pathlib
+import pandas as pd
+import pytest
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("data_validation", BASE / "data_validation.py")
+dv_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dv_module)
+DataValidator = dv_module.DataValidator
+
+
+def _make_df(note):
+    idx = pd.date_range('2024-01-01', periods=1, freq='1T')
+    data = {
+        'timestamp': idx,
+        'symbol': ['BTCUSDT'],
+        'open': [1.0],
+        'high': [1.0],
+        'low': [1.0],
+        'close': [1.0],
+        'volume': [1.0],
+        'quote_asset_volume': [1.0],
+        'number_of_trades': [1],
+        'taker_buy_base_asset_volume': [1.0],
+        'taker_buy_quote_asset_volume': [1.0],
+        'note': [note],
+    }
+    return pd.DataFrame(data, index=idx)
+
+
+def test_rejects_email():
+    df = _make_df('user@example.com')
+    validator = DataValidator()
+    with pytest.raises(ValueError):
+        validator.validate(df)
+
+
+def test_accepts_clean_data():
+    df = _make_df('seasonal pattern')
+    validator = DataValidator()
+    validator.validate(df)


### PR DESCRIPTION
## Summary
- document seasonality data handling rules and usage limitations
- add automated PII scan script and validator hook
- provide tests for PII detection

## Testing
- `python scripts/check_pii.py`
- `pytest tests/test_pii_detection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b8d3cd04832f993aab34ab148ae6