### PR TITLE
chore: drop legacy seasonality multipliers

### DIFF
--- a/docs/seasonality_migration.md
+++ b/docs/seasonality_migration.md
@@ -16,9 +16,8 @@ The script reads a legacy file and writes a new JSON mapping with the provided
 key (default: `liquidity`). Adjust `--key` if the multipliers should be stored
 under a different name, for example `--key latency`.
 
-## Backward-compatible loading
+## Loader requirements
 
 The helper functions in `utils_time.py` (`load_hourly_seasonality` and
-`load_seasonality`) automatically recognise the legacy structures so existing
-files continue to work without conversion. However, the conversion utility
-makes it easier to adopt the new layout and remove ambiguity.
+`load_seasonality`) no longer support legacy structures. Convert old files with
+the script above before loading them to avoid errors.

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -502,7 +502,7 @@ class ExecutionSimulator:
                 path = "configs/liquidity_seasonality.json"
             if path:
                 if liq_arr is None:
-                    liq_arr = load_hourly_seasonality(path, "liquidity", "multipliers")
+                    liq_arr = load_hourly_seasonality(path, "liquidity")
                 if spread_arr is None:
                     spread_arr = load_hourly_seasonality(path, "spread", "latency")
 
@@ -560,7 +560,7 @@ class ExecutionSimulator:
             if override_path and (liq_override is None or spread_override is None):
                 if liq_override is None:
                     liq_override = load_hourly_seasonality(
-                        override_path, "liquidity", "multipliers"
+                        override_path, "liquidity"
                     )
                 if spread_override is None:
                     spread_override = load_hourly_seasonality(
@@ -735,7 +735,6 @@ class ExecutionSimulator:
 
         liq = data.get("liquidity")
         spread = data.get("spread")
-        legacy = data.get("multipliers")
 
         expected = 7 if self.seasonality_day_only else HOURS_IN_WEEK
 
@@ -746,27 +745,12 @@ class ExecutionSimulator:
                     f"liquidity multipliers must have length {expected}"
                 )
             self._liq_seasonality = arr.copy()
-        elif legacy is not None:
-            arr = np.asarray(legacy, dtype=float)
-            if arr.size != expected:
-                raise ValueError(
-                    f"multipliers must have length {expected}"
-                )
-            self._liq_seasonality = arr.copy()
 
         if spread is not None:
             arr = np.asarray(spread, dtype=float)
             if arr.size != expected:
                 raise ValueError(
                     f"spread multipliers must have length {expected}"
-                )
-            self._spread_seasonality = arr.copy()
-        elif legacy is not None and spread is None and liq is None:
-            # Legacy single-array structure applied to both
-            arr = np.asarray(legacy, dtype=float)
-            if arr.size != expected:
-                raise ValueError(
-                    f"multipliers must have length {expected}"
                 )
             self._spread_seasonality = arr.copy()
     def _build_executor(self) -> None:

--- a/tests/test_load_seasonality.py
+++ b/tests/test_load_seasonality.py
@@ -40,13 +40,6 @@ def test_load_seasonality_nested(tmp_path):
     assert np.allclose(res["spread"], 3.0)
 
 
-def test_load_seasonality_legacy_top_level(tmp_path):
-    p = tmp_path / "legacy.json"
-    p.write_text(json.dumps(_arr(4.0)))
-    res = load_seasonality(str(p))
-    assert np.allclose(res["multipliers"], 4.0)
-
-
 def test_load_seasonality_file_missing(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_seasonality(str(tmp_path / "missing.json"))
@@ -82,13 +75,6 @@ def test_hourly_seasonality_clamping(tmp_path):
     p2.write_text(json.dumps({"latency": [20.0] * HOURS_IN_WEEK}))
     arr2 = load_hourly_seasonality(str(p2), "latency")
     assert arr2.max() == SEASONALITY_MULT_MAX
-
-
-def test_hourly_seasonality_legacy_key(tmp_path):
-    p = tmp_path / "old.json"
-    p.write_text(json.dumps({"multipliers": _arr(5.0)}))
-    arr = load_hourly_seasonality(str(p), "liquidity")
-    assert np.allclose(arr, 5.0)
 
 
 def test_load_seasonality_daily(tmp_path):

--- a/tests/test_multiplier_checkpoint.py
+++ b/tests/test_multiplier_checkpoint.py
@@ -35,15 +35,6 @@ def test_execution_simulator_round_trip():
     assert sim2.dump_seasonality_multipliers() == dump
 
 
-def test_execution_simulator_legacy_multipliers():
-    arr = [1.0] * 168
-    sim = ExecutionSimulator()
-    sim.load_seasonality_multipliers({"multipliers": arr})
-    dump = sim.dump_seasonality_multipliers()
-    assert dump["liquidity"] == arr
-    assert dump["spread"] == arr
-
-
 def test_latency_impl_round_trip():
     cfg = {
         "base_ms": 100,

--- a/trading_patchnew.py
+++ b/trading_patchnew.py
@@ -241,7 +241,6 @@ class TradingEnv(gym.Env):
         self._liq_seasonality = load_hourly_seasonality(
             liq_path,
             "liquidity",
-            "multipliers",
             expected_hash=liquidity_seasonality_hash,
         )
         if self._liq_seasonality is None:


### PR DESCRIPTION
## Summary
- remove backward-compatible parsing of legacy seasonality files
- adjust components and CLI to require explicit seasonality keys
- update migration docs to reflect dropped support

## Testing
- `pytest` *(fails: errors in unrelated tests during collection)*
- `pytest tests/test_load_seasonality.py tests/test_multiplier_checkpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_68c30735f86c832f9deea34cde0ce5a1