### PR TITLE
Add throttle configuration

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -86,6 +86,31 @@ class TTLConfig(BaseModel):
     dedup_persist: Optional[str] = Field(default=None)
 
 
+class TokenBucketConfig(BaseModel):
+    """Token bucket limiter settings."""
+
+    rps: float = 0.0
+    burst: int = 0
+
+
+class ThrottleQueueConfig(BaseModel):
+    """Settings for queued throttle mode."""
+
+    max_items: int = 0
+    ttl_ms: int = 0
+
+
+class ThrottleConfig(BaseModel):
+    """Global throttling configuration."""
+
+    enabled: bool = False
+    global_: TokenBucketConfig = Field(default_factory=TokenBucketConfig, alias="global")
+    symbol: TokenBucketConfig = Field(default_factory=TokenBucketConfig)
+    mode: str = "drop"
+    queue: ThrottleQueueConfig = Field(default_factory=ThrottleQueueConfig)
+    time_source: str = "monotonic"
+
+
 class CommonRunConfig(BaseModel):
     run_id: Optional[str] = Field(
         default=None, description="Идентификатор запуска; если None — генерируется."
@@ -113,6 +138,7 @@ class CommonRunConfig(BaseModel):
     clock_sync: ClockSyncConfig = Field(default_factory=ClockSyncConfig)
     ws_dedup: WSDedupConfig = Field(default_factory=WSDedupConfig)
     ttl: TTLConfig = Field(default_factory=TTLConfig)
+    throttle: ThrottleConfig = Field(default_factory=ThrottleConfig)
     components: Components
 
 


### PR DESCRIPTION
## Summary
- add token bucket, queue and throttle configuration models
- expose throttle settings via CommonRunConfig

## Testing
- `pytest` *(fails: tests/test_execution_rules.py::test_unquantized_limit_rejected_sim - assert [] == [1]; tests/test_execution_rules.py::test_ttl_two_steps_sim - assert [] == [1]; tests/test_limit_mid_bps_profile.py::test_limit_mid_bps_profile - AssertionError: assert 0 == 1; tests/test_limit_order_ttl.py::test_limit_order_ttl_expires - assert [] == [1]; tests/test_limit_order_ttl.py::test_limit_order_ttl_survives - assert [] == [1]; tests/test_limit_order_ttl.py::test_limit_order_ioc_partial_cancel - assert [10.0] == [5.0]; tests/test_limit_order_ttl.py::test_limit_order_fok_partial_cancel - AssertionError: assert [ExecTrade(ts... ttl_steps...); tests/test_market_open_h1.py::test_market_open_next_h1_slippage - AttributeError: 'NoneType' object has no attribute ...; tests/test_market_open_h1.py::test_market_open_next_h1_snapshot_price - AttributeError: 'NoneType' object has no attribute ...; tests/test_no_trade_mask.py::test_funding_buffer_blocks_orders - TypeError: Unsupported action type; tests/test_no_trade_mask.py::test_custom_window_blocks_orders - TypeError: Unsupported action type)*

------
https://chatgpt.com/codex/tasks/task_e_68c6983c6c04832faa8219f68fa63b7f