### PR TITLE
Add websocket duplicate skip counter

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -52,6 +52,13 @@ skipped_incomplete_bars = Counter(
     ["symbol"],
 )
 
+# Websocket duplicates skipped
+ws_dup_skipped_count = Counter(
+    "ws_dup_skipped_count",
+    "WS duplicates skipped",
+    ["symbol"],
+)
+
 _last_sync_ts_ms: float = 0.0
 
 
@@ -103,6 +110,7 @@ def clock_sync_age_seconds() -> float:
 
 __all__ = [
     "skipped_incomplete_bars",
+    "ws_dup_skipped_count",
     "clock_sync_fail",
     "clock_sync_success",
     "report_clock_sync",


### PR DESCRIPTION
## Summary
- track skipped websocket duplicates using ws_dup_skipped_count

## Testing
- `pytest` *(fails: tests/test_execution_rules.py::test_unquantized_limit_rejected_sim, tests/test_execution_rules.py::test_ttl_two_steps_sim, tests/test_limit_mid_bps_profile.py::test_limit_mid_bps_profile, tests/test_limit_order_ttl.py::test_limit_order_ttl_expires, tests/test_limit_order_ttl.py::test_limit_order_ttl_survives, tests/test_limit_order_ttl.py::test_limit_order_ioc_partial_cancel, tests/test_limit_order_ttl.py::test_limit_order_fok_partial_cancel, tests/test_market_open_h1.py::test_market_open_next_h1_slippage, tests/test_market_open_h1.py::test_market_open_next_h1_snapshot_price, tests/test_no_trade_mask.py::test_funding_buffer_blocks_orders, tests/test_no_trade_mask.py::test_custom_window_blocks_orders)`

------
https://chatgpt.com/codex/tasks/task_e_68c637a4c59c832fb257b31104e345f4