### PR TITLE
Refactor signal pipeline stages

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -114,6 +114,13 @@ ws_backpressure_drop_count = Counter(
     ["symbol"],
 )
 
+# Pipeline stage drops
+pipeline_stage_drop_count = Counter(
+    "pipeline_stage_drop_count",
+    "Pipeline drops per stage and reason",
+    ["symbol", "stage", "reason"],
+)
+
 # Additional per-symbol metrics
 feed_lag_max_ms = Gauge(
     "feed_lag_max_ms",
@@ -399,6 +406,7 @@ __all__ = [
     "skipped_incomplete_bars",
     "ws_dup_skipped_count",
     "ws_backpressure_drop_count",
+    "pipeline_stage_drop_count",
     "ttl_expired_boundary_count",
     "signal_boundary_count",
     "signal_absolute_count",

--- a/tests/test_pipeline_flow.py
+++ b/tests/test_pipeline_flow.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core_models import Bar
+from core_contracts import FeaturePipe, SignalPolicy
+from pipeline import policy_decide, apply_risk
+
+
+class DummyFP(FeaturePipe):
+    def warmup(self):
+        pass
+
+    def update(self, bar):
+        return {"x": 1}
+
+
+class DummyPolicy(SignalPolicy):
+    def decide(self, feats, ctx):
+        return ["o1", "o2"]
+
+
+class DummyGuards:
+    def apply(self, ts_ms, symbol, decisions):
+        return decisions[:1]
+
+
+def test_decision_flow():
+    bar = Bar(ts=0, symbol="BTC", open=Decimal("0"), high=Decimal("0"), low=Decimal("0"), close=Decimal("0"))
+    fp = DummyFP()
+    policy = DummyPolicy()
+    pol_res = policy_decide(fp, policy, bar)
+    assert pol_res.decision == ["o1", "o2"]
+    guards = DummyGuards()
+    risk_res = apply_risk(0, "BTC", guards, pol_res.decision)
+    assert risk_res.decision == ["o1"]


### PR DESCRIPTION
## Summary
- orchestrate worker stages via new `policy_decide` and `apply_risk` functions
- log and monitor early pipeline drops with `pipeline_stage_drop_count`
- cover decision flow with a dedicated test

## Testing
- `pytest tests/test_pipeline_flow.py tests/test_metric_kill_switch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f825f768832fa590e476aa0a0410