### PR TITLE
Check enabled flag before publishing signals

### DIFF
--- a/services/signal_bus.py
+++ b/services/signal_bus.py
@@ -7,6 +7,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict
+from dataclasses import dataclass
 
 # Путь к файлу состояния
 _STATE_PATH = Path("state/seen_signals.json")
@@ -15,6 +16,14 @@ _STATE_PATH = Path("state/seen_signals.json")
 _SEEN: Dict[str, int] = {}
 _lock = threading.Lock()
 _loaded = False
+
+
+@dataclass
+class _Config:
+    enabled: bool = True
+
+
+config = _Config()
 
 
 def signal_id(symbol: str, bar_close_ms: int) -> str:
@@ -127,6 +136,8 @@ def publish_signal(
 
     Возвращает True, если сигнал был отправлен, иначе False.
     """
+    if not config.enabled:
+        return False
     _ensure_loaded()
     sid = signal_id(symbol, bar_close_ms)
     if already_emitted(sid, now_ms=now_ms):

--- a/tests/test_signal_bus.py
+++ b/tests/test_signal_bus.py
@@ -55,6 +55,26 @@ def test_publish_signal_payload_fields(tmp_path):
     assert captured == [payload]
 
 
+def test_publish_signal_disabled(tmp_path):
+    sb._STATE_PATH = tmp_path / "seen.json"
+    sb._SEEN.clear()
+    sb._loaded = False
+    sb.load_state()
+
+    sent = []
+
+    def send_fn(payload):
+        sent.append(payload)
+
+    sb.config.enabled = False
+    try:
+        assert not sb.publish_signal("BTCUSDT", 1, {"p": 1}, send_fn, ttl_ms=100, now_ms=0)
+        assert sent == []
+        assert sb._SEEN == {}
+    finally:
+        sb.config.enabled = True
+
+
 def test_load_and_flush_state(tmp_path):
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()


### PR DESCRIPTION
## Summary
- add simple config object with `enabled` flag to `signal_bus`
- skip publishing and state operations when signal bus is disabled
- test that signals aren't sent when disabled

## Testing
- `pytest tests/test_signal_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c658fc589c832f9bca3cab2fbffee2