### PR TITLE
Clarify hour-of-week index calculations

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -622,6 +622,9 @@ class ExecutionSimulator:
             if self.use_seasonality:
                 logger.warning("ts_ms is None; seasonality multipliers not applied")
         else:
+            # Convert UTC milliseconds to hour-of-week (0=Mon 00:00 UTC) via the
+            # shared helper: (ts_ms // HOUR_MS + 72) % 168.  This keeps hour
+            # indexing consistent across modules.
             how = hour_of_week(int(ts_ms))
             if self.use_seasonality:
                 liq_mult = get_liquidity_multiplier(

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -93,6 +93,9 @@ class _LatencyWithSeasonality:
     def sample(self, ts_ms: int | None = None):
         if ts_ms is None:
             return self._model.sample()
+        # Use the shared hour_of_week helper: (ts_ms // HOUR_MS + 72) % 168
+        # yields an index where Monday 00:00 UTC == 0. ts_ms must therefore be
+        # a UTC timestamp.  Wrap the result to the multiplier array length.
         hour = hour_of_week(int(ts_ms)) % len(self._mult)
         m = get_latency_multiplier(int(ts_ms), self._mult, interpolate=self._interpolate)
         base, jitter, timeout = (

--- a/utils/time.py
+++ b/utils/time.py
@@ -19,6 +19,12 @@ def hour_of_week(ts_ms: Union[int, Sequence[int], np.ndarray]) -> Union[int, np.
     arr = np.asarray(ts_ms, dtype=np.int64)
 
     def _calc(ts: int) -> int:
+        # Convert milliseconds since epoch to an hour-of-week index.  We add the
+        # epoch offset (1970‑01‑01 00:00 UTC was Thursday, hour 72 of the week)
+        # and wrap by 168 so that Monday 00:00 UTC maps to ``0``.
+        #
+        # This formula is used across the codebase via this shared helper, so it
+        # assumes ``ts`` is a UTC timestamp.
         idx = int((ts // HOUR_MS + _EPOCH_HOW) % HOURS_IN_WEEK)
         assert 0 <= idx < HOURS_IN_WEEK
         return idx

--- a/utils_time.py
+++ b/utils_time.py
@@ -170,6 +170,9 @@ def _hour_index(ts_ms: int, length: int) -> int:
     week. ``length`` defaults to :data:`HOURS_IN_WEEK`.
     """
 
+    # Reuse the shared hour_of_week helper which computes
+    # ``(ts_ms // HOUR_MS + 72) % 168`` so that ``0`` maps to Monday 00:00 UTC.
+    # ``ts_ms`` must therefore be a UTC timestamp.
     hour = hour_of_week(int(ts_ms))
     if length:
         hour %= int(length)


### PR DESCRIPTION
## Summary
- document hour-of-week index formula and UTC assumptions
- clarify hour-of-week usage in latency and simulator modules
- reference shared helper for computing hour-of-week indexes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c2f8dc5d98832f92111e9393bf0ff0