### PR TITLE
Use centralized clock utilities for timing

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -5,8 +5,8 @@ import asyncio
 import json
 import logging
 import random
-import time
 from typing import Awaitable, Callable, List
+from clock import now_ms
 
 from decimal import Decimal
 
@@ -95,15 +95,15 @@ class BinanceWS:
             self._rl_total += 1
             return True
         self._rl_total += 1
-        allowed, status = self._rate_limiter.can_send()
+        allowed, status = self._rate_limiter.can_send(now_ms() / 1000.0)
         if allowed:
             return True
         if status == "rejected":
             self._rl_delayed += 1
-            wait = max(self._rate_limiter._cooldown_until - time.time(), 0.0)
+            wait = max(self._rate_limiter._cooldown_until - now_ms() / 1000.0, 0.0)
             if wait > 0:
                 await asyncio.sleep(wait)
-            allowed, _ = self._rate_limiter.can_send()
+            allowed, _ = self._rate_limiter.can_send(now_ms() / 1000.0)
             return allowed
         self._rl_dropped += 1
         return False

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -25,11 +25,11 @@ ExecutionSimulator v2
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, Any, Dict, Sequence
 import math
-import time
 import os
 import logging
 import threading
 import random
+from clock import now_ms
 
 try:
     from runtime_flags import seasonality_enabled  # type: ignore
@@ -1190,7 +1190,7 @@ class ExecutionSimulator:
                 proto=proto,
                 client_order_id=cid,
                 remaining_lat=remaining,
-                timestamp=int(now_ts or int(time.time() * 1000)),
+                timestamp=int(now_ts or now_ms()),
                 lat_ms=int(lat_ms),
                 timeout=bool(timeout),
                 spike=bool(spike),
@@ -1323,7 +1323,7 @@ class ExecutionSimulator:
         new_order_pos: List[int] = []
         fee_total: float = 0.0
 
-        ts = int(now_ts or int(time.time() * 1000))
+        ts = int(now_ts or now_ms())
         ref = self._ref(ref_price)
         self._vwap_on_tick(ts, ref, self._last_liquidity)
 

--- a/risk_guard.py
+++ b/risk_guard.py
@@ -1,11 +1,11 @@
 # risk_guard.py
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass, asdict
 from enum import IntEnum
 from typing import Optional, Deque, Tuple, Dict, Any, TYPE_CHECKING
 from collections import deque
+from clock import now_ms
 
 if TYPE_CHECKING:
     from core_contracts import RiskGuards
@@ -47,7 +47,7 @@ class RiskConfig:
     bankruptcy_cash_th: float = -1e12     # порог банкротства по кэшу
 
     # Технические опции
-    ts_provider: callable = lambda: int(time.time_ns())  # нано-время
+    ts_provider: callable = lambda: now_ms()
 
 
 class RiskGuard:


### PR DESCRIPTION
## Summary
- use clock.now_ms for default timestamps in RiskGuard
- replace time.time usage in execution simulator with now_ms
- rely on wall-clock milliseconds for rate limiting and latency checks in mediator and BinanceWS

## Testing
- `pytest -q` *(fails: assert [] == [1], etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bd22a194832f867a7287f9e21ab7