### PR TITLE
feat: optional linear interpolation for seasonality multipliers

### DIFF
--- a/benchmarks/simulator_seasonality_bench.py
+++ b/benchmarks/simulator_seasonality_bench.py
@@ -11,11 +11,12 @@ if str(ROOT) not in sys.path:
 from execution_sim import ExecutionSimulator
 
 
-def _run(use_seasonality: bool, n: int = 100_000) -> float:
+def _run(use_seasonality: bool, interpolate: bool = False, n: int = 100_000) -> float:
     sim = ExecutionSimulator(
         liquidity_seasonality=[1.0] * 168,
         spread_seasonality=[1.0] * 168,
         use_seasonality=use_seasonality,
+        seasonality_interpolate=interpolate,
     )
     ts = np.arange(n, dtype=np.int64) * 60_000  # 1-minute steps
     start = time.perf_counter()
@@ -25,9 +26,16 @@ def _run(use_seasonality: bool, n: int = 100_000) -> float:
 
 
 def main() -> None:
-    for flag in (False, True):
-        dt = _run(flag)
-        print(f"use_seasonality={flag}: {dt:.3f}s")
+    cases = [
+        (False, False),
+        (True, False),
+        (True, True),
+    ]
+    for use_seasonality, interp in cases:
+        dt = _run(use_seasonality, interpolate=interp)
+        print(
+            f"use_seasonality={use_seasonality} interpolate={interp}: {dt:.3f}s"
+        )
 
 
 if __name__ == "__main__":

--- a/docs/seasonality_example.md
+++ b/docs/seasonality_example.md
@@ -45,6 +45,7 @@ from impl_latency import LatencyImpl
 sim = ExecutionSimulator(
     liquidity_seasonality=multipliers["liquidity"],
     spread_seasonality=multipliers["spread"],
+    seasonality_interpolate=True,  # enable minute-level interpolation
 )
 
 lat_cfg = {
@@ -52,6 +53,7 @@ lat_cfg = {
     "jitter_ms": 20,
     "seasonality_path": "configs/liquidity_latency_seasonality.json",
     "seasonality_override": multipliers["latency"],
+    "seasonality_interpolate": True,  # smooth latency multipliers
 }
 lat = LatencyImpl.from_dict(lat_cfg)
 lat.attach_to(sim)


### PR DESCRIPTION
## Summary
- add `seasonality_interpolate` flag and interpolate hourly multipliers based on minute offset
- wire interpolation through ExecutionSimulator and LatencyImpl
- document performance trade-offs and provide usage examples

## Testing
- `pytest tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2cfb18208832fad826c8952489668