### PR TITLE
Publish BinanceWS bars via event bus with backpressure handling

### DIFF
--- a/docs/data_degradation.md
+++ b/docs/data_degradation.md
@@ -39,12 +39,13 @@ python script_backtest.py --config config_sim.yaml
 
 ```python
 from binance_ws import BinanceWS
+from services.event_bus import EventBus
 from config import DataDegradationConfig
 
 cfg = DataDegradationConfig(stale_prob=0.05, drop_prob=0.02,
                             dropout_prob=0.1, max_delay_ms=50, seed=7)
-ws = BinanceWS(symbols=["BTCUSDT"], on_bar=handle_bar,
-               data_degradation=cfg)
+bus = EventBus(queue_size=1000, drop_policy="newest")
+ws = BinanceWS(symbols=["BTCUSDT"], bus=bus, data_degradation=cfg)
 ws.run()
 ```
 

--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -79,6 +79,13 @@ ws_dup_skipped_count = Counter(
     ["symbol"],
 )
 
+# Websocket bars dropped due to event bus backpressure
+ws_backpressure_drop_count = Counter(
+    "ws_backpressure_drop_count",
+    "WS bars dropped due to event bus backpressure",
+    ["symbol"],
+)
+
 # Orders dropped because their originating bar exceeded TTL boundary
 ttl_expired_boundary_count = Counter(
     "ttl_expired_boundary_count",
@@ -162,6 +169,7 @@ def clock_sync_age_seconds() -> float:
 __all__ = [
     "skipped_incomplete_bars",
     "ws_dup_skipped_count",
+    "ws_backpressure_drop_count",
     "ttl_expired_boundary_count",
     "signal_boundary_count",
     "signal_absolute_count",

--- a/tests/test_degradation_logging.py
+++ b/tests/test_degradation_logging.py
@@ -28,6 +28,7 @@ class _DummyWS:
     pass
 sys.modules.setdefault("websockets", _DummyWS())
 import binance_ws
+from services.event_bus import EventBus
 
 
 def _simulate_bar_stream(n: int, cfg: DataDegradationConfig) -> tuple[int, int, int]:
@@ -109,10 +110,8 @@ def test_binance_ws_degradation_logging(monkeypatch, caplog):
             json.dumps({"data": {"k": {"x": True, "t": i, "s": "BTCUSDT", "o": "1", "h": "1", "l": "1", "c": "1", "v": "1", "n": 1}}})
             for i in range(20)
         ]
-        bars = []
-        async def on_bar(bar):
-            bars.append(bar)
-        client = binance_ws.BinanceWS(symbols=["BTCUSDT"], on_bar=on_bar, data_degradation=cfg)
+        bus = EventBus(queue_size=100, drop_policy="newest")
+        client = binance_ws.BinanceWS(symbols=["BTCUSDT"], bus=bus, data_degradation=cfg)
 
         class MockWS:
             def __init__(self, msgs):

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("websockets", _DummyWS())
 
 import binance_public
 import binance_ws
+from services.event_bus import EventBus
 
 
 # --- TokenBucket tests ---
@@ -124,10 +125,8 @@ def test_binance_public_limiter_enabled_and_disabled():
 # --- BinanceWS limiter inclusion and counters ---
 
 def test_binance_ws_rate_limit_counters(monkeypatch):
-    async def on_bar(_):
-        pass
-
-    ws = binance_ws.BinanceWS(symbols=["BTCUSDT"], on_bar=on_bar, rate_limit=1)
+    bus = EventBus(queue_size=10, drop_policy="newest")
+    ws = binance_ws.BinanceWS(symbols=["BTCUSDT"], bus=bus, rate_limit=1)
     rl_mock = MagicMock()
     rl_mock.can_send.side_effect = [
         (False, "rejected"), (True, "ok"),


### PR DESCRIPTION
## Summary
- Publish closed Binance klines to an injected EventBus instead of callback
- Add `feed_lag_ms` metadata, deduplicate via `ws_dedup_state` and persist last close
- Handle event bus backpressure with logging and per-symbol metrics
- Expose backpressure drops through new monitoring counter and boolean `EventBus.put`

## Testing
- `pytest tests/test_degradation_logging.py::test_binance_ws_degradation_logging -q`
- `pytest tests/test_rate_limiter.py::test_binance_ws_rate_limit_counters -q`
- `pytest tests/test_ws_dedup_state.py::test_load_update_and_flush -q`
- `pytest -q` *(fails: ExecutionSimulator and no-trade related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c6add9a780832f8919c092d084bf89