### PR TITLE
Add websocket deduplication config

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -69,6 +69,14 @@ class TimingConfig(BaseModel):
     close_lag_ms: int = Field(default=2000)
 
 
+class WSDedupConfig(BaseModel):
+    """Конфигурация дедупликации данных вебсокета."""
+
+    enabled: bool = Field(default=False)
+    persist_path: str = Field(default="state/last_bar_seen.json")
+    log_skips: bool = Field(default=False)
+
+
 class CommonRunConfig(BaseModel):
     run_id: Optional[str] = Field(
         default=None, description="Идентификатор запуска; если None — генерируется."
@@ -94,6 +102,7 @@ class CommonRunConfig(BaseModel):
     )
     timing: TimingConfig = Field(default_factory=TimingConfig)
     clock_sync: ClockSyncConfig = Field(default_factory=ClockSyncConfig)
+    ws_dedup: WSDedupConfig = Field(default_factory=WSDedupConfig)
     components: Components
 
 
@@ -285,6 +294,7 @@ __all__ = [
     "Components",
     "ClockSyncConfig",
     "TimingConfig",
+    "WSDedupConfig",
     "CommonRunConfig",
     "SimulationDataConfig",
     "SimulationConfig",

--- a/tests/test_ws_dedup_config.py
+++ b/tests/test_ws_dedup_config.py
@@ -1,0 +1,62 @@
+import textwrap
+import sys
+import pathlib
+
+# Ensure stdlib logging is used instead of local logging.py
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_orig_sys_path = list(sys.path)
+sys.path = [p for p in sys.path if p not in ("", str(REPO_ROOT))]
+import logging as std_logging  # type: ignore
+sys.modules["logging"] = std_logging
+sys.path = _orig_sys_path
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core_config import load_config_from_str
+
+
+BASE_YAML = textwrap.dedent(
+    """
+    mode: sim
+    symbols: ["BTCUSDT"]
+    components:
+      market_data:
+        target: "module:Cls"
+        params: {}
+      executor:
+        target: "module:Cls"
+        params: {}
+      feature_pipe:
+        target: "module:Cls"
+        params: {}
+      policy:
+        target: "module:Cls"
+        params: {}
+      risk_guards:
+        target: "module:Cls"
+        params: {}
+    data:
+      symbols: ["BTCUSDT"]
+      timeframe: "1m"
+    """
+)
+
+
+def test_ws_dedup_defaults_and_override():
+    cfg = load_config_from_str(BASE_YAML)
+    assert cfg.ws_dedup.enabled is False
+    assert cfg.ws_dedup.persist_path == "state/last_bar_seen.json"
+    assert cfg.ws_dedup.log_skips is False
+
+    yaml_with_dedup = BASE_YAML + textwrap.dedent(
+        """
+        ws_dedup:
+          enabled: true
+          persist_path: "custom.json"
+          log_skips: true
+        """
+    )
+    cfg2 = load_config_from_str(yaml_with_dedup)
+    assert cfg2.ws_dedup.enabled is True
+    assert cfg2.ws_dedup.persist_path == "custom.json"
+    assert cfg2.ws_dedup.log_skips is True


### PR DESCRIPTION
## Summary
- add `WSDedupConfig` for websocket deduplication settings with sensible defaults
- expose `ws_dedup` field on `CommonRunConfig`
- test loading defaults and overrides for websocket dedup config

## Testing
- `pytest tests/test_ws_dedup_config.py -q`
- `pytest -q` *(fails: assert [] == [1]; assert 0 == 1; more failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c632ccb77c832f9f9e2f0282bcc372