### PR TITLE
Fix spread seasonality multiplier loading

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -510,7 +510,9 @@ class ExecutionSimulator:
                 if liq_arr is None:
                     liq_arr = load_hourly_seasonality(path, "liquidity")
                 if spread_arr is None:
-                    spread_arr = load_hourly_seasonality(path, "spread", "latency")
+                    # Prefer the dedicated "spread" field, falling back to generic
+                    # "multipliers" for backwards compatibility with older configs.
+                    spread_arr = load_hourly_seasonality(path, "spread", "multipliers")
 
             from utils_time import interpolate_daily_multipliers, daily_from_hourly
 
@@ -570,7 +572,7 @@ class ExecutionSimulator:
                     )
                 if spread_override is None:
                     spread_override = load_hourly_seasonality(
-                        override_path, "spread", "latency"
+                        override_path, "spread", "multipliers"
                     )
 
             liq_override = _prep(liq_override)


### PR DESCRIPTION
## Summary
- use "multipliers" fallback when loading spread seasonality
- keep override section consistent

## Testing
- `pytest tests/test_load_seasonality.py tests/test_liquidity_seasonality.py tests/test_integration_seasonality_simulation.py tests/test_watch_seasonality_file.py tests/test_risk_seasonality.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3e170bb04832faf5b89418a6477d3