### PR TITLE
feat: support daily seasonality multipliers

### DIFF
--- a/tests/test_liquidity_seasonality.py
+++ b/tests/test_liquidity_seasonality.py
@@ -104,6 +104,24 @@ def test_seasonality_edge_hours_wraparound():
     check(168, 1.5, 1.1)
 
 
+def test_day_only_multipliers():
+    liq = [1.0] * 7
+    spr = [1.0] * 7
+    idx = 2  # Wednesday
+    liq[idx] = 2.0
+    spr[idx] = 3.0
+    sim = ExecutionSimulator(
+        liquidity_seasonality=liq,
+        spread_seasonality=spr,
+        seasonality_day_only=True,
+    )
+    base_dt = datetime.datetime(2024, 1, 3, 0, 0, tzinfo=datetime.timezone.utc)
+    ts_ms = int(base_dt.timestamp() * 1000 + 5 * 3_600_000)
+    sim.set_market_snapshot(bid=100.0, ask=101.0, liquidity=5.0, spread_bps=1.0, ts_ms=ts_ms)
+    assert sim._last_liquidity == pytest.approx(10.0)
+    assert sim._last_spread_bps == pytest.approx(3.0)
+
+
 def test_seasonality_override_applied():
     liq_mult = [1.0] * 168
     spr_mult = [1.0] * 168

--- a/tests/test_load_seasonality.py
+++ b/tests/test_load_seasonality.py
@@ -89,3 +89,12 @@ def test_hourly_seasonality_legacy_key(tmp_path):
     p.write_text(json.dumps({"multipliers": _arr(5.0)}))
     arr = load_hourly_seasonality(str(p), "liquidity")
     assert np.allclose(arr, 5.0)
+
+
+def test_load_seasonality_daily(tmp_path):
+    p = tmp_path / "day.json"
+    p.write_text(json.dumps({"liquidity": [1.0] * 7}))
+    res = load_seasonality(str(p))
+    assert len(res["liquidity"]) == 7
+    arr = load_hourly_seasonality(str(p), "liquidity")
+    assert len(arr) == 7

--- a/tests/test_seasonality_builder_simulator.py
+++ b/tests/test_seasonality_builder_simulator.py
@@ -70,3 +70,11 @@ def test_compute_multipliers_trims_outliers():
     multipliers, _ = compute_multipliers(df, min_samples=1, trim_top_pct=25.0)
     assert multipliers["liquidity"][0] == pytest.approx(1.0)
     assert multipliers["liquidity"][1] == pytest.approx(1.0)
+
+
+def test_compute_multipliers_by_day():
+    df = pd.read_csv(_data_path())
+    multipliers, _ = compute_multipliers(df, min_samples=1, by_day=True)
+    arr = multipliers["liquidity"]
+    assert len(arr) == 168
+    assert np.allclose(arr, 1.0)


### PR DESCRIPTION
## Summary
- allow seasonality loaders to handle daily arrays and provide helpers to interpolate or collapse multipliers
- option to build day-of-week multipliers and interpolate to 168-hour arrays
- add `seasonality_day_only` flag so simulator and latency modules can use 7-element multipliers

## Testing
- `pytest tests/test_load_seasonality.py tests/test_seasonality_builder_simulator.py tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py`

------
https://chatgpt.com/codex/tasks/task_e_68c303201f00832fa44ef37980c3fced