### PR TITLE
feat: verify liquidity seasonality consistency

### DIFF
--- a/trading_patchnew.py
+++ b/trading_patchnew.py
@@ -202,6 +202,7 @@ class TradingEnv(gym.Env):
         decision_mode: DecisionTiming = DecisionTiming.CLOSE_TO_OPEN,
         decision_delay_ms: int = 0,
         liquidity_seasonality_path: str | None = None,
+        liquidity_seasonality_hash: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -238,7 +239,10 @@ class TradingEnv(gym.Env):
             "liquidity_seasonality_path", "configs/liquidity_seasonality.json"
         )
         self._liq_seasonality = load_hourly_seasonality(
-            liq_path, "liquidity", "multipliers"
+            liq_path,
+            "liquidity",
+            "multipliers",
+            expected_hash=liquidity_seasonality_hash,
         )
         if self._liq_seasonality is None:
             logger.warning(


### PR DESCRIPTION
## Summary
- compute and pass liquidity seasonality hash in training
- verify expected hash when loading seasonality in `TradingEnv`

## Testing
- `pytest` *(fails: tests/test_close_shift.py, tests/test_leak_guard_env.py, tests/test_no_trade_config_shared.py, tests/test_no_trade_mask.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c4b05bf4832fbf2786832b26c57f