### PR TITLE
Extract order metadata for signals

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -124,10 +124,9 @@ class _Provider:
             "score",
             "features_hash",
         ]
-        score = float(feats.get("score", 0) or 0)
-        fh = str(feats.get("features_hash", "") or "")
-
         for o in orders:
+            score = float(getattr(o, "score", 0) or 0)
+            fh = str(getattr(o, "features_hash", "") or "")
             side = getattr(o, "side", "")
             side = side.value if hasattr(side, "value") else str(side)
             side = str(side).upper()
@@ -161,6 +160,8 @@ class _Provider:
                         ts_ms=int(bar.ts),
                         symbol=bar.symbol,
                         side=side,
+                        score=score,
+                        features_hash=fh,
                         bar_close_ms=int(bar.ts),
                     )
                 except Exception:

--- a/tests/test_signal_bus.py
+++ b/tests/test_signal_bus.py
@@ -33,3 +33,17 @@ def test_publish_signal_dedup(tmp_path):
     assert sb.publish_signal("BTCUSDT", 1, {"p": 3}, send_fn, ttl_ms=100, now_ms=now + 200)
     assert sent == [{"p": 1}, {"p": 3}]
     assert sb._SEEN[sid] == now + 200 + 100
+
+
+def test_publish_signal_payload_fields(tmp_path):
+    sb._STATE_PATH = tmp_path / "seen.json"
+    sb._SEEN.clear()
+
+    captured = []
+
+    def send_fn(payload):
+        captured.append(payload)
+
+    payload = {"score": 1.23, "features_hash": "abc"}
+    assert sb.publish_signal("ETHUSDT", 2, payload, send_fn, ttl_ms=100, now_ms=1000)
+    assert captured == [payload]


### PR DESCRIPTION
## Summary
- derive `score` and `features_hash` from each order when logging
- forward these attributes through `publish_signal`
- test that signal bus keeps custom payload fields

## Testing
- `pytest tests/test_signal_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c65668aa7c832f9be5e19be4f8a324