### PR TITLE
Track throttle metrics for signal throttling

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -41,6 +41,23 @@ queue_len = Gauge(
     "Current number of queued signals awaiting tokens",
 )
 
+# Throttling outcomes
+throttle_dropped_count = Counter(
+    "throttle_dropped_count",
+    "Signals dropped due to throttling",
+    ["symbol", "reason"],
+)
+throttle_enqueued_count = Counter(
+    "throttle_enqueued_count",
+    "Signals enqueued due to throttling",
+    ["symbol", "reason"],
+)
+throttle_queue_expired_count = Counter(
+    "throttle_queue_expired_count",
+    "Queued signals expired before tokens became available",
+    ["symbol"],
+)
+
 # Event bus metrics
 queue_depth = Gauge(
     "event_bus_queue_depth",
@@ -181,6 +198,9 @@ __all__ = [
     "clock_sync_rtt_ms",
     "clock_sync_last_sync_ts",
     "queue_len",
+    "throttle_dropped_count",
+    "throttle_enqueued_count",
+    "throttle_queue_expired_count",
     "queue_depth",
     "events_in",
     "dropped_bp",


### PR DESCRIPTION
## Summary
- record throttle drop and queue events in monitoring metrics
- capture queue expiry metrics while maintaining FIFO fairness

## Testing
- `pytest -q` *(fails: 11 failed, 136 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bf5f0678832fbd5e0741f8b92eb0