### PR TITLE
Implement persistent close state management module

### DIFF
--- a/tests/test_ws_dedup_state.py
+++ b/tests/test_ws_dedup_state.py
@@ -1,0 +1,42 @@
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import ws_dedup_state as s
+
+
+def test_load_update_and_flush(tmp_path, caplog):
+    state_file = tmp_path / "state.json"
+
+    # load_state should handle missing file
+    with caplog.at_level(logging.INFO):
+        s.load_state(state_file)
+    assert s.STATE == {}
+    assert "does not exist" in caplog.text
+
+    # initial update persists immediately
+    s.update("BTCUSDT", 1000, path=state_file)
+    assert json.loads(state_file.read_text()) == {"BTCUSDT": 1000}
+    assert s.should_skip("BTCUSDT", 1000)
+    assert s.should_skip("BTCUSDT", 900)
+    assert not s.should_skip("BTCUSDT", 1100)
+
+    # update without auto flush
+    s.update("ETHUSDT", 2000, path=state_file, auto_flush=False)
+    # file not yet updated
+    assert json.loads(state_file.read_text()) == {"BTCUSDT": 1000}
+    # flush manually
+    s.flush(state_file)
+    assert json.loads(state_file.read_text()) == {
+        "BTCUSDT": 1000,
+        "ETHUSDT": 2000,
+    }
+
+    # reload from disk
+    s.STATE.clear()
+    with caplog.at_level(logging.INFO):
+        s.load_state(state_file)
+    assert s.STATE == {"BTCUSDT": 1000, "ETHUSDT": 2000}
+    assert "Loaded 2 symbols" in caplog.text

--- a/ws_dedup_state.py
+++ b/ws_dedup_state.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Dict
+import sys
+import sysconfig
+
+# Ensure we use stdlib logging despite local logging module
+_stdlib_path = sysconfig.get_path("stdlib")
+if _stdlib_path:
+    sys.path.insert(0, _stdlib_path)
+import logging as _std_logging
+if _stdlib_path:
+    sys.path.pop(0)
+
+logger = _std_logging.getLogger(__name__)
+
+# Global state mapping symbol -> last close timestamp in ms
+STATE: Dict[str, int] = {}
+_lock = threading.Lock()
+
+# Default persistence location
+PERSIST_PATH = Path("state/close_state.json")
+
+def load_state(path: str | Path = PERSIST_PATH) -> None:
+    """Load state dictionary from JSON file if it exists.
+
+    Parameters
+    ----------
+    path: str | Path
+        Path to JSON file storing state.
+    """
+    p = Path(path)
+    if not p.exists():
+        logger.info("State file %s does not exist; starting empty", p)
+        return
+
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        logger.exception("Failed reading state file %s", p)
+        return
+
+    with _lock:
+        STATE.clear()
+        STATE.update({str(k): int(v) for k, v in data.items()})
+    logger.info("Loaded %d symbols from %s", len(STATE), p)
+
+def should_skip(symbol: str, close_ms: int) -> bool:
+    """Return True if ``close_ms`` is not newer than stored value for ``symbol``."""
+    with _lock:
+        prev = STATE.get(symbol)
+    return prev is not None and close_ms <= prev
+
+def _atomic_write(path: Path) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(STATE, separators=(",", ":")))
+    tmp.replace(path)
+
+def flush(path: str | Path = PERSIST_PATH) -> None:
+    """Persist current state to disk using atomic replace."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with _lock:
+        _atomic_write(p)
+
+
+def update(
+    symbol: str,
+    close_ms: int,
+    *,
+    path: str | Path = PERSIST_PATH,
+    auto_flush: bool = True,
+) -> None:
+    """Update state for symbol and optionally flush to disk."""
+    with _lock:
+        STATE[symbol] = close_ms
+        if auto_flush:
+            p = Path(path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(p)


### PR DESCRIPTION
## Summary
- add `ws_dedup_state` module with thread-safe in-memory cache and JSON persistence
- include helpers to load, update, flush, and skip updates based on stored close timestamps
- cover state persistence with unit tests

## Testing
- `pytest tests/test_ws_dedup_state.py -q`
- `pytest tests/test_ws_dedup_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c63b34505c832f8e636fc870133584