### PR TITLE
Add pipeline docs and structure drop logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 сервисов.
 
 Документация по утилите скользящего среднего доступна в [docs/moving_average.md](docs/moving_average.md) (English/Russian).
+Обзор конвейера принятия решений описан в [docs/pipeline.md](docs/pipeline.md).
 
 ## File Ownership and Permissions
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,55 @@
+# Pipeline Overview
+
+This document summarizes the stages of the decision-making pipeline, the
+reasons a stage may drop an item, and the configuration flags that control
+each part of the process.
+
+## Order of stages
+
+1. **CLOSED_BAR** – Ensure incoming bars are fully closed before processing.
+2. **WINDOWS** – Skip timestamps falling into configured no-trade windows.
+3. **ANOMALY** – Optional anomaly screens for returns or spread.
+4. **EXTREME** – Optional guards for extreme volatility or spread.
+5. **POLICY** – Generate candidate orders from policies and feature pipes.
+6. **RISK** – Enforce account and position limits on candidate orders.
+7. **PUBLISH** – Throttle, queue or emit orders to downstream services.
+
+## Drop reasons
+
+Stages can return a ``PipelineResult`` with one of the following reasons:
+
+- ``INCOMPLETE_BAR``
+- ``MAINTENANCE``
+- ``WINDOW``
+- ``ANOMALY_RET``
+- ``ANOMALY_SPREAD``
+- ``EXTREME_VOL``
+- ``EXTREME_SPREAD``
+- ``RISK_POSITION``
+- ``OTHER``
+
+## Configuration
+
+The pipeline is configured with :class:`PipelineConfig`, which holds a global
+``enabled`` flag and per-stage settings.  Each stage entry is a
+:class:`PipelineStageConfig` containing its own ``enabled`` flag and optional
+parameters passed to the stage function.
+
+Example:
+
+```python
+PipelineConfig(
+    enabled=True,
+    stages={
+        "closed_bar": PipelineStageConfig(enabled=True),
+        "windows": PipelineStageConfig(enabled=True, params={"symbols": ["BTCUSDT"]}),
+        "policy": PipelineStageConfig(enabled=True),
+        "risk": PipelineStageConfig(enabled=True),
+        "publish": PipelineStageConfig(enabled=True),
+    },
+)
+```
+
+Disabling a stage removes it from the processing chain.  Individual stage
+parameters allow finer control, such as no-trade window definitions or risk
+limits.

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -153,7 +153,10 @@ class _Worker:
             checked, reason = self._guards.apply(bar_close_ms, symbol, [o])
             if reason or not checked:
                 try:
-                    self._logger.info(f"DROP_{Stage.PUBLISH.name}_{reason or ''}")
+                    self._logger.info(
+                        "DROP %s",
+                        {"stage": Stage.PUBLISH.name, "reason": reason or ""},
+                    )
                 except Exception:
                     pass
                 try:
@@ -348,7 +351,13 @@ class _Worker:
         )
         if guard_res.action == "drop":
             try:
-                self._logger.info(f"DROP_{guard_res.stage.name}_{getattr(guard_res.reason, 'name', '')}")
+                self._logger.info(
+                    "DROP %s",
+                    {
+                        "stage": guard_res.stage.name,
+                        "reason": getattr(guard_res.reason, "name", ""),
+                    },
+                )
             except Exception:
                 pass
             try:
@@ -378,7 +387,13 @@ class _Worker:
             )
             if win_res.action == "drop":
                 try:
-                    self._logger.info(f"DROP_{win_res.stage.name}_{getattr(win_res.reason, 'name', '')}")
+                    self._logger.info(
+                        "DROP %s",
+                        {
+                            "stage": win_res.stage.name,
+                            "reason": getattr(win_res.reason, "name", ""),
+                        },
+                    )
                 except Exception:
                     pass
                 try:
@@ -399,7 +414,13 @@ class _Worker:
         )
         if pol_res.action == "drop":
             try:
-                self._logger.info(f"DROP_{pol_res.stage.name}_{getattr(pol_res.reason, 'name', '')}")
+                self._logger.info(
+                    "DROP %s",
+                    {
+                        "stage": pol_res.stage.name,
+                        "reason": getattr(pol_res.reason, "name", ""),
+                    },
+                )
             except Exception:
                 pass
             try:
@@ -422,7 +443,13 @@ class _Worker:
         )
         if risk_res.action == "drop":
             try:
-                self._logger.info(f"DROP_{risk_res.stage.name}_{getattr(risk_res.reason, 'name', '')}")
+                self._logger.info(
+                    "DROP %s",
+                    {
+                        "stage": risk_res.stage.name,
+                        "reason": getattr(risk_res.reason, "name", ""),
+                    },
+                )
             except Exception:
                 pass
             try:
@@ -479,7 +506,11 @@ class _Worker:
             elif res.action == "drop":
                 try:
                     self._logger.info(
-                        f"DROP_{res.stage.name}_{getattr(res.reason, 'name', '')}"
+                        "DROP %s",
+                        {
+                            "stage": res.stage.name,
+                            "reason": getattr(res.reason, "name", ""),
+                        },
                     )
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary
- log pipeline drops as single-line dictionaries with stage and reason
- document pipeline stages, reasons, and configuration in docs/pipeline.md
- link pipeline documentation from README

## Testing
- `pytest -q` *(fails: 11 failed, 147 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c702118d78832fbf2cc29aed7e702f