### PR TITLE
Add per-symbol risk guard and drop tracking

### DIFF
--- a/tests/test_pipeline_flow.py
+++ b/tests/test_pipeline_flow.py
@@ -24,7 +24,7 @@ class DummyPolicy(SignalPolicy):
 
 class DummyGuards:
     def apply(self, ts_ms, symbol, decisions):
-        return decisions[:1]
+        return decisions[:1], None
 
 
 def test_decision_flow():

--- a/tests/test_signal_bus.py
+++ b/tests/test_signal_bus.py
@@ -12,6 +12,7 @@ def test_publish_signal_dedup(tmp_path):
     # redirect state path to temporary location to avoid polluting repo
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()
+    sb.dropped_by_reason.clear()
     sb._loaded = False
     sb.load_state()
 
@@ -42,6 +43,7 @@ def test_publish_signal_dedup(tmp_path):
 def test_publish_signal_payload_fields(tmp_path):
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()
+    sb.dropped_by_reason.clear()
     sb._loaded = False
     sb.load_state()
 
@@ -58,6 +60,7 @@ def test_publish_signal_payload_fields(tmp_path):
 def test_publish_signal_disabled(tmp_path):
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()
+    sb.dropped_by_reason.clear()
     sb._loaded = False
     sb.load_state()
 
@@ -78,6 +81,7 @@ def test_publish_signal_disabled(tmp_path):
 def test_load_and_flush_state(tmp_path):
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()
+    sb.dropped_by_reason.clear()
     sb._loaded = False
     sb.load_state()
     assert sb._SEEN == {}
@@ -113,6 +117,7 @@ def test_load_and_flush_state(tmp_path):
 def test_publish_signal_csv_logging(tmp_path):
     sb._STATE_PATH = tmp_path / "seen.json"
     sb._SEEN.clear()
+    sb.dropped_by_reason.clear()
     sb._loaded = False
     sb.load_state()
 
@@ -142,3 +147,9 @@ def test_publish_signal_csv_logging(tmp_path):
 
     sb.OUT_CSV = None
     sb.DROPS_CSV = None
+
+
+def test_log_drop_counts():
+    sb.dropped_by_reason.clear()
+    sb.log_drop("BTC", 1, {}, "RISK_TEST")
+    assert sb.dropped_by_reason["RISK_TEST"] == 1


### PR DESCRIPTION
## Summary
- track per-symbol timestamp and exposure in new `SimpleRiskGuard`
- have pipeline risk stage return reason for drops
- log risk drops before publish and count them per reason

## Testing
- `pytest tests/test_pipeline_flow.py tests/test_risk_guard_reset.py tests/test_signal_bus.py`
- `pytest tests/test_service_eval_all_profiles.py tests/test_kill_switch_config.py tests/test_ws_dedup_config.py tests/test_clock_sync_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6f97d35d4832f82dafa4a5d3a3a9e