### PR TITLE
Add ws_dedup runtime configuration example

### DIFF
--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -6,3 +6,8 @@ clock_sync:
   max_step_ms: 1000       # Max single adjustment step in milliseconds
   attempts: 5             # Number of sync attempts before giving up
 
+ws_dedup:
+  enabled: true
+  persist_path: state/last_bar_seen.json
+  log_skips: true
+


### PR DESCRIPTION
## Summary
- document websocket deduplication runtime options in ops config

## Testing
- `pytest tests/test_ws_dedup_config.py::test_ws_dedup_defaults_and_override tests/test_clock_sync_config.py::test_clock_sync_config_loading -q`


------
https://chatgpt.com/codex/tasks/task_e_68c635648cd0832f97f949caea719306