### PR TITLE
Add bar-close filtering to no-trade mask

### DIFF
--- a/tests/run_no_trade_mask_sample.py
+++ b/tests/run_no_trade_mask_sample.py
@@ -15,6 +15,8 @@ def run(mode: str | None) -> None:
         "--data", os.path.join(REPO, "tests/data/no_trade_sample.csv"),
         "--out", out,
         "--sandbox_config", os.path.join(REPO, "configs/legacy_sandbox.yaml"),
+        "--timeframe", "1m",
+        "--close-lag-ms", "0",
     ]
     if mode:
         sys.argv += ["--mode", mode]


### PR DESCRIPTION
## Summary
- allow specifying timeframe and close-lag when applying the no-trade mask
- exclude rows where the bar hasn't closed yet and combine with existing mask

## Testing
- `python tests/run_no_trade_mask_sample.py`
- `pytest tests/test_no_trade_ratio.py tests/test_no_trade_mask.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5cfd720b0832faf696e8a6292f560