### PR TITLE
Add asynchronous event bus with drop policies and metrics

### DIFF
--- a/services/event_bus.py
+++ b/services/event_bus.py
@@ -1,0 +1,128 @@
+"""Asynchronous in-memory event bus with backpressure handling.
+
+The bus maintains a bounded queue of events.  When the queue is full new
+events are dropped according to ``drop_policy``:
+
+``"oldest"``  – remove the oldest queued event and enqueue the new one.
+
+``"newest"``  – drop the incoming event.
+
+Simple Prometheus metrics are emitted via :mod:`services.monitoring`:
+
+``queue_depth`` -- current queue size
+
+``events_in`` -- total number of events accepted into the queue
+
+``dropped_bp`` -- events dropped because of backpressure
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from . import monitoring
+
+
+class EventBus:
+    """Lightweight asynchronous event bus with drop policies."""
+
+    def __init__(self, queue_size: int, drop_policy: str) -> None:
+        self._queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=max(0, int(queue_size)))
+        if drop_policy not in {"oldest", "newest", "drop_oldest", "drop_newest"}:
+            raise ValueError("drop_policy must be 'oldest' or 'newest'")
+        self._drop_oldest = drop_policy in {"oldest", "drop_oldest"}
+        self._closed = False
+        self._sentinel: object = object()
+
+    # ------------------------------------------------------------------
+    def _set_depth(self) -> None:
+        try:
+            monitoring.queue_depth.set(self._queue.qsize())
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    async def put(self, event: Any) -> None:
+        """Put ``event`` into the queue honoring the drop policy."""
+
+        if self._closed:
+            raise RuntimeError("EventBus is closed")
+        try:
+            self._queue.put_nowait(event)
+            try:
+                monitoring.events_in.inc()
+            except Exception:
+                pass
+        except asyncio.QueueFull:
+            try:
+                monitoring.dropped_bp.inc()
+            except Exception:
+                pass
+            if self._drop_oldest:
+                try:
+                    # Discard oldest event
+                    self._queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+                try:
+                    self._queue.put_nowait(event)
+                    try:
+                        monitoring.events_in.inc()
+                    except Exception:
+                        pass
+                except asyncio.QueueFull:
+                    # Queue size zero, drop new event as well
+                    pass
+            else:
+                # Drop newest – do nothing
+                pass
+        self._set_depth()
+
+    # ------------------------------------------------------------------
+    async def get(self) -> Any:
+        """Return the next event or ``None`` after :meth:`close`."""
+
+        item = await self._queue.get()
+        self._set_depth()
+        if item is self._sentinel:
+            # keep sentinel for other consumers
+            await self._queue.put(self._sentinel)
+            return None
+        return item
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        """Signal that no more events will be published."""
+
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._queue.put_nowait(self._sentinel)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                self._queue.put_nowait(self._sentinel)
+            except asyncio.QueueFull:
+                pass
+        self._set_depth()
+
+    # ------------------------------------------------------------------
+    async def __aenter__(self) -> "EventBus":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.close()
+
+    def __enter__(self) -> "EventBus":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+__all__ = ["EventBus"]
+

--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -41,6 +41,20 @@ queue_len = Gauge(
     "Current number of queued signals awaiting tokens",
 )
 
+# Event bus metrics
+queue_depth = Gauge(
+    "event_bus_queue_depth",
+    "Current depth of the event bus queue",
+)
+events_in = Counter(
+    "event_bus_events_in_total",
+    "Total number of events enqueued to the event bus",
+)
+dropped_bp = Counter(
+    "event_bus_dropped_backpressure_total",
+    "Events dropped due to backpressure in the event bus",
+)
+
 # Counters for sync attempts
 clock_sync_success = Counter(
     "clock_sync_success_total",
@@ -159,6 +173,9 @@ __all__ = [
     "clock_sync_rtt_ms",
     "clock_sync_last_sync_ts",
     "queue_len",
+    "queue_depth",
+    "events_in",
+    "dropped_bp",
     "report_clock_sync",
     "clock_sync_age_seconds",
 ]


### PR DESCRIPTION
## Summary
- add Prometheus gauges and counters for event bus metrics
- implement `EventBus` with configurable overflow drop policy and context manager support

## Testing
- `pytest` *(fails: test_execution_rules.py::test_unquantized_limit_rejected_sim, test_execution_rules.py::test_ttl_two_steps_sim, test_limit_mid_bps_profile.py::test_limit_mid_bps_profile, test_limit_order_ttl.py::test_limit_order_ttl_expires, test_limit_order_ttl.py::test_limit_order_ttl_survives, test_limit_order_ttl.py::test_limit_order_ioc_partial_cancel, test_limit_order_ttl.py::test_limit_order_fok_partial_cancel, test_market_open_h1.py::test_market_open_next_h1_slippage, test_market_open_h1.py::test_market_open_next_h1_snapshot_price, test_no_trade_mask.py::test_funding_buffer_blocks_orders, test_no_trade_mask.py::test_custom_window_blocks_orders)*

------
https://chatgpt.com/codex/tasks/task_e_68c6aa1e1d44832f8c883bf3bcec058f