### PR TITLE
docs: add seasonality changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- **Seasonality Support**: Introduced hour-of-week seasonality multipliers to improve simulation fidelity.
+  - **Required actions**:
+    - Regenerate multipliers with the quick-start script.
+    - Validate and update configurations before training or running simulations.
+  - **Resources**:
+    - [Seasonality overview](docs/seasonality.md)
+    - [Quick start guide](docs/seasonality_quickstart.md)
+    - [Process checklist](docs/seasonality_checklist.md)
+    - [Example notebook](docs/seasonality_example.md)
+    - [Migration guide](docs/seasonality_migration.md)


### PR DESCRIPTION
## Summary
- add changelog entry announcing new seasonality support
- outline required actions and link to seasonality docs

## Testing
- `pytest tests/test_load_seasonality.py -q`
- `pytest tests/test_liquidity_seasonality.py -q`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c30b067364832fb7216020197c9c7a