### PR TITLE
Add configurable pipeline configuration and stage controls

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -56,6 +56,23 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
+pipeline:
+  enabled: true
+  stages:
+    closed_bar:
+      enabled: true
+    windows:
+      enabled: true
+    anomaly:
+      enabled: true
+    extreme:
+      enabled: true
+    policy:
+      enabled: true
+    risk:
+      enabled: true
+    publish:
+      enabled: true
 components:
   market_data:
     target: impl_binance_public:BinancePublicBarSource

--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -41,3 +41,21 @@ runtime:
     capacity: 1000            # event bus capacity; 0 for unbounded
     drop_policy: newest       # "newest" drops incoming, "oldest" drops oldest
 
+pipeline:
+  enabled: true
+  stages:
+    closed_bar:
+      enabled: true
+    windows:
+      enabled: true
+    anomaly:
+      enabled: true
+    extreme:
+      enabled: true
+    policy:
+      enabled: true
+    risk:
+      enabled: true
+    publish:
+      enabled: true
+


### PR DESCRIPTION
## Summary
- add pipeline enabled/stage settings to configs
- parse pipeline settings into PipelineConfig and propagate to worker/stage functions
- allow publish and other stages to be toggled via config

## Testing
- `pip install gymnasium -q`
- `pytest tests/test_publish_decision.py -q`
- `pytest -q` *(fails: assert [] == [1], etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c6fe4e63b4832fbc912e35eeea44c3