### PR TITLE
Document UTC requirement for seasonality

### DIFF
--- a/docs/seasonality.md
+++ b/docs/seasonality.md
@@ -2,6 +2,8 @@
 
 Certain hours of the week exhibit systematic patterns in market depth, bid-ask spreads and order-processing delays. To capture this behaviour, the simulator supports **hour-of-week multipliers** that scale baseline liquidity, spread and latency parameters. Multipliers are indexed from `0` (Monday 00:00 UTC) to `167` (Sunday 23:00 UTC). All hour-of-week calculations use `datetime.utcfromtimestamp`, so timestamps must be interpreted as UTC.
 
+All timestamp inputs **must** be expressed in UTC to avoid daylight-saving time (DST) ambiguity. Feeding local-time data into multiplier computations will misalign hour-of-week indices, so always convert source data to UTC before generating or applying multipliers.
+
 ## `liquidity_latency_seasonality.json` format
 
 The JSON file contains up to three arrays with 168 floating-point numbers each.

--- a/docs/seasonality_QA.md
+++ b/docs/seasonality_QA.md
@@ -4,7 +4,7 @@ This guide describes how the QA team should validate hourly seasonality multipli
 
 ## Running the validation script
 
-1. Prepare a CSV or Parquet file with historical trades. The file must include a timestamp column (`ts_ms` or `ts`).
+1. Prepare a CSV or Parquet file with historical trades. The file must include a timestamp column (`ts_ms` or `ts`) expressed in UTC. Feeding local-time timestamps into the validator can misalign hour-of-week multipliers due to DST, so convert any source data to UTC first.
 2. Run the validation script with paths to the historical dataset and the multipliers JSON:
 
 ```bash

--- a/docs/seasonality_example.md
+++ b/docs/seasonality_example.md
@@ -3,6 +3,8 @@
 This example demonstrates how to derive hour-of-week multipliers,
 configure the simulator with them and validate the result.
 
+All timestamp data **must** be in UTC to avoid daylight-saving time ambiguity. Feeding local-time values into multiplier computations will misalign the hour-of-week indices, so convert any inputs to UTC before processing.
+
 ## Generate multipliers from sample data
 
 ```python


### PR DESCRIPTION
## Summary
- Clarify that hourly seasonality expects UTC timestamps
- Warn against feeding local-time data into multiplier calculations and QA inputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c2c3870648832fb2357d2c8fe5b045