### PR TITLE
docs: describe data degradation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ latency:
   mean_ms: 50
 ```
 
+### Деградация данных
+
+`DataDegradationConfig` позволяет смоделировать пропуски и задержки в
+потоке маркет‑данных. Полный список полей описан в
+[docs/data_degradation.md](docs/data_degradation.md).
+
+Пример настройки в YAML‑конфиге:
+
+```yaml
+data_degradation:
+  stale_prob: 0.1      # вероятность повторить предыдущий бар
+  drop_prob: 0.05      # вероятность пропустить бар
+  dropout_prob: 0.2    # вероятность добавить задержку
+  max_delay_ms: 50     # верхняя граница задержки
+  seed: 42
+```
+
+Во время работы сервисы выводят сводку вида
+`OfflineCSVBarSource degradation: ...`, `BinanceWS degradation: ...` или
+`LatencyQueue degradation: ...` — по этим сообщениям можно контролировать
+доли пропусков и задержек.
+
 Обработка окон **no‑trade** описывается в конфигурации; подробности
 см. [docs/no_trade.md](docs/no_trade.md).
 

--- a/docs/data_degradation.md
+++ b/docs/data_degradation.md
@@ -1,0 +1,56 @@
+# Data degradation
+
+`DataDegradationConfig` injects missing or delayed bars to emulate
+real‑world data issues. All fields are optional; by default the stream is
+unchanged.
+
+## Configuration fields
+
+| Field | Type | Description |
+|------|------|-------------|
+| `stale_prob` | float | Chance to repeat the previous bar instead of the new one. |
+| `drop_prob` | float | Probability to drop the bar entirely. |
+| `dropout_prob` | float | Probability to delay delivery by up to `max_delay_ms`. |
+| `max_delay_ms` | int | Upper bound on the random delay in milliseconds. |
+| `seed` | int | RNG seed for reproducibility. |
+
+## Examples
+
+### Offline CSV
+
+```yaml
+# config_sim.yaml
+symbols: ["BTCUSDT"]
+data_degradation:
+  stale_prob: 0.1
+  drop_prob: 0.05
+  dropout_prob: 0.2
+  max_delay_ms: 50
+  seed: 42
+```
+
+Run:
+
+```bash
+python script_backtest.py --config config_sim.yaml
+```
+
+### Live WebSocket
+
+```python
+from binance_ws import BinanceWS
+from config import DataDegradationConfig
+
+cfg = DataDegradationConfig(stale_prob=0.05, drop_prob=0.02,
+                            dropout_prob=0.1, max_delay_ms=50, seed=7)
+ws = BinanceWS(symbols=["BTCUSDT"], on_bar=handle_bar,
+               data_degradation=cfg)
+ws.run()
+```
+
+## Monitoring
+
+Components log degradation statistics on shutdown. Look for messages
+`OfflineCSVBarSource degradation`, `BinanceWS degradation` or
+`LatencyQueue degradation` in the INFO log level to inspect drop and
+delay ratios.


### PR DESCRIPTION
## Summary
- document DataDegradationConfig parameters and usage
- show offline and live configuration examples
- point to log messages reporting drop and delay ratios

## Testing
- `pytest tests/test_degradation_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3f82f6794832fa3fc0ae744fc6729