### PR TITLE
Add daily-rotating signal CSV writer

### DIFF
--- a/services/signal_csv_writer.py
+++ b/services/signal_csv_writer.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import csv
+import os
+from datetime import datetime, date
+from typing import Dict, Sequence, Any
+
+
+class SignalCSVWriter:
+    """Write signal rows to a CSV file with daily rotation.
+
+    The writer maintains a file at ``path`` and automatically rotates it when
+    UTC day changes.  Previous day files are renamed to ``<name>-YYYY-MM-DD.csv``.
+    """
+
+    DEFAULT_HEADER = [
+        "ts_ms",
+        "symbol",
+        "side",
+        "volume_frac",
+        "score",
+        "features_hash",
+    ]
+
+    def __init__(self, path: str, header: Sequence[str] | None = None) -> None:
+        self.path = str(path)
+        self.header = list(header) if header is not None else list(self.DEFAULT_HEADER)
+        self._file: Any | None = None
+        self._writer: csv.DictWriter | None = None
+        self._day: date | None = None
+        self._ensure_dir()
+        self._rotate_existing()
+        self._open_file(initial=True)
+
+    # ------------------------------------------------------------------
+    def _ensure_dir(self) -> None:
+        directory = os.path.dirname(self.path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def _rotate_name(self, d: date) -> str:
+        base, ext = os.path.splitext(self.path)
+        return f"{base}-{d.isoformat()}{ext}"
+
+    # ------------------------------------------------------------------
+    def _rotate_existing(self) -> None:
+        if not os.path.exists(self.path):
+            return
+        mtime = os.path.getmtime(self.path)
+        mday = datetime.utcfromtimestamp(mtime).date()
+        today = datetime.utcnow().date()
+        if mday != today:
+            try:
+                os.replace(self.path, self._rotate_name(mday))
+            except Exception:
+                pass
+        else:
+            self._day = mday
+
+    # ------------------------------------------------------------------
+    def _open_file(self, *, initial: bool = False) -> None:
+        need_header = True
+        if os.path.exists(self.path):
+            if os.path.getsize(self.path) > 0:
+                need_header = False
+            if initial and self._day is None:
+                mtime = os.path.getmtime(self.path)
+                self._day = datetime.utcfromtimestamp(mtime).date()
+        if self._day is None:
+            self._day = datetime.utcnow().date()
+        self._file = open(self.path, "a", encoding="utf-8", newline="")
+        self._writer = csv.DictWriter(self._file, fieldnames=self.header)
+        if need_header:
+            self._writer.writeheader()
+            self._file.flush()
+
+    # ------------------------------------------------------------------
+    def _maybe_rotate(self, ts_ms: int) -> None:
+        day = datetime.utcfromtimestamp(int(ts_ms) / 1000).date()
+        if self._day is None:
+            self._day = day
+        if day == self._day:
+            return
+        self.flush_fsync()
+        if self._file:
+            try:
+                self._file.close()
+            except Exception:
+                pass
+        try:
+            os.replace(self.path, self._rotate_name(self._day))
+        except Exception:
+            pass
+        self._day = day
+        self._open_file()
+
+    # ------------------------------------------------------------------
+    def write(self, row: Dict[str, Any]) -> None:
+        if self._writer is None:
+            return
+        ts_ms = int(row.get("ts_ms", 0))
+        self._maybe_rotate(ts_ms)
+        self._writer.writerow({k: row.get(k, "") for k in self.header})
+
+    # ------------------------------------------------------------------
+    def flush_fsync(self) -> None:
+        if not self._file:
+            return
+        try:
+            self._file.flush()
+            os.fsync(self._file.fileno())
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        if self._file:
+            try:
+                self._file.close()
+            except Exception:
+                pass
+            self._file = None
+            self._writer = None
+
+
+__all__ = ["SignalCSVWriter"]

--- a/tests/test_signal_csv_writer.py
+++ b/tests/test_signal_csv_writer.py
@@ -1,0 +1,58 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+from services.signal_csv_writer import SignalCSVWriter
+
+
+def _ts_ms(dt: datetime) -> int:
+    return int(dt.replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def test_header_and_append(tmp_path):
+    path = tmp_path / "signals.csv"
+    w = SignalCSVWriter(str(path))
+    ts = _ts_ms(datetime.utcnow())
+    w.write({"ts_ms": ts, "symbol": "BTC", "side": "BUY", "volume_frac": 1, "score": 0.1, "features_hash": "x"})
+    w.flush_fsync()
+    w.close()
+
+    w2 = SignalCSVWriter(str(path))
+    w2.write({"ts_ms": ts, "symbol": "ETH", "side": "SELL", "volume_frac": 2, "score": 0.2, "features_hash": "y"})
+    w2.close()
+
+    lines = path.read_text().strip().splitlines()
+    assert lines[0].startswith("ts_ms")
+    assert len(lines) == 3  # header + 2 rows
+
+
+def test_rotation_on_init(tmp_path):
+    path = tmp_path / "signals.csv"
+    old_day = datetime.utcnow().date() - timedelta(days=1)
+    rotated = tmp_path / f"signals-{old_day.isoformat()}.csv"
+    path.write_text("ts_ms,symbol,side,volume_frac,score,features_hash\n1,BTC,BUY,0.1,0.2,fh\n")
+    ts_old = datetime.combine(old_day, datetime.min.time(), tzinfo=timezone.utc).timestamp()
+    os.utime(path, (ts_old, ts_old))
+
+    w = SignalCSVWriter(str(path))
+    w.write({"ts_ms": _ts_ms(datetime.utcnow()), "symbol": "BTC", "side": "BUY", "volume_frac": 1, "score": 0.1, "features_hash": "x"})
+    w.close()
+
+    assert rotated.exists()
+    assert path.exists()
+    assert rotated.read_text().strip().splitlines()[0].startswith("ts_ms")
+
+
+def test_rotation_on_write(tmp_path):
+    path = tmp_path / "signals.csv"
+    w = SignalCSVWriter(str(path))
+    day1 = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    day2 = day1 + timedelta(days=1)
+    w.write({"ts_ms": _ts_ms(day1), "symbol": "BTC", "side": "BUY", "volume_frac": 1, "score": 0.1, "features_hash": "x"})
+    w.write({"ts_ms": _ts_ms(day2), "symbol": "BTC", "side": "SELL", "volume_frac": 2, "score": 0.2, "features_hash": "y"})
+    w.close()
+
+    rotated = tmp_path / "signals-2024-01-01.csv"
+    assert rotated.exists()
+    assert path.exists()
+    assert len(rotated.read_text().strip().splitlines()) == 2
+    assert len(path.read_text().strip().splitlines()) == 2


### PR DESCRIPTION
## Summary
- implement `SignalCSVWriter` with daily rotation, header management and fsync
- log signals via `SignalCSVWriter` in `service_signal_runner`
- add tests for CSV writer rotation and header behaviour

## Testing
- `pytest tests/test_signal_bus.py tests/test_signal_csv_writer.py -q`
- `pytest -q` *(fails: assert [] == [1] in tests/test_execution_rules.py::test_unquantized_limit_rejected_sim, tests/test_execution_rules.py::test_ttl_two_steps_sim, tests/test_limit_mid_bps_profile.py::test_limit_mid_bps_profile, tests/test_limit_order_ttl.py::test_limit_order_ttl_expires, tests/test_limit_order_ttl.py::test_limit_order_ttl_survives, tests/test_limit_order_ttl.py::test_limit_order_ioc_partial_cancel, tests/test_limit_order_ttl.py::test_limit_order_fok_partial_cancel, tests/test_market_open_h1.py::test_market_open_next_h1_slippage, tests/test_market_open_h1.py::test_market_open_next_h1_snapshot_price, tests/test_no_trade_mask.py::test_funding_buffer_blocks_orders, tests/test_no_trade_mask.py::test_custom_window_blocks_orders)*

------
https://chatgpt.com/codex/tasks/task_e_68c710d953d0832fb87fe258eb270cd5