### PR TITLE
docs: document file ownership and permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS
+# Replace example teams with actual GitHub usernames or teams.
+* @example-org/maintainers
+.github/workflows/ @example-org/devops

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 Документация по утилите скользящего среднего доступна в [docs/moving_average.md](docs/moving_average.md) (English/Russian).
 
+## File Ownership and Permissions
+
+Информация о ролях, владении файлами и необходимых правах доступа приведена в [docs/permissions.md](docs/permissions.md).
+
 ## Установка зависимостей для скриптов
 
 Скрипты построения и валидации данных полагаются на библиотеки

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,27 @@
+# File Ownership and Permissions
+
+This document outlines ownership and required permissions for major parts of the repository.
+
+## File Ownership
+
+- Source code (`*.py`, `*.pyx`, `*.cpp`, `*.h`) — owned by the **Core Development team**.
+- Documentation under `docs/` — owned by the **Documentation team**.
+- Continuous integration workflows in `.github/workflows/` — owned by the **DevOps team**.
+
+Ownership is enforced via the repository's `CODEOWNERS` file.
+
+## Required Permissions
+
+| Role | Permissions |
+| ---- | ----------- |
+| Contributors | Read access, submit pull requests for review |
+| Core Development team | Write access to source code files |
+| Documentation team | Write access to `docs/` |
+| DevOps team | Write access to `.github/workflows/` and CI settings |
+| Repository administrators | Manage branch protection rules and secrets |
+
+## CI/CD Editing Restrictions
+
+- Branch protection should block direct pushes to `main` and require reviews from code owners.
+- Changes to `.github/workflows/` must be approved by the DevOps team.
+- Repository settings should limit who can modify CI/CD secrets and runners.


### PR DESCRIPTION
## Summary
- add permissions guide describing file ownership and required access levels
- reference permissions doc in README
- restrict workflow edits via CODEOWNERS

## Testing
- `make lint` *(fails: flake8: No such file or directory)*
- `make no-trade-mask-sample`

------
https://chatgpt.com/codex/tasks/task_e_68c301a327b0832f8a6826e0a43c19ee