### PR TITLE
feat: add dynamic large order execution

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -9,6 +9,9 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution_config:
+  notional_threshold: 10000.0
+  large_order_algo: TWAP
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -3,6 +3,9 @@ run_id: live-run
 logs_dir: logs
 artifacts_dir: artifacts
 seasonality_log_level: INFO
+execution_config:
+  notional_threshold: 10000.0
+  large_order_algo: TWAP
 max_signals_per_sec: 5.0
 backoff_base_s: 2.0
 max_backoff_s: 60.0

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -9,6 +9,9 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution_config:
+  notional_threshold: 10000.0
+  large_order_algo: TWAP
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -15,6 +15,9 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution_config:
+  notional_threshold: 10000.0
+  large_order_algo: TWAP
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -9,6 +9,9 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution_config:
+  notional_threshold: 10000.0
+  large_order_algo: TWAP
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/configs/legacy_sim.yaml
+++ b/configs/legacy_sim.yaml
@@ -27,6 +27,8 @@ slippage:
 
 execution:
   algo: "TWAP"
+  notional_threshold: 10000.0
+  large_order_algo: TWAP
   twap:
     parts: 6
     child_interval_s: 600


### PR DESCRIPTION
## Summary
- choose TWAP/POV executors for large notionals using new `notional_threshold` and `large_order_algo`
- add `make_executor` factory for execution algorithms
- expose threshold/algo fields in sample configs

## Testing
- `flake8 execution_algos.py execution_sim.py` *(fails: command not found)*
- `pytest -q` *(fails: assert [] == [1]; TypeError: Unsupported action type)*


------
https://chatgpt.com/codex/tasks/task_e_68c409e064a8832fad44cbcbfb5d2f10