### PR TITLE
Support legacy multipliers JSON and add migration utility

### DIFF
--- a/docs/seasonality_migration.md
+++ b/docs/seasonality_migration.md
@@ -1,0 +1,24 @@
+# Seasonality Multipliers Migration
+
+Older versions of the codebase stored hourly seasonality multipliers as a
+single array under a top-level `multipliers` key or even as a bare JSON list.
+Current loaders expect mappings such as `{"liquidity": [...], "latency": [...]}`.
+
+## Converting legacy files
+
+Use `scripts/convert_multipliers.py` to rewrite old files into the new format:
+
+```bash
+python scripts/convert_multipliers.py old.json new.json --key liquidity
+```
+
+The script reads a legacy file and writes a new JSON mapping with the provided
+key (default: `liquidity`). Adjust `--key` if the multipliers should be stored
+under a different name, for example `--key latency`.
+
+## Backward-compatible loading
+
+The helper functions in `utils_time.py` (`load_hourly_seasonality` and
+`load_seasonality`) automatically recognise the legacy structures so existing
+files continue to work without conversion. However, the conversion utility
+makes it easier to adopt the new layout and remove ambiguity.

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -727,17 +727,30 @@ class ExecutionSimulator:
         """
 
         liq = data.get("liquidity")
+        spread = data.get("spread")
+        legacy = data.get("multipliers")
+
         if liq is not None:
             arr = np.asarray(liq, dtype=float)
             if arr.size != HOURS_IN_WEEK:
                 raise ValueError("liquidity multipliers must have length 168")
             self._liq_seasonality = arr.copy()
+        elif legacy is not None:
+            arr = np.asarray(legacy, dtype=float)
+            if arr.size != HOURS_IN_WEEK:
+                raise ValueError("multipliers must have length 168")
+            self._liq_seasonality = arr.copy()
 
-        spread = data.get("spread")
         if spread is not None:
             arr = np.asarray(spread, dtype=float)
             if arr.size != HOURS_IN_WEEK:
                 raise ValueError("spread multipliers must have length 168")
+            self._spread_seasonality = arr.copy()
+        elif legacy is not None and spread is None and liq is None:
+            # Legacy single-array structure applied to both
+            arr = np.asarray(legacy, dtype=float)
+            if arr.size != HOURS_IN_WEEK:
+                raise ValueError("multipliers must have length 168")
             self._spread_seasonality = arr.copy()
     def _build_executor(self) -> None:
         """

--- a/scripts/convert_multipliers.py
+++ b/scripts/convert_multipliers.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Convert legacy seasonality multipliers JSON to the new format.
+
+Legacy files may contain a bare list or a mapping with a single
+``"multipliers"`` key. This utility rewrites them into a mapping with a
+specific target key (defaults to ``"liquidity"``).
+"""
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("input", help="Path to legacy multipliers JSON")
+    p.add_argument("output", help="Where to write the converted JSON")
+    p.add_argument(
+        "--key",
+        default="liquidity",
+        help="Destination key for the multipliers in the new file",
+    )
+    args = p.parse_args()
+
+    src = Path(args.input)
+    data = json.loads(src.read_text())
+    if isinstance(data, list):
+        arr = data
+    elif isinstance(data, dict):
+        arr = (
+            data.get("multipliers")
+            or data.get("liquidity")
+            or data.get("latency")
+            or data.get("spread")
+        )
+    else:
+        raise ValueError("Unsupported legacy format")
+
+    if not isinstance(arr, list):
+        raise ValueError("No multipliers array found in legacy file")
+
+    out = {args.key: arr}
+    dst = Path(args.output)
+    dst.write_text(json.dumps(out, indent=2))
+    print(f"Wrote {dst}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/tests/test_load_seasonality.py
+++ b/tests/test_load_seasonality.py
@@ -40,6 +40,13 @@ def test_load_seasonality_nested(tmp_path):
     assert np.allclose(res["spread"], 3.0)
 
 
+def test_load_seasonality_legacy_top_level(tmp_path):
+    p = tmp_path / "legacy.json"
+    p.write_text(json.dumps(_arr(4.0)))
+    res = load_seasonality(str(p))
+    assert np.allclose(res["multipliers"], 4.0)
+
+
 def test_load_seasonality_file_missing(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_seasonality(str(tmp_path / "missing.json"))
@@ -75,3 +82,10 @@ def test_hourly_seasonality_clamping(tmp_path):
     p2.write_text(json.dumps({"latency": [20.0] * HOURS_IN_WEEK}))
     arr2 = load_hourly_seasonality(str(p2), "latency")
     assert arr2.max() == SEASONALITY_MULT_MAX
+
+
+def test_hourly_seasonality_legacy_key(tmp_path):
+    p = tmp_path / "old.json"
+    p.write_text(json.dumps({"multipliers": _arr(5.0)}))
+    arr = load_hourly_seasonality(str(p), "liquidity")
+    assert np.allclose(arr, 5.0)

--- a/tests/test_multiplier_checkpoint.py
+++ b/tests/test_multiplier_checkpoint.py
@@ -35,6 +35,15 @@ def test_execution_simulator_round_trip():
     assert sim2.dump_seasonality_multipliers() == dump
 
 
+def test_execution_simulator_legacy_multipliers():
+    arr = [1.0] * 168
+    sim = ExecutionSimulator()
+    sim.load_seasonality_multipliers({"multipliers": arr})
+    dump = sim.dump_seasonality_multipliers()
+    assert dump["liquidity"] == arr
+    assert dump["spread"] == arr
+
+
 def test_latency_impl_round_trip():
     cfg = {
         "base_ms": 100,


### PR DESCRIPTION
## Summary
- allow `load_hourly_seasonality` and `load_seasonality` to read legacy `{"multipliers": [...]}` or bare list JSON
- extend `ExecutionSimulator.load_seasonality_multipliers` to accept legacy structures
- add `scripts/convert_multipliers.py` and migration docs for converting old files

## Testing
- `pytest tests/test_load_seasonality.py tests/test_multiplier_checkpoint.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_68c2fb6130cc832fb8b6aa485925a79e