### PR TITLE
Integrate shutdown manager

### DIFF
--- a/logging.py
+++ b/logging.py
@@ -165,6 +165,19 @@ class LogWriter:
         else:
             self._flush_parquet()
 
+    def flush_fsync(self) -> None:
+        """Flush buffers and fsync output files to disk."""
+        self.flush()
+        if not self.cfg.enabled:
+            return
+        for path in (self.cfg.trades_path, self.cfg.reports_path):
+            try:
+                fd = os.open(path, os.O_RDONLY)
+                os.fsync(fd)
+                os.close(fd)
+            except Exception:
+                pass
+
     def _flush_csv(self) -> None:
         if self._trades_buf:
             df_t = pd.DataFrame(self._trades_buf)

--- a/services/shutdown.py
+++ b/services/shutdown.py
@@ -95,7 +95,13 @@ class ShutdownManager:
         if self._shutdown_requested:
             return
         self._shutdown_requested = True
-        self._shutdown_task = asyncio.create_task(self._run_sequence(), name="shutdown")
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self._run_sequence())
+            self._shutdown_task = None
+        else:
+            self._shutdown_task = loop.create_task(self._run_sequence(), name="shutdown")
 
     # ------------------------------------------------------------------
     async def _run_callbacks(self, cbs: Iterable[Callback], timeout: float | None) -> None:


### PR DESCRIPTION
## Summary
- add FlushFsync to logging
- add synchronous-aware shutdown manager
- integrate shutdown manager in ServiceSignalRunner lifecycle

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gymnasium')*


------
https://chatgpt.com/codex/tasks/task_e_68c70ce8d6f0832fb846bc51bb80dc06