### PR TITLE
Add server time fetch with RTT measurement

### DIFF
--- a/binance_public.py
+++ b/binance_public.py
@@ -107,6 +107,22 @@ class BinancePublicClient:
                 self._rl_total,
             )
 
+    # -------- SERVER TIME --------
+
+    def get_server_time(self) -> Tuple[int, float]:
+        """Fetch Binance server time and measure round-trip time."""
+        base = self.e.spot_base
+        path = "/api/v3/time"
+        url = f"{base}{path}"
+        params: Dict[str, Any] = {}
+        self._throttle()
+        t0 = time.time()
+        data = _retrying_get(url, params, timeout=self.timeout)
+        t1 = time.time()
+        if isinstance(data, dict) and "serverTime" in data:
+            return int(data["serverTime"]), (t1 - t0) * 1000.0
+        raise RuntimeError(f"Unexpected server time response: {data}")
+
     # -------- KLINES --------
 
     def get_klines(self, *, market: str, symbol: str, interval: str, start_ms: Optional[int] = None, end_ms: Optional[int] = None, limit: int = 1500) -> List[List[Any]]:


### PR DESCRIPTION
## Summary
- add `get_server_time` to `BinancePublicClient` to fetch server time and compute round-trip time

## Testing
- `python -m py_compile binance_public.py`
- `pytest` *(fails: assert [] == [1] in tests/test_execution_rules.py::test_unquantized_limit_rejected_sim, assert [] == [1] in tests/test_execution_rules.py::test_ttl_two_steps_sim, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b859b658832fbaf2fc4d5edab8f6