### PR TITLE
Add default TTL config blocks

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -23,6 +23,11 @@ clock_sync:
   kill_threshold_ms: 2000 # Terminate if drift exceeds this many milliseconds
   max_step_ms: 1000       # Max single adjustment step in milliseconds
   attempts: 5             # Number of sync attempts before giving up
+ttl:
+  enabled: false
+  ttl_seconds: 60
+  out_csv: null
+  dedup_persist: null
 api:
   api_key: null
   api_secret: null

--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -11,3 +11,9 @@ ws_dedup:
   persist_path: state/last_bar_seen.json
   log_skips: true
 
+ttl:
+  enabled: false
+  ttl_seconds: 60
+  out_csv: null
+  dedup_persist: null
+


### PR DESCRIPTION
## Summary
- add default TTL settings to live runtime config
- include same TTL configuration in ops settings

## Testing
- `make lint`
- `pytest` *(fails: assert [] == [1]; other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c66d2868d8832f984118b3494cda76