### PR TITLE
Expose clock sync gauges in monitoring

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -22,15 +22,15 @@ except Exception:  # pragma: no cover - fallback when prometheus_client is missi
     Gauge = _DummyGauge  # type: ignore
 
 # Gauges for latest clock sync measurements
-_CLOCK_SYNC_DRIFT_MS = Gauge(
+clock_sync_drift_ms = Gauge(
     "clock_sync_drift_ms",
     "Latest measured clock drift in milliseconds",
 )
-_CLOCK_SYNC_RTT_MS = Gauge(
+clock_sync_rtt_ms = Gauge(
     "clock_sync_rtt_ms",
     "Latest measured clock sync round-trip time in milliseconds",
 )
-_CLOCK_SYNC_LAST_TS = Gauge(
+clock_sync_last_sync_ts = Gauge(
     "clock_sync_last_sync_ts",
     "Timestamp of last successful clock sync in milliseconds since epoch",
 )
@@ -123,11 +123,11 @@ def report_clock_sync(
         pass
 
     try:
-        _CLOCK_SYNC_DRIFT_MS.set(float(drift_ms))
-        _CLOCK_SYNC_RTT_MS.set(float(rtt_ms))
+        clock_sync_drift_ms.set(float(drift_ms))
+        clock_sync_rtt_ms.set(float(rtt_ms))
         if success:
             _last_sync_ts_ms = float(sync_ts)
-            _CLOCK_SYNC_LAST_TS.set(float(sync_ts))
+            clock_sync_last_sync_ts.set(float(sync_ts))
     except Exception:
         pass
 
@@ -149,6 +149,9 @@ __all__ = [
     "age_at_publish_ms",
     "clock_sync_fail",
     "clock_sync_success",
+    "clock_sync_drift_ms",
+    "clock_sync_rtt_ms",
+    "clock_sync_last_sync_ts",
     "report_clock_sync",
     "clock_sync_age_seconds",
 ]


### PR DESCRIPTION
## Summary
- export Prometheus gauges for clock drift, RTT and last sync timestamp
- keep counters label-capable for symbol-level metrics

## Testing
- `pytest` *(fails: tests/test_close_shift.py, tests/test_leak_guard_env.py, tests/test_no_trade_config_shared.py, tests/test_no_trade_mask.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c69ddd8c14832f88d97cd14b102dd2