### PR TITLE
Propagate final flag in Binance WS bar creation

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -148,7 +148,7 @@ class BinanceWS:
                                         close=Decimal(k.get("c", 0.0)),
                                         volume_base=Decimal(k.get("v", 0.0)),
                                         trades=int(k.get("n", 0)),
-                                        is_final=True,
+                                        is_final=bool(k.get("x", False)),
                                     )
                                 except Exception:
                                     continue


### PR DESCRIPTION
## Summary
- Set `Bar.is_final` using kline `x` field instead of constant `True`
- Preserve filtering of unfinished bars based on `k["x"]`

## Testing
- `pytest tests/test_rate_limiter.py tests/test_degradation_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c723a428832fb3e43eb6cda3e7f6