### PR TITLE
Add TokenBucket rate limiter

### DIFF
--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -22,7 +22,7 @@ import logging
 from unittest.mock import MagicMock
 import pytest
 
-from utils import SignalRateLimiter
+from utils import SignalRateLimiter, TokenBucket
 
 # provide dummy websockets module for importing binance_ws without dependency
 class _DummyWS:
@@ -31,6 +31,17 @@ sys.modules.setdefault("websockets", _DummyWS())
 
 import binance_public
 import binance_ws
+
+
+# --- TokenBucket tests ---
+
+def test_token_bucket_basic():
+    tb = TokenBucket(rps=2.0, burst=4.0, tokens=4.0, last_ts=0.0)
+    assert tb.consume(tokens=1, now=0.0)
+    assert tb.tokens == pytest.approx(3.0)
+    assert tb.consume(tokens=4, now=0.5)
+    assert tb.tokens == pytest.approx(0.0)
+    assert not tb.consume(tokens=1, now=0.5)
 
 
 # --- SignalRateLimiter tests ---

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,6 +1,6 @@
 from .time import hour_of_week, HOUR_MS, HOURS_IN_WEEK
 from .moving_average import simple_moving_average
-from .rate_limiter import SignalRateLimiter
+from .rate_limiter import SignalRateLimiter, TokenBucket
 
 __all__ = [
     "hour_of_week",
@@ -8,4 +8,5 @@ __all__ = [
     "HOURS_IN_WEEK",
     "simple_moving_average",
     "SignalRateLimiter",
+    "TokenBucket",
 ]

--- a/utils/rate_limiter.py
+++ b/utils/rate_limiter.py
@@ -6,6 +6,25 @@ from typing import Literal, Tuple
 
 
 @dataclass
+class TokenBucket:
+    """Simple token bucket rate limiter."""
+
+    rps: float
+    burst: float
+    tokens: float = 0.0
+    last_ts: float = field(default_factory=time.monotonic)
+
+    def consume(self, tokens: float = 1, now: float | None = None) -> bool:
+        ts = time.monotonic() if now is None else now
+        self.tokens = min(self.burst, self.tokens + (ts - self.last_ts) * self.rps)
+        self.last_ts = ts
+        if self.tokens >= tokens:
+            self.tokens -= tokens
+            return True
+        return False
+
+
+@dataclass
 class SignalRateLimiter:
     """Simple rate limiter with exponential backoff.
 


### PR DESCRIPTION
## Summary
- implement TokenBucket dataclass for rate limiting using monotonic time
- expose TokenBucket via utils package
- cover TokenBucket behavior with unit tests

## Testing
- `pytest tests/test_rate_limiter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69af9ac40832f9da801a6d475bc77