### PR TITLE
Assert positive seasonality multipliers

### DIFF
--- a/tests/test_load_seasonality.py
+++ b/tests/test_load_seasonality.py
@@ -61,6 +61,15 @@ def test_load_seasonality_bad_length(tmp_path):
         load_seasonality(str(p))
 
 
+def test_seasonality_negative_values(tmp_path):
+    p = tmp_path / "neg.json"
+    p.write_text(json.dumps({"liquidity": [-1.0] * HOURS_IN_WEEK}))
+    with pytest.raises(ValueError):
+        load_seasonality(str(p))
+    with pytest.raises(ValueError):
+        load_hourly_seasonality(str(p), "liquidity")
+
+
 def test_seasonality_clamping(tmp_path):
     data = {
         "liquidity": [0.01] * HOURS_IN_WEEK,

--- a/utils_time.py
+++ b/utils_time.py
@@ -106,9 +106,13 @@ def load_hourly_seasonality(
             return None
         arr = np.asarray(data, dtype=float)
         if arr.shape[0] in (HOURS_IN_WEEK, 7):
+            if np.any(arr <= 0):
+                raise ValueError("Seasonality array values must be > 0")
             if any(k in {"liquidity", "latency"} for k in keys):
                 arr = np.clip(arr, SEASONALITY_MULT_MIN, SEASONALITY_MULT_MAX)
             return arr
+    except ValueError:
+        raise
     except Exception:
         return None
     return None
@@ -166,6 +170,10 @@ def load_seasonality(path: str) -> Dict[str, np.ndarray]:
                 if arr.shape[0] not in (HOURS_IN_WEEK, 7):
                     raise ValueError(
                         "Seasonality array '%s' must have length 168 or 7" % key
+                    )
+                if np.any(arr <= 0):
+                    raise ValueError(
+                        "Seasonality array '%s' must contain positive values" % key
                     )
                 if key in {"liquidity", "latency"}:
                     arr = np.clip(arr, SEASONALITY_MULT_MIN, SEASONALITY_MULT_MAX)


### PR DESCRIPTION
## Summary
- validate positive values in seasonality loaders
- test that negative seasonality data triggers errors

## Testing
- `pytest tests/test_load_seasonality.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3df6797a8832faff94513549d87e8