### PR TITLE
feat: configurable event bus drop policy

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -153,7 +153,10 @@ class BinanceWS:
         accepted = await self._bus.put(event)
         if not accepted:
             try:
-                logger.info("BACKPRESSURE_DROP")
+                logger.info(
+                    "BACKPRESSURE_DROP %s",
+                    {"symbol": bar.symbol, "depth": self._bus.depth},
+                )
             except Exception:
                 pass
             try:

--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -31,3 +31,8 @@ throttle:
     ttl_ms: 0                 # item lifetime in ms
   time_source: "monotonic"
 
+runtime:
+  queue:
+    capacity: 1000            # event bus capacity; 0 for unbounded
+    drop_policy: newest       # "newest" drops incoming, "oldest" drops oldest
+


### PR DESCRIPTION
## Summary
- allow EventBus to choose drop policy and expose queue depth
- make ServiceSignalRunner load runtime queue settings and pass bus to components
- log BACKPRESSURE_DROP with symbol and queue depth in BinanceWS

## Testing
- `pytest tests/test_rate_limiter.py::test_binance_ws_rate_limit_counters tests/test_degradation_logging.py::test_binance_ws_degradation_logging -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6c1138cb8832f93d8409536c8da2a