### PR TITLE
Add default signals configuration

### DIFF
--- a/configs/signals.yaml
+++ b/configs/signals.yaml
@@ -1,0 +1,4 @@
+enabled: false            # Enable or disable signal generation
+out_csv: "signals.csv"    # Path to write signals CSV (null to disable)
+ttl_seconds: 60           # Time-to-live for signal cache entries
+dedup_persist: null       # Path to dedup persistence file or null for in-memory only


### PR DESCRIPTION
## Summary
- add `configs/signals.yaml` with defaults for signal generation

## Testing
- `pytest -q` *(fails: assert [] == [1], TypeError: Unsupported action type, AttributeError: 'NoneType' object has no attribute 'min_half_spread_bps')*

------
https://chatgpt.com/codex/tasks/task_e_68c64c138688832f9aea65cc2ceb9392