### PR TITLE
Implement clock synchronization utilities

### DIFF
--- a/clock.py
+++ b/clock.py
@@ -1,0 +1,99 @@
+"""Clock synchronization utilities."""
+
+from __future__ import annotations
+
+import math
+import statistics
+import time
+from typing import List
+
+from binance_public import BinancePublicClient
+from core_config import ClockSyncConfig
+
+# Global clock skew in milliseconds (server - local) and last sync timestamp
+clock_skew_ms: float = 0.0
+last_sync_at: float = 0.0
+
+
+def system_utc_ms() -> int:
+    """Return current system time in milliseconds since the epoch."""
+    return int(time.time() * 1000.0)
+
+
+def now_ms() -> int:
+    """Return current corrected time accounting for clock skew."""
+    return int(system_utc_ms() + clock_skew_ms)
+
+
+def clock_skew() -> float:
+    """Return current clock skew in milliseconds."""
+    return float(clock_skew_ms)
+
+
+def last_sync_age_sec() -> float:
+    """Return age of last successful sync in seconds."""
+    if last_sync_at <= 0:
+        return float("inf")
+    return (system_utc_ms() - last_sync_at) / 1000.0
+
+
+def sync_clock(client: BinancePublicClient, cfg: ClockSyncConfig, monitor) -> float:
+    """Synchronize local clock with exchange server time.
+
+    Parameters
+    ----------
+    client : BinancePublicClient
+        Client used to fetch server time.
+    cfg : ClockSyncConfig
+        Configuration parameters controlling sync behaviour.
+    monitor : object
+        Monitoring object with ``clock_sync_fail`` counter (optional).
+
+    Returns
+    -------
+    float
+        Updated clock skew in milliseconds.
+    """
+    global clock_skew_ms, last_sync_at
+
+    offsets: List[float] = []
+    rtts: List[float] = []
+    try:
+        attempts = max(1, int(getattr(cfg, "attempts", 1)))
+        for _ in range(attempts):
+            server_ms, rtt_ms = client.get_server_time()
+            local_ms = system_utc_ms()
+            offsets.append(float(server_ms) + float(rtt_ms) / 2.0 - float(local_ms))
+            rtts.append(float(rtt_ms))
+    except Exception:
+        if monitor is not None and hasattr(monitor, "clock_sync_fail"):
+            try:
+                monitor.clock_sync_fail.inc()
+            except Exception:
+                pass
+        return float(clock_skew_ms)
+
+    if not offsets:
+        return float(clock_skew_ms)
+
+    # Filter out samples with RTT above the 90th percentile
+    if len(rtts) > 1:
+        sorted_rtts = sorted(rtts)
+        idx = max(0, int(math.ceil(len(sorted_rtts) * 0.9)) - 1)
+        p90 = sorted_rtts[idx]
+        filtered = [off for off, rtt in zip(offsets, rtts) if rtt <= p90]
+        if filtered:
+            offsets = filtered
+    median_offset = statistics.median(offsets)
+
+    alpha = float(getattr(cfg, "ema_alpha", 1.0))
+    alpha = min(max(alpha, 0.0), 1.0)
+    new_skew = (1.0 - alpha) * float(clock_skew_ms) + alpha * float(median_offset)
+    step = new_skew - float(clock_skew_ms)
+    max_step = float(getattr(cfg, "max_step_ms", 0.0))
+    if max_step > 0 and abs(step) > max_step:
+        new_skew = float(clock_skew_ms) + math.copysign(max_step, step)
+
+    clock_skew_ms = float(new_skew)
+    last_sync_at = float(system_utc_ms())
+    return float(clock_skew_ms)

--- a/core_config.py
+++ b/core_config.py
@@ -41,6 +41,9 @@ class ClockSyncConfig(BaseModel):
 
     refresh: float = Field(default=60.0, description="How often to refresh clock sync in seconds")
     threshold: float = Field(default=1.0, description="Threshold in seconds to trigger resync")
+    attempts: int = Field(default=5, description="Number of samples per sync attempt")
+    ema_alpha: float = Field(default=0.1, description="EMA coefficient for skew updates")
+    max_step_ms: float = Field(default=1000.0, description="Maximum skew adjustment per sync in ms")
 
 
 class CommonRunConfig(BaseModel):

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,72 @@
+import types
+from types import SimpleNamespace
+
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import clock
+from core_config import ClockSyncConfig
+
+
+class DummyCounter:
+    def __init__(self):
+        self.count = 0
+
+    def inc(self):
+        self.count += 1
+
+
+class DummyMonitor:
+    def __init__(self):
+        self.clock_sync_fail = DummyCounter()
+
+
+def test_sync_clock_updates_skew(monkeypatch):
+    clock.clock_skew_ms = 0.0
+    clock.last_sync_at = 0.0
+
+    times = iter([1000, 2000, 3000, 4000])
+    monkeypatch.setattr(clock, "system_utc_ms", lambda: next(times))
+
+    class DummyClient:
+        def __init__(self):
+            self.calls = 0
+            self.responses = [(1075, 50), (2050, 100), (3095, 10)]
+
+        def get_server_time(self):
+            resp = self.responses[self.calls]
+            self.calls += 1
+            return resp
+
+    cfg = ClockSyncConfig(attempts=3, ema_alpha=1.0, max_step_ms=1000.0)
+    monitor = DummyMonitor()
+    client = DummyClient()
+
+    drift = clock.sync_clock(client, cfg, monitor)
+    assert drift == clock.clock_skew()
+    assert clock.clock_skew() == 100.0
+    assert clock.last_sync_at == 4000
+
+    monkeypatch.setattr(clock, "system_utc_ms", lambda: 4500)
+    assert clock.last_sync_age_sec() == 0.5
+
+
+def test_sync_clock_failure(monkeypatch):
+    clock.clock_skew_ms = 42.0
+    clock.last_sync_at = 0.0
+
+    class BadClient:
+        def get_server_time(self):
+            raise RuntimeError("boom")
+
+    cfg = ClockSyncConfig(attempts=1)
+    monitor = DummyMonitor()
+    drift = clock.sync_clock(BadClient(), cfg, monitor)
+    assert drift == 42.0
+    assert clock.clock_skew() == 42.0
+    assert clock.last_sync_at == 0.0
+    assert monitor.clock_sync_fail.count == 1


### PR DESCRIPTION
## Summary
- add clock skew tracking and clock sync routine
- expose clock helpers for current time and skew age
- extend ClockSyncConfig with tuning parameters

## Testing
- `pytest` *(failed: collection errors in unrelated tests)*
- `pytest tests/test_clock.py tests/test_clock_sync_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5b8eecbcc832f8644bf30f50409b5