### PR TITLE
Track rate-limited and rejected signals in Mediator

### DIFF
--- a/utils/rate_limiter.py
+++ b/utils/rate_limiter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import time
+from typing import Literal, Tuple
 
 
 @dataclass
@@ -27,18 +28,25 @@ class SignalRateLimiter:
     _cooldown_until: float = field(default_factory=lambda: 0.0, init=False)
     _current_backoff: float = field(default_factory=lambda: 0.0, init=False)
 
-    def can_send(self, now: float | None = None) -> bool:
-        """Return ``True`` if a new signal can be sent at ``now``.
+    def can_send(self, now: float | None = None) -> Tuple[bool, Literal["ok", "delayed", "rejected"]]:
+        """Return status whether a new signal can be sent at ``now``.
 
-        When the limit is exceeded the next allowed time is delayed using
-        exponential backoff.
+        Returns
+        -------
+        allowed : bool
+            ``True`` if a signal may be sent immediately.
+        status : {"ok", "delayed", "rejected"}
+            Additional status describing the limiter decision. ``"delayed"``
+            means the call happened during a cooldown period, while
+            ``"rejected"`` indicates the rate limit has just been exceeded and
+            a new cooldown is started.
         """
         if self.max_per_sec <= 0:
-            return True
+            return True, "ok"
 
         ts = float(time.time() if now is None else now)
         if ts < self._cooldown_until:
-            return False
+            return False, "delayed"
 
         if ts - self._last_reset >= 1.0:
             self._last_reset = ts
@@ -47,7 +55,7 @@ class SignalRateLimiter:
         if self._count < self.max_per_sec:
             self._count += 1
             self._current_backoff = 0.0
-            return True
+            return True, "ok"
 
         # limit exceeded -> backoff
         if self._current_backoff == 0.0:
@@ -55,7 +63,7 @@ class SignalRateLimiter:
         else:
             self._current_backoff = min(self._current_backoff * self.backoff_base, self.max_backoff)
         self._cooldown_until = ts + self._current_backoff
-        return False
+        return False, "rejected"
 
     def reset(self) -> None:
         """Reset internal counters and timers."""


### PR DESCRIPTION
## Summary
- add total, delayed and rejected signal counters to Mediator
- extend SignalRateLimiter to return decision status
- log share of delayed and rejected signals at the end of an episode

## Testing
- `pytest` *(fails: tests/test_close_shift.py, tests/test_leak_guard_env.py, tests/test_no_trade_config_shared.py, tests/test_no_trade_mask.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fae09ed0832f9ae9b92e3d46b36e