### PR TITLE
Publish signals after order logging

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -128,9 +128,10 @@ class _Provider:
         fh = str(feats.get("features_hash", "") or "")
 
         for o in orders:
+            side = getattr(o, "side", "")
+            side = side.value if hasattr(side, "value") else str(side)
+            side = str(side).upper()
             if out_csv:
-                side = getattr(o, "side", "")
-                side = side.value if hasattr(side, "value") else str(side)
                 vol = getattr(o, "volume_frac", None)
                 if vol is None:
                     vol = getattr(o, "quantity", 0)
@@ -154,6 +155,16 @@ class _Provider:
                 self._logger.info("order %s", o)
             except Exception:
                 pass
+            if getattr(signal_bus, "ENABLED", False):
+                try:
+                    signal_bus.publish_signal(
+                        ts_ms=int(bar.ts),
+                        symbol=bar.symbol,
+                        side=side,
+                        bar_close_ms=int(bar.ts),
+                    )
+                except Exception:
+                    pass
             submit = getattr(self._executor, "submit", None)
             if callable(submit):
                 try:


### PR DESCRIPTION
## Summary
- emit signals on order logging via `signal_bus.publish_signal`
- guard publishing by checking signal bus `ENABLED`
- reuse order side string across CSV logging and signal publishing

## Testing
- `PYTHONPATH=/root/.pyenv/versions/3.12.10/lib/python3.12:/workspace/TradingBot python -m pytest TradingBot` *(fails: collection errors in tests/test_close_shift.py, tests/test_leak_guard_env.py, tests/test_no_trade_config_shared.py, tests/test_no_trade_mask.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c654e7b750832f8d1ce570125bd0a7