### PR TITLE
Add periodic flush for websocket dedup state

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -336,7 +336,7 @@ class _Provider:
 
         if self._ws_dedup_enabled and close_ms is not None:
             try:
-                signal_bus.update(bar.symbol, close_ms)
+                signal_bus.update(bar.symbol, close_ms, auto_flush=False)
             except Exception:
                 pass
         return emitted
@@ -498,6 +498,11 @@ class ServiceSignalRunner:
                     logger.flush()
             except Exception:
                 pass
+            if signal_bus.ENABLED:
+                try:
+                    signal_bus.shutdown()
+                except Exception:
+                    pass
 
 
 def from_config(

--- a/tests/test_ws_dedup_state.py
+++ b/tests/test_ws_dedup_state.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import time
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -40,3 +41,14 @@ def test_load_update_and_flush(tmp_path, caplog):
         s.load_state(state_file)
     assert s.STATE == {"BTCUSDT": 1000, "ETHUSDT": 2000}
     assert "Loaded 2 symbols" in caplog.text
+
+
+def test_periodic_flush(tmp_path):
+    state_file = tmp_path / "state.json"
+    s.init(enabled=True, persist_path=state_file, flush_interval_s=0.1)
+    try:
+        s.update("BTCUSDT", 1234, auto_flush=False)
+        time.sleep(0.25)
+    finally:
+        s.shutdown()
+    assert json.loads(state_file.read_text()) == {"BTCUSDT": 1234}


### PR DESCRIPTION
## Summary
- add background thread to periodically flush websocket dedup state and persist on shutdown
- ensure websocket and runner producers record dedup timestamps after enqueue
- test periodic flushing and persist state on service shutdown

## Testing
- `python - <<'PY'
import sys, sysconfig, runpy
stdlib = sysconfig.get_path('stdlib')
if stdlib:
    sys.path.insert(0, stdlib)
sys.argv = ['pytest', 'tests/test_ws_dedup_state.py', '-q']
runpy.run_module('pytest', run_name='__main__')
PY`
- `python - <<'PY'
import sys, sysconfig, runpy
stdlib = sysconfig.get_path('stdlib')
if stdlib:
    sys.path.insert(0, stdlib)
sys.argv = ['pytest', '-q']
runpy.run_module('pytest', run_name='__main__')
PY` *(fails: assert [] == [1])*

------
https://chatgpt.com/codex/tasks/task_e_68c6b1c0b378832f909937eea7497951