### PR TITLE
Add clock sync defaults to runtime configs

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -13,6 +13,12 @@ execution_config:
 max_signals_per_sec: 5.0
 backoff_base_s: 2.0
 max_backoff_s: 60.0
+clock_sync:
+  refresh_sec: 300        # How often to resync clocks in seconds
+  warn_threshold_ms: 500  # Log warning if drift exceeds this many milliseconds
+  kill_threshold_ms: 2000 # Terminate if drift exceeds this many milliseconds
+  max_step_ms: 1000       # Max single adjustment step in milliseconds
+  attempts: 5             # Number of sync attempts before giving up
 api:
   api_key: null
   api_secret: null

--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -1,0 +1,8 @@
+# Operational settings for the runtime environment
+clock_sync:
+  refresh_sec: 300        # How often to resync clocks in seconds
+  warn_threshold_ms: 500  # Log warning if drift exceeds this many milliseconds
+  kill_threshold_ms: 2000 # Terminate if drift exceeds this many milliseconds
+  max_step_ms: 1000       # Max single adjustment step in milliseconds
+  attempts: 5             # Number of sync attempts before giving up
+


### PR DESCRIPTION
## Summary
- document clock synchronization settings for live runs
- provide standalone ops.yaml with clock sync defaults

## Testing
- `pytest tests/test_clock_sync_config.py::test_clock_sync_config_loading -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b7993478832fbf619481e65f6342