### PR TITLE
Add signal metrics for TTL and publish monitoring

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -139,6 +139,7 @@ class _Provider:
                     pass
                 try:
                     monitoring.ttl_expired_boundary_count.labels(bar.symbol).inc()
+                    monitoring.signal_boundary_count.labels(bar.symbol).inc()
                 except Exception:
                     pass
                 continue
@@ -178,12 +179,16 @@ class _Provider:
                     )
                 except Exception:
                     pass
+                try:
+                    monitoring.signal_absolute_count.labels(bar.symbol).inc()
+                except Exception:
+                    pass
                 continue
 
             try:
                 age_ms = now_ms - created_ts
-                monitoring.signal_publish_age_ms.labels(bar.symbol).observe(age_ms)
-                monitoring.signal_publish_count.labels(bar.symbol).inc()
+                monitoring.age_at_publish_ms.labels(bar.symbol).observe(age_ms)
+                monitoring.signal_published_count.labels(bar.symbol).inc()
             except Exception:
                 pass
 

--- a/utils/prometheus.py
+++ b/utils/prometheus.py
@@ -7,7 +7,7 @@ metrics calls do not fail in environments without Prometheus support.
 from __future__ import annotations
 
 try:  # pragma: no cover - simple import
-    from prometheus_client import Counter  # type: ignore
+    from prometheus_client import Counter, Histogram  # type: ignore
 except Exception:  # pragma: no cover - fallback for missing dependency
     class _DummyCounter:
         def __init__(self, *args, **kwargs) -> None:
@@ -19,4 +19,17 @@ except Exception:  # pragma: no cover - fallback for missing dependency
         def inc(self, *args, **kwargs) -> None:
             pass
 
+    class _DummyHistogram:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def labels(self, *args, **kwargs) -> "_DummyHistogram":
+            return self
+
+        def observe(self, *args, **kwargs) -> None:
+            pass
+
     Counter = _DummyCounter  # type: ignore
+    Histogram = _DummyHistogram  # type: ignore
+
+__all__ = ["Counter", "Histogram"]


### PR DESCRIPTION
## Summary
- Add Histogram fallback to `utils.prometheus`
- Track boundary, absolute, and published signal counts in monitoring
- Record signal age at publish with `age_at_publish_ms`

## Testing
- `pytest` *(fails: assert [] == [1]; assert 0 == 1; assert [10.0] == [5.0]; AttributeError: 'NoneType' object has no attribute ...; TypeError: Unsupported action type)*


------
https://chatgpt.com/codex/tasks/task_e_68c67294bc68832f903c9ace42627209