### PR TITLE
Add authenticated seasonality API endpoints and documentation

### DIFF
--- a/docs/seasonality_api.md
+++ b/docs/seasonality_api.md
@@ -1,0 +1,50 @@
+# Seasonality API
+
+The project exposes simple HTTP endpoints for retrieving and rebuilding
+hour-of-week seasonality multipliers.  These endpoints are served by the
+`FastAPI` application defined in `app.py` and require an API key for
+access.
+
+## Authentication
+
+Requests must include an `X-API-Key` header whose value matches the
+`SEASONALITY_API_TOKEN` environment variable defined on the server.  A
+default placeholder of `changeme` is used if the variable is unset.
+Never expose the service without setting a strong token.
+
+```bash
+export SEASONALITY_API_TOKEN="supersecret"
+uvicorn app:api --reload
+```
+
+## Endpoints
+
+### `GET /seasonality`
+
+Return the contents of the seasonality JSON file.  The optional `path`
+query parameter specifies the file to read and defaults to
+`configs/liquidity_latency_seasonality.json`.
+
+```bash
+curl -H "X-API-Key: $SEASONALITY_API_TOKEN" \
+  http://localhost:8000/seasonality
+```
+
+### `POST /seasonality/refresh`
+
+Rebuild the seasonality JSON using the helper script
+`scripts/build_hourly_seasonality.py` and return the generated data.  Two
+query parameters are available:
+
+* `data` – path to the historical trade or latency dataset; defaults to
+  `data/seasonality_source/latest.parquet`.
+* `out` – output JSON path; defaults to
+  `configs/liquidity_latency_seasonality.json`.
+
+```bash
+curl -X POST -H "X-API-Key: $SEASONALITY_API_TOKEN" \
+  "http://localhost:8000/seasonality/refresh?data=logs.parquet"
+```
+
+Both endpoints respond with the parsed JSON data on success or an error
+message on failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ extra = [
     "investpy==1.0.8",
     "joblib>=1.3.0",
     "torch>=2.0.0 ; platform_system!='Windows'",
+    "fastapi>=0.110.0",
+    "uvicorn>=0.27.0",
 ]
 
 [tool.setuptools.extension-modules."core.core"]

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -5,3 +5,5 @@ requests>=2.31.0
 investpy==1.0.8
 joblib>=1.3.0
 torch>=2.0.0 ; platform_system!="Windows"  # если нужен PyTorch для .pt моделей
+fastapi>=0.110.0
+uvicorn>=0.27.0


### PR DESCRIPTION
## Summary
- expose FastAPI app with `/seasonality` and `/seasonality/refresh` endpoints
- secure seasonality endpoints using `X-API-Key` header
- document seasonality API usage and add FastAPI dependencies

## Testing
- `pytest tests/test_load_seasonality.py tests/test_liquidity_seasonality.py -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2c5dc1108832fa3ff20a0bfc4cd2e