### PR TITLE
Allow environment overrides for ingest paths

### DIFF
--- a/tests/test_ingest_config_env.py
+++ b/tests/test_ingest_config_env.py
@@ -1,0 +1,26 @@
+import logging  # ensure stdlib logging is loaded before path hacks
+import pathlib
+import sys
+
+
+BASE = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BASE))
+
+
+def test_paths_config_env_override(monkeypatch):
+    from ingest_config import load_config_from_str
+
+    yaml_cfg = """
+    symbols: ["BTCUSDT"]
+    period:
+      start: '2021-01-01'
+      end: '2021-01-02'
+    paths:
+      klines_dir: yaml_klines
+      prices_out: yaml_prices.parquet
+    """
+
+    monkeypatch.setenv("KLINES_DIR", "/tmp/klines")
+    cfg = load_config_from_str(yaml_cfg)
+    assert cfg.paths.klines_dir == "/tmp/klines"
+    assert cfg.paths.prices_out == "yaml_prices.parquet"


### PR DESCRIPTION
## Summary
- Allow ingest path defaults to be overridden by environment variables
- Test that environment variables override configured paths

## Testing
- `pytest tests/test_ingest_config_env.py -q`
- `pytest -q` *(fails: assert [] == [1] and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f2dc3370832fb3a5ec0b1d2cfdd2