### PR TITLE
Use shared hour_of_week helper

### DIFF
--- a/impl_latency.py
+++ b/impl_latency.py
@@ -23,7 +23,7 @@ except Exception:  # pragma: no cover - fallback when module not found
     def seasonality_enabled(default: bool = True) -> bool:
         return default
 
-from utils.time import hour_of_week
+from utils_time import hour_of_week
 from utils.prometheus import Counter
 
 _logging_spec = importlib.util.spec_from_file_location(
@@ -109,9 +109,9 @@ class _LatencyWithSeasonality:
     def sample(self, ts_ms: int | None = None):
         if ts_ms is None:
             return self._model.sample()
-        # Use the shared hour_of_week helper: (ts_ms // HOUR_MS + 72) % 168
-        # yields an index where Monday 00:00 UTC == 0. ts_ms must therefore be
-        # a UTC timestamp.  Wrap the result to the multiplier array length.
+        # Convert milliseconds since epoch to hour-of-week (0=Mon 00:00 UTC)
+        # using the shared helper.  Wrap the result to the multiplier array
+        # length for day-only configurations.
         hour = hour_of_week(int(ts_ms)) % len(self._mult)
         m = get_latency_multiplier(int(ts_ms), self._mult, interpolate=self._interpolate)
         with self._lock:

--- a/tests/test_hour_of_week.py
+++ b/tests/test_hour_of_week.py
@@ -1,14 +1,39 @@
 from datetime import datetime, timezone, timedelta
 import numpy as np
-import pathlib, sys
+import pathlib, sys, importlib.util
+import logging
 
 import pytest
 
+# Pre-load stdlib logging before adding repo path to avoid local module shadowing
+logging.getLogger()
+
 BASE = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(BASE))
+
 from utils.time import hour_of_week
 from utils_time import hour_of_week as hour_of_week_dt
-from impl_latency import hour_of_week as hour_of_week_latency
+
+# Dynamically load modules that re-export hour_of_week
+spec_lat = importlib.util.spec_from_file_location("latency", BASE / "latency.py")
+lat_module = importlib.util.module_from_spec(spec_lat)
+sys.modules["latency"] = lat_module
+spec_lat.loader.exec_module(lat_module)
+LatencyModel = lat_module.LatencyModel
+
+spec_impl = importlib.util.spec_from_file_location("impl_latency", BASE / "impl_latency.py")
+impl_module = importlib.util.module_from_spec(spec_impl)
+sys.modules["impl_latency"] = impl_module
+spec_impl.loader.exec_module(impl_module)
+hour_of_week_latency = impl_module.hour_of_week
+_LatencyWithSeasonality = impl_module._LatencyWithSeasonality
+
+spec_exec = importlib.util.spec_from_file_location("execution_sim", BASE / "execution_sim.py")
+exec_module = importlib.util.module_from_spec(spec_exec)
+sys.modules["execution_sim"] = exec_module
+spec_exec.loader.exec_module(exec_module)
+hour_of_week_exec = exec_module.hour_of_week
+ExecutionSimulator = exec_module.ExecutionSimulator
 
 
 @pytest.mark.parametrize("func", [hour_of_week, hour_of_week_dt])
@@ -39,7 +64,7 @@ def test_hour_of_week_week_boundary(func):
 
 
 def test_cross_module_consistency():
-    """Ensure all hour-of-week helpers agree on index mapping."""
+    """Ensure hour-of-week helpers agree across modules."""
     base = datetime(2024, 1, 1, tzinfo=timezone.utc)
     ts_samples = np.array(
         [
@@ -52,6 +77,48 @@ def test_cross_module_consistency():
     expected = hour_of_week(ts_samples)
     out_dt = hour_of_week_dt(ts_samples)
     out_latency = hour_of_week_latency(ts_samples)
+    out_exec = hour_of_week_exec(ts_samples)
     np.testing.assert_array_equal(out_dt, expected)
     np.testing.assert_array_equal(out_latency, expected)
-    np.testing.assert_array_equal(out_dt, out_latency)
+    np.testing.assert_array_equal(out_exec, expected)
+
+
+def test_timestamp_hour_index_alignment_across_components():
+    """Identical timestamps should map to the same hour index for latency,
+    liquidity and spread seasonality handlers."""
+    hour_idx = 42
+    liq_mult = [1.0] * 168
+    spr_mult = [1.0] * 168
+    lat_mult = [1.0] * 168
+    liq_mult[hour_idx] = 2.0
+    spr_mult[hour_idx] = 3.0
+    lat_mult[hour_idx] = 4.0
+
+    sim = ExecutionSimulator(
+        liquidity_seasonality=liq_mult,
+        spread_seasonality=spr_mult,
+    )
+    lat_model = LatencyModel(base_ms=100, jitter_ms=0, spike_p=0.0, spike_mult=1.0, timeout_ms=1000)
+    lat = _LatencyWithSeasonality(lat_model, lat_mult)
+
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts_ms = int((base + timedelta(hours=hour_idx)).timestamp() * 1000)
+
+    # Ensure all helpers agree on the hour index
+    idx_expected = hour_of_week(ts_ms)
+    assert hour_of_week_latency(ts_ms) == idx_expected
+    assert hour_of_week_exec(ts_ms) == idx_expected
+
+    lat.sample(ts_ms)
+    sim.set_market_snapshot(
+        bid=100.0,
+        ask=101.0,
+        liquidity=5.0,
+        spread_bps=1.0,
+        ts_ms=ts_ms,
+    )
+
+    assert lat._mult_sum[idx_expected] == pytest.approx(lat_mult[idx_expected])
+    assert sim._last_liquidity == pytest.approx(5.0 * liq_mult[idx_expected])
+    assert sim._last_spread_bps == pytest.approx(1.0 * spr_mult[idx_expected])
+


### PR DESCRIPTION
## Summary
- Replace manual hour calculation in latency seasonality wrapper with `utils_time.hour_of_week`
- Verify hour-of-week alignment across latency, liquidity and spread seasonality

## Testing
- `pytest tests/test_hour_of_week.py tests/test_liquidity_seasonality.py tests/test_latency_seasonality.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3e235f264832f9d0971e8c06e897c