### PR TITLE
feat: persist signal bus state

### DIFF
--- a/tests/test_signal_bus.py
+++ b/tests/test_signal_bus.py
@@ -1,4 +1,6 @@
 import sys
+import json
+import time
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -10,6 +12,8 @@ def test_publish_signal_dedup(tmp_path):
     # redirect state path to temporary location to avoid polluting repo
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()
+    sb._loaded = False
+    sb.load_state()
 
     sent = []
     now = 1000
@@ -38,6 +42,8 @@ def test_publish_signal_dedup(tmp_path):
 def test_publish_signal_payload_fields(tmp_path):
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()
+    sb._loaded = False
+    sb.load_state()
 
     captured = []
 
@@ -47,3 +53,38 @@ def test_publish_signal_payload_fields(tmp_path):
     payload = {"score": 1.23, "features_hash": "abc"}
     assert sb.publish_signal("ETHUSDT", 2, payload, send_fn, ttl_ms=100, now_ms=1000)
     assert captured == [payload]
+
+
+def test_load_and_flush_state(tmp_path):
+    sb._STATE_PATH = tmp_path / "seen.json"
+    sb._SEEN.clear()
+    sb._loaded = False
+    sb.load_state()
+    assert sb._SEEN == {}
+
+    now = int(time.time() * 1000)
+    sid = sb.signal_id("BTCUSDT", 1)
+    sb.mark_emitted(sid, expires_at_ms=now + 100, now_ms=now)
+    assert json.loads(sb._STATE_PATH.read_text()) == {sid: now + 100}
+
+    # Add expired entry and ensure mark_emitted purges it
+    expired_sid = sb.signal_id("ETHUSDT", 2)
+    sb._SEEN[expired_sid] = now - 1
+    sb.flush_state()
+    sb.mark_emitted(sid, expires_at_ms=now + 200, now_ms=now)
+    data = json.loads(sb._STATE_PATH.read_text())
+    assert expired_sid not in data
+    assert data[sid] == now + 200
+
+    # Prepare file with expired and valid entries to test load_state purge
+    valid_sid = sid
+    future_exp = now + 5000
+    past_exp = now - 5000
+    sb._STATE_PATH.write_text(
+        json.dumps({valid_sid: future_exp, expired_sid: past_exp})
+    )
+    sb._SEEN.clear()
+    sb._loaded = False
+    sb.load_state()
+    assert sb._SEEN == {valid_sid: future_exp}
+    assert json.loads(sb._STATE_PATH.read_text()) == {valid_sid: future_exp}


### PR DESCRIPTION
## Summary
- persist signal bus deduplication map with new `load_state` and `flush_state`
- ensure state loads lazily and mark_emitted purges expired entries before saving
- test signal bus persistence and dedup behavior

## Testing
- `pytest tests/test_signal_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c65790a758832f8db4afabf706a997