### PR TITLE
Track hourly multiplier usage via Prometheus metrics

### DIFF
--- a/scripts/chart_hourly_multiplier_metrics.py
+++ b/scripts/chart_hourly_multiplier_metrics.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Plot hour-of-week multiplier metric coverage.
+
+Reads Prometheus metrics either from a local file or an HTTP endpoint and
+produces a simple chart visualising how often each hour-of-week multiplier
+was used in the simulator and latency model.
+"""
+from __future__ import annotations
+
+import argparse
+import urllib.request
+from typing import List
+
+import matplotlib.pyplot as plt
+from prometheus_client.parser import text_string_to_metric_families
+
+
+def _fetch(source: str) -> str:
+    if source.startswith("http://") or source.startswith("https://"):
+        with urllib.request.urlopen(source) as resp:  # nosec - optional usage
+            return resp.read().decode("utf-8")
+    with open(source, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _extract(metrics_text: str, name: str) -> List[float]:
+    values = [0.0] * 168
+    for fam in text_string_to_metric_families(metrics_text):
+        if fam.name != name:
+            continue
+        for sample in fam.samples:
+            try:
+                hour = int(sample.labels.get("hour", 0))
+                if 0 <= hour < len(values):
+                    values[hour] = float(sample.value)
+            except Exception:
+                continue
+    return values
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("source", help="Metrics URL or file path")
+    ap.add_argument("--out", default="hourly_multiplier_coverage.png", help="Output image path")
+    args = ap.parse_args()
+
+    text = _fetch(args.source)
+    sim = _extract(text, "sim_hour_of_week_multiplier_total")
+    lat = _extract(text, "latency_hour_of_week_multiplier_total")
+
+    plt.figure(figsize=(12, 5))
+    plt.plot(sim, label="simulator")
+    plt.plot(lat, label="latency")
+    plt.xlabel("hour of week")
+    plt.ylabel("count")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(args.out)
+    print(f"saved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/prometheus.py
+++ b/utils/prometheus.py
@@ -1,0 +1,22 @@
+"""Prometheus helper with graceful fallback.
+
+Provides :class:`Counter` compatible with :mod:`prometheus_client` if
+available.  When the dependency is missing, a no-op stub is used so that
+metrics calls do not fail in environments without Prometheus support.
+"""
+from __future__ import annotations
+
+try:  # pragma: no cover - simple import
+    from prometheus_client import Counter  # type: ignore
+except Exception:  # pragma: no cover - fallback for missing dependency
+    class _DummyCounter:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def labels(self, *args, **kwargs) -> "_DummyCounter":
+            return self
+
+        def inc(self, *args, **kwargs) -> None:
+            pass
+
+    Counter = _DummyCounter  # type: ignore


### PR DESCRIPTION
## Summary
- add Prometheus counters to simulator and latency wrapper to record hour-of-week multiplier usage
- provide helper for optional prometheus_client dependency
- add script to chart metric coverage from a metrics endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*
- `pytest tests/test_hour_of_week.py tests/test_sim_reality_check.py tests/test_metrics_profiles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f4edbf8c832faa50466dd6b7cab7