### PR TITLE
Add seasonality review note and specialized reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # CODEOWNERS
 # Replace example teams with actual GitHub usernames or teams.
-* @example-org/maintainers
+# Ensure PRs are reviewed by experts in market microstructure and latency.
+* @example-org/maintainers @example-org/microstructure @example-org/latency
 .github/workflows/ @example-org/devops

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+Thank you for considering contributing to TradingBot.
+
+## Seasonality review requirements
+
+Before submitting changes, evaluate how seasonality could impact the affected strategies and describe your findings in the pull request.
+Contributions lacking a seasonality review may be delayed until this analysis is provided.


### PR DESCRIPTION
## Summary
- Assign market microstructure and latency experts as code owners for repository-wide reviews
- Document seasonality review expectations for contributions

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c30bd425d8832f95fca725307adae4