### PR TITLE
Add periodic clock synchronization with safe mode

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -39,8 +39,9 @@ class Components(BaseModel):
 class ClockSyncConfig(BaseModel):
     """Настройки синхронизации часов между процессами."""
 
-    refresh: float = Field(default=60.0, description="How often to refresh clock sync in seconds")
-    threshold: float = Field(default=1.0, description="Threshold in seconds to trigger resync")
+    refresh_sec: float = Field(default=60.0, description="How often to refresh clock sync in seconds")
+    warn_threshold_ms: float = Field(default=500.0, description="Log warning if drift exceeds this many ms")
+    kill_threshold_ms: float = Field(default=2000.0, description="Enter safe mode if drift exceeds this many ms")
     attempts: int = Field(default=5, description="Number of samples per sync attempt")
     ema_alpha: float = Field(default=0.1, description="EMA coefficient for skew updates")
     max_step_ms: float = Field(default=1000.0, description="Maximum skew adjustment per sync in ms")

--- a/tests/test_clock_sync_config.py
+++ b/tests/test_clock_sync_config.py
@@ -40,10 +40,12 @@ def test_clock_sync_config_loading():
           symbols: ["BTCUSDT"]
           timeframe: "1m"
         clock_sync:
-          refresh: 123
-          threshold: 456
+          refresh_sec: 123
+          warn_threshold_ms: 456
+          kill_threshold_ms: 789
         """
     )
     cfg = load_config_from_str(yaml_cfg)
-    assert cfg.clock_sync.refresh == 123
-    assert cfg.clock_sync.threshold == 456
+    assert cfg.clock_sync.refresh_sec == 123
+    assert cfg.clock_sync.warn_threshold_ms == 456
+    assert cfg.clock_sync.kill_threshold_ms == 789


### PR DESCRIPTION
## Summary
- extend clock sync configuration with warning and kill thresholds
- spawn background clock sync loop with backoff and safe mode
- provider suppresses orders when clock drift exceeds kill threshold

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*
- `pytest tests/test_clock.py tests/test_clock_sync_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb989188832fa695f00ceb5047b2