### PR TITLE
Add clock sync configuration model

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -36,6 +36,13 @@ class Components(BaseModel):
     backtest_engine: Optional[ComponentSpec] = None
 
 
+class ClockSyncConfig(BaseModel):
+    """Настройки синхронизации часов между процессами."""
+
+    refresh: float = Field(default=60.0, description="How often to refresh clock sync in seconds")
+    threshold: float = Field(default=1.0, description="Threshold in seconds to trigger resync")
+
+
 class CommonRunConfig(BaseModel):
     run_id: Optional[str] = Field(default=None, description="Идентификатор запуска; если None — генерируется.")
     seed: Optional[int] = Field(default=None)
@@ -51,6 +58,7 @@ class CommonRunConfig(BaseModel):
     )
     backoff_base_s: float = Field(default=2.0, description="Initial backoff in seconds for rate limiter")
     max_backoff_s: float = Field(default=60.0, description="Maximum backoff in seconds for rate limiter")
+    clock_sync: ClockSyncConfig = Field(default_factory=ClockSyncConfig)
     components: Components
 
 
@@ -229,6 +237,7 @@ def _set_seasonality_log_level(cfg: CommonRunConfig) -> None:
 __all__ = [
     "ComponentSpec",
     "Components",
+    "ClockSyncConfig",
     "CommonRunConfig",
     "SimulationDataConfig",
     "SimulationConfig",

--- a/tests/test_clock_sync_config.py
+++ b/tests/test_clock_sync_config.py
@@ -1,0 +1,49 @@
+import textwrap
+import sys
+import pathlib
+
+# Ensure stdlib logging is used instead of local logging.py
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_orig_sys_path = list(sys.path)
+sys.path = [p for p in sys.path if p not in ("", str(REPO_ROOT))]
+import logging as std_logging  # type: ignore
+sys.modules["logging"] = std_logging
+sys.path = _orig_sys_path
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core_config import load_config_from_str
+
+
+def test_clock_sync_config_loading():
+    yaml_cfg = textwrap.dedent(
+        """
+        mode: sim
+        symbols: ["BTCUSDT"]
+        components:
+          market_data:
+            target: "module:Cls"
+            params: {}
+          executor:
+            target: "module:Cls"
+            params: {}
+          feature_pipe:
+            target: "module:Cls"
+            params: {}
+          policy:
+            target: "module:Cls"
+            params: {}
+          risk_guards:
+            target: "module:Cls"
+            params: {}
+        data:
+          symbols: ["BTCUSDT"]
+          timeframe: "1m"
+        clock_sync:
+          refresh: 123
+          threshold: 456
+        """
+    )
+    cfg = load_config_from_str(yaml_cfg)
+    assert cfg.clock_sync.refresh == 123
+    assert cfg.clock_sync.threshold == 456


### PR DESCRIPTION
## Summary
- add `ClockSyncConfig` with refresh and threshold settings
- include `clock_sync` field in `CommonRunConfig`
- test loading configurations with `clock_sync`

## Testing
- `pytest tests/test_clock_sync_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b6d8d90c832f90493fbaa5ca80ed