### PR TITLE
Add runtime configuration loader

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -3,6 +3,8 @@ run_id: live-run
 logs_dir: logs
 artifacts_dir: artifacts
 seasonality_log_level: INFO
+# Runtime settings are defined in runtime.yaml
+runtime_config: runtime.yaml
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP
@@ -23,29 +25,11 @@ clock_sync:
   kill_threshold_ms: 2000 # Terminate if drift exceeds this many milliseconds
   max_step_ms: 1000       # Max single adjustment step in milliseconds
   attempts: 5             # Number of sync attempts before giving up
-
-kill_switch:
-  feed_lag_ms: 60000       # Enter safe mode if worst feed lag exceeds this; 0 disables
-  ws_failures: 100         # Enter safe mode if WS failures exceed this count; 0 disables
-  error_rate: 0.2          # Enter safe mode if signal error rate exceeds this fraction; 0 disables
 ttl:
   enabled: false
   ttl_seconds: 60
   out_csv: null
   dedup_persist: null
-throttle:
-  enabled: false              # disable throttling
-  global:
-    rps: 0.0                  # requests per second; 0 disables
-    burst: 0                  # burst capacity
-  symbol:
-    rps: 0.0                  # per-symbol RPS limit
-    burst: 0
-  mode: drop                  # drop or queue
-  queue:
-    max_items: 0              # queue size when mode=queue
-    ttl_ms: 0                 # item lifetime in ms
-  time_source: "monotonic"
 api:
   api_key: null
   api_secret: null

--- a/configs/runtime.yaml
+++ b/configs/runtime.yaml
@@ -1,0 +1,32 @@
+# Runtime settings for live execution
+concurrency:
+  workers: 1
+
+queue:
+  capacity: 1000            # event bus capacity; 0 for unbounded
+  drop_policy: newest       # "newest" drops incoming, "oldest" drops oldest
+
+ws:
+  enabled: true
+  persist_path: state/last_bar_seen.json
+  log_skips: true
+
+throttle:
+  enabled: false              # disable throttling
+  global:
+    rps: 0.0                  # requests per second; 0 disables
+    burst: 0                  # burst capacity
+  symbol:
+    rps: 0.0                  # per-symbol RPS limit
+    burst: 0
+  mode: drop                  # drop or queue
+  queue:
+    max_items: 0              # queue size when mode=queue
+    ttl_ms: 0                 # item lifetime in ms
+  time_source: "monotonic"
+
+ops:
+  kill_switch:
+    feed_lag_ms: 60000       # Enter safe mode if worst feed lag exceeds this; 0 disables
+    ws_failures: 100         # Enter safe mode if WS failures exceed this count; 0 disables
+    error_rate: 0.2          # Enter safe mode if signal error rate exceeds this fraction; 0 disables


### PR DESCRIPTION
## Summary
- add runtime.yaml with concurrency, queue, ws, throttle and kill switch settings
- reference runtime settings from config_live
- load runtime parameters in `ServiceSignalRunner.from_config`

## Testing
- `pytest tests/test_kill_switch_config.py tests/test_ws_dedup_config.py tests/test_clock_sync_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6c92dab58832fa88a6a4b0a9731df