### PR TITLE
Add pipeline enums and result dataclass

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1,9 +1,47 @@
 from __future__ import annotations
 
 """Utilities for basic pipeline time-to-live checks."""
-from typing import Tuple
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Tuple
 
 from utils_time import next_bar_open_ms
+
+
+class Stage(Enum):
+    """Pipeline stages for decision making."""
+
+    CLOSED_BAR = auto()
+    WINDOWS = auto()
+    ANOMALY = auto()
+    EXTREME = auto()
+    POLICY = auto()
+    RISK = auto()
+    PUBLISH = auto()
+
+
+class Reason(Enum):
+    """Reasons for halting or skipping pipeline stages."""
+
+    INCOMPLETE_BAR = auto()
+    MAINTENANCE = auto()
+    WINDOW = auto()
+    ANOMALY_RET = auto()
+    ANOMALY_SPREAD = auto()
+    EXTREME_VOL = auto()
+    EXTREME_SPREAD = auto()
+    RISK_POSITION = auto()
+    OTHER = auto()
+
+
+@dataclass
+class PipelineResult:
+    """Result produced by each pipeline stage."""
+
+    action: str
+    stage: Stage
+    reason: Reason | None = None
+    decision: Any | None = None
 
 
 def compute_expires_at(bar_close_ms: int, timeframe_ms: int) -> int:
@@ -24,7 +62,9 @@ def compute_expires_at(bar_close_ms: int, timeframe_ms: int) -> int:
     return next_bar_open_ms(bar_close_ms, timeframe_ms)
 
 
-def check_ttl(bar_close_ms: int, now_ms: int, timeframe_ms: int) -> Tuple[bool, int, str]:
+def check_ttl(
+    bar_close_ms: int, now_ms: int, timeframe_ms: int
+) -> Tuple[bool, int, str]:
     """Validate that a bar has not exceeded its time-to-live.
 
     The TTL for a bar is one full timeframe after its close. This function
@@ -52,3 +92,12 @@ def check_ttl(bar_close_ms: int, now_ms: int, timeframe_ms: int) -> Tuple[bool, 
     if now_ms <= expires_at_ms:
         return True, expires_at_ms, ""
     return False, expires_at_ms, f"age {age_ms}ms exceeds {timeframe_ms}ms"
+
+
+__all__ = [
+    "Stage",
+    "Reason",
+    "PipelineResult",
+    "compute_expires_at",
+    "check_ttl",
+]


### PR DESCRIPTION
## Summary
- define Stage and Reason enums for pipeline stages and skip reasons
- add PipelineResult dataclass and export via `__all__`

## Testing
- `black pipeline.py`
- `flake8 pipeline.py`
- `pytest tests/test_clock.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d645f8e4832f8e45ec5a6d25be89