### PR TITLE
Add throttle configuration to ops and live configs

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -28,6 +28,19 @@ ttl:
   ttl_seconds: 60
   out_csv: null
   dedup_persist: null
+throttle:
+  enabled: false              # disable throttling
+  global:
+    rps: 0.0                  # requests per second; 0 disables
+    burst: 0                  # burst capacity
+  symbol:
+    rps: 0.0                  # per-symbol RPS limit
+    burst: 0
+  mode: drop                  # drop or queue
+  queue:
+    max_items: 0              # queue size when mode=queue
+    ttl_ms: 0                 # item lifetime in ms
+  time_source: "monotonic"
 api:
   api_key: null
   api_secret: null

--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -17,3 +17,17 @@ ttl:
   out_csv: null
   dedup_persist: null
 
+throttle:
+  enabled: false              # disable throttling
+  global:
+    rps: 0.0                  # requests per second; 0 disables
+    burst: 0                  # burst capacity
+  symbol:
+    rps: 0.0                  # per-symbol RPS limit
+    burst: 0
+  mode: drop                  # drop or queue
+  queue:
+    max_items: 0              # queue size when mode=queue
+    ttl_ms: 0                 # item lifetime in ms
+  time_source: "monotonic"
+


### PR DESCRIPTION
## Summary
- add throttle block to ops and live YAML configs
- define global/symbol token bucket settings, mode, queue, and time source defaults

## Testing
- `pytest -q` *(fails: test_execution_rules::test_unquantized_limit_rejected_sim, test_execution_rules::test_ttl_two_steps_sim, test_limit_mid_bps_profile::test_limit_mid_bps_profile, test_limit_order_ttl::test_limit_order_ttl_expires, test_limit_order_ttl::test_limit_order_ttl_survives, test_limit_order_ttl::test_limit_order_ioc_partial_cancel, test_limit_order_ttl::test_limit_order_fok_partial_cancel, test_market_open_h1::test_market_open_next_h1_slippage, test_market_open_h1::test_market_open_next_h1_snapshot_price, test_no_trade_mask::test_funding_buffer_blocks_orders, test_no_trade_mask::test_custom_window_blocks_orders)*

------
https://chatgpt.com/codex/tasks/task_e_68c69a1ac330832f9991b41134a7a843