### PR TITLE
Deprecate legacy LatencyImpl multipliers API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,9 @@
     - [Process checklist](docs/seasonality_checklist.md)
     - [Example notebook](docs/seasonality_example.md)
     - [Migration guide](docs/seasonality_migration.md)
+
+### Deprecated
+- `LatencyImpl.dump_latency_multipliers` and
+  `LatencyImpl.load_latency_multipliers` have been replaced by
+  `dump_multipliers` and `load_multipliers`. The old names continue to work but
+  emit `DeprecationWarning`. See the migration guide for details.

--- a/docs/seasonality_migration.md
+++ b/docs/seasonality_migration.md
@@ -21,3 +21,10 @@ under a different name, for example `--key latency`.
 The helper functions in `utils_time.py` (`load_hourly_seasonality` and
 `load_seasonality`) no longer support legacy structures. Convert old files with
 the script above before loading them to avoid errors.
+
+## API changes
+
+`LatencyImpl.dump_latency_multipliers` and `LatencyImpl.load_latency_multipliers`
+have been renamed to `dump_multipliers` and `load_multipliers`. The previous
+methods remain available for backward compatibility but emit a
+`DeprecationWarning`. Update any custom code to use the new method names.

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -14,6 +14,7 @@ import importlib.util
 import sysconfig
 from pathlib import Path
 import threading
+import warnings
 
 import numpy as np
 try:
@@ -317,6 +318,22 @@ class LatencyImpl:
                     self._wrapper._mult_sum = [0.0] * n
                     self._wrapper._lat_sum = [0.0] * n
                     self._wrapper._count = [0] * n
+
+    def dump_latency_multipliers(self) -> List[float]:
+        warnings.warn(
+            "dump_latency_multipliers() is deprecated; use dump_multipliers() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.dump_multipliers()
+
+    def load_latency_multipliers(self, arr: Sequence[float]) -> None:
+        warnings.warn(
+            "load_latency_multipliers() is deprecated; use load_multipliers() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.load_multipliers(arr)
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "LatencyImpl":


### PR DESCRIPTION
## Summary
- add deprecated wrappers for legacy `LatencyImpl` multiplier methods
- document migration from `dump_latency_multipliers`/`load_latency_multipliers`
- record deprecation in changelog

## Testing
- `pytest tests/test_latency_validation.py tests/test_multiplier_checkpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3ddcd5004832fb4e396aa0be0c83a