### PR TITLE
Add monitoring kill switch based on feed lag thresholds

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -165,7 +165,7 @@ class BinanceWS:
                 pass
             try:
                 monitoring.ws_backpressure_drop_count.labels(bar.symbol).inc()
-                monitoring.ws_failure_count.labels(bar.symbol).inc()
+                monitoring.report_ws_failure(bar.symbol)
             except Exception:
                 pass
         try:
@@ -241,7 +241,7 @@ class BinanceWS:
                                                     pass
                                             try:
                                                 monitoring.ws_dup_skipped_count.labels(bar.symbol).inc()
-                                                monitoring.ws_failure_count.labels(bar.symbol).inc()
+                                                monitoring.report_ws_failure(bar.symbol)
                                             except Exception:
                                                 pass
                                             continue

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -23,6 +23,11 @@ clock_sync:
   kill_threshold_ms: 2000 # Terminate if drift exceeds this many milliseconds
   max_step_ms: 1000       # Max single adjustment step in milliseconds
   attempts: 5             # Number of sync attempts before giving up
+
+kill_switch:
+  feed_lag_ms: 60000       # Enter safe mode if worst feed lag exceeds this; 0 disables
+  ws_failures: 100         # Enter safe mode if WS failures exceed this count; 0 disables
+  error_rate: 0.2          # Enter safe mode if signal error rate exceeds this fraction; 0 disables
 ttl:
   enabled: false
   ttl_seconds: 60

--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -11,6 +11,11 @@ ws_dedup:
   persist_path: state/last_bar_seen.json
   log_skips: true
 
+kill_switch:
+  feed_lag_ms: 60000       # Enter safe mode if worst feed lag exceeds this; 0 disables
+  ws_failures: 100         # Enter safe mode if WS failures exceed this count; 0 disables
+  error_rate: 0.2          # Enter safe mode if signal error rate exceeds this fraction; 0 disables
+
 ttl:
   enabled: false
   ttl_seconds: 60

--- a/core_config.py
+++ b/core_config.py
@@ -111,6 +111,26 @@ class ThrottleConfig(BaseModel):
     time_source: str = "monotonic"
 
 
+class KillSwitchConfig(BaseModel):
+    """Thresholds for entering safe mode based on runtime metrics."""
+
+    feed_lag_ms: float = Field(
+        default=0.0,
+        description=
+        "Enter safe mode if worst feed lag exceeds this many milliseconds; non-positive disables",
+    )
+    ws_failures: float = Field(
+        default=0.0,
+        description=
+        "Enter safe mode if websocket failures for any symbol exceed this count; non-positive disables",
+    )
+    error_rate: float = Field(
+        default=0.0,
+        description=
+        "Enter safe mode if signal error rate for any symbol exceeds this fraction; non-positive disables",
+    )
+
+
 class CommonRunConfig(BaseModel):
     run_id: Optional[str] = Field(
         default=None, description="Идентификатор запуска; если None — генерируется."
@@ -139,6 +159,7 @@ class CommonRunConfig(BaseModel):
     ws_dedup: WSDedupConfig = Field(default_factory=WSDedupConfig)
     ttl: TTLConfig = Field(default_factory=TTLConfig)
     throttle: ThrottleConfig = Field(default_factory=ThrottleConfig)
+    kill_switch: KillSwitchConfig = Field(default_factory=KillSwitchConfig)
     components: Components
 
 
@@ -332,6 +353,8 @@ __all__ = [
     "TimingConfig",
     "WSDedupConfig",
     "TTLConfig",
+    "ThrottleConfig",
+    "KillSwitchConfig",
     "CommonRunConfig",
     "SimulationDataConfig",
     "SimulationConfig",

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -450,13 +450,14 @@ class ServiceSignalRunner:
             snapshot_config(self.cfg.snapshot_config_path, self.cfg.artifacts_dir)
 
         self.feature_pipe.warmup()
+        monitoring.configure_kill_switch(self.cfg.kill_switch)
         worker = _Worker(
             self.feature_pipe,
             self.policy,
             self.logger,
             self.adapter,
             self.risk_guards,
-            lambda: self._clock_safe_mode,
+            lambda: self._clock_safe_mode or monitoring.kill_switch_triggered(),
             enforce_closed_bars=self.enforce_closed_bars,
             ws_dedup_enabled=self.ws_dedup_enabled,
             ws_dedup_log_skips=self.ws_dedup_log_skips,

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -1,0 +1,33 @@
+import pathlib
+import sys
+
+# Ensure stdlib logging is used instead of local logging.py
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_orig_sys_path = list(sys.path)
+sys.path = [p for p in sys.path if p not in ("", str(REPO_ROOT))]
+import logging as std_logging  # type: ignore
+sys.modules["logging"] = std_logging
+sys.path = _orig_sys_path
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core_config import KillSwitchConfig
+from services import monitoring
+
+
+def test_kill_switch_feed_lag_trigger():
+    monitoring.configure_kill_switch(KillSwitchConfig(feed_lag_ms=100.0))
+    monitoring.report_feed_lag("BTCUSDT", 150.0)
+    assert monitoring.kill_switch_triggered()
+    info = monitoring.kill_switch_info()
+    assert info["metric"] == "feed_lag_ms"
+    assert info["symbol"] == "BTCUSDT"
+
+
+def test_kill_switch_reset_on_configure():
+    monitoring.configure_kill_switch(KillSwitchConfig(feed_lag_ms=100.0))
+    monitoring.report_feed_lag("BTCUSDT", 50.0)
+    assert not monitoring.kill_switch_triggered()
+    monitoring.configure_kill_switch(KillSwitchConfig(feed_lag_ms=10.0))
+    monitoring.report_feed_lag("BTCUSDT", 5.0)
+    assert not monitoring.kill_switch_triggered()

--- a/tests/test_kill_switch_config.py
+++ b/tests/test_kill_switch_config.py
@@ -1,0 +1,49 @@
+import textwrap, sys, pathlib
+
+# Ensure stdlib logging is used instead of local logging.py
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_orig_sys_path = list(sys.path)
+sys.path = [p for p in sys.path if p not in ("", str(REPO_ROOT))]
+import logging as std_logging  # type: ignore
+sys.modules["logging"] = std_logging
+sys.path = _orig_sys_path
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core_config import load_config_from_str
+
+
+def test_kill_switch_config_loading():
+    yaml_cfg = textwrap.dedent(
+        """
+        mode: sim
+        symbols: ["BTCUSDT"]
+        components:
+          market_data:
+            target: "module:Cls"
+            params: {}
+          executor:
+            target: "module:Cls"
+            params: {}
+          feature_pipe:
+            target: "module:Cls"
+            params: {}
+          policy:
+            target: "module:Cls"
+            params: {}
+          risk_guards:
+            target: "module:Cls"
+            params: {}
+        data:
+          symbols: ["BTCUSDT"]
+          timeframe: "1m"
+        kill_switch:
+          feed_lag_ms: 123
+          ws_failures: 5
+          error_rate: 0.1
+        """
+    )
+    cfg = load_config_from_str(yaml_cfg)
+    assert cfg.kill_switch.feed_lag_ms == 123
+    assert cfg.kill_switch.ws_failures == 5
+    assert cfg.kill_switch.error_rate == 0.1


### PR DESCRIPTION
## Summary
- Introduce `KillSwitchConfig` with feed-lag, websocket failure and error-rate thresholds
- Monitor worst symbol metrics and trigger kill switch when thresholds exceeded
- Signal runner halts processing when kill switch is active
- Add configuration entries and tests for kill switch

## Testing
- `pytest tests/test_kill_switch.py tests/test_kill_switch_config.py tests/test_clock_sync_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c6443930832fb18b0e4ab675d11c