### PR TITLE
Support participation for POV execution algorithm

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -12,6 +12,10 @@ execution_params:
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP
+  pov:
+    participation: 0.10
+    child_interval_s: 60
+    min_child_notional: 20.0
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -6,6 +6,10 @@ seasonality_log_level: INFO
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP
+  pov:
+    participation: 0.10
+    child_interval_s: 60
+    min_child_notional: 20.0
 max_signals_per_sec: 5.0
 backoff_base_s: 2.0
 max_backoff_s: 60.0

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -12,6 +12,10 @@ execution_params:
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP
+  pov:
+    participation: 0.10
+    child_interval_s: 60
+    min_child_notional: 20.0
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -18,6 +18,10 @@ execution_params:
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP
+  pov:
+    participation: 0.10
+    child_interval_s: 60
+    min_child_notional: 20.0
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -12,6 +12,10 @@ execution_params:
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP
+  pov:
+    participation: 0.10
+    child_interval_s: 60
+    min_child_notional: 20.0
 
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -245,10 +245,22 @@ if make_executor is None:
 
     def make_executor(algo: str, cfg: Dict[str, Any] | None = None):  # type: ignore[override]
         a = str(algo).upper()
+        cfg = dict(cfg or {})
         if a == "TWAP" and TWAPExecutor is not None:
-            return TWAPExecutor()
+            tw = dict(cfg.get("twap", {}))
+            parts = int(tw.get("parts", 6))
+            interval = int(tw.get("child_interval_s", 600))
+            return TWAPExecutor(parts=parts, child_interval_s=interval)
         if a == "POV" and POVExecutor is not None:
-            return POVExecutor()
+            pv = dict(cfg.get("pov", {}))
+            part = float(pv.get("participation", 0.10))
+            interval = int(pv.get("child_interval_s", 60))
+            min_not = float(pv.get("min_child_notional", 20.0))
+            return POVExecutor(
+                participation=part,
+                child_interval_s=interval,
+                min_child_notional=min_not,
+            )
         if a == "VWAP" and VWAPExecutor is not None:
             return VWAPExecutor()
         return TakerExecutor()

--- a/tests/test_pov_executor.py
+++ b/tests/test_pov_executor.py
@@ -1,0 +1,49 @@
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+base = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(base))
+spec = importlib.util.spec_from_file_location("execution_sim", base / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec)
+sys.modules["execution_sim"] = exec_mod
+spec.loader.exec_module(exec_mod)
+
+POVExecutor = exec_mod.POVExecutor
+ExecutionSimulator = exec_mod.ExecutionSimulator
+
+
+def test_pov_participation_propagation():
+    sim = ExecutionSimulator(
+        execution_config={
+            "algo": "POV",
+            "pov": {
+                "participation": 0.2,
+                "child_interval_s": 1,
+                "min_child_notional": 0.0,
+            },
+        },
+        slippage_config={
+            "default_spread_bps": 0.0,
+            "k": 0.0,
+            "min_half_spread_bps": 0.0,
+        },
+    )
+    executor = sim._executor
+    assert isinstance(executor, POVExecutor)
+    assert executor.participation == pytest.approx(0.2)
+
+
+def test_pov_plan_uses_participation():
+    execu = POVExecutor(participation=0.2, child_interval_s=1, min_child_notional=0.0)
+    plan = execu.plan_market(
+        now_ts_ms=0,
+        side="BUY",
+        target_qty=300,
+        snapshot={"liquidity": 1000.0, "ref_price": 100.0},
+    )
+    assert len(plan) == 2
+    assert plan[0].qty == pytest.approx(200.0)
+    assert plan[1].qty == pytest.approx(100.0)


### PR DESCRIPTION
## Summary
- allow configuring POV executor participation through `execution.pov.participation`
- forward participation when building `POVExecutor`
- add regression tests for POV participation handling

## Testing
- `pytest tests/test_pov_executor.py -q`
- `pytest -q` *(fails: assert [] == [1], etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c40bba1710832fa3446c5b04fb5b4f