### PR TITLE
Atomically write snapshot metrics and log flush summary

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -735,7 +735,15 @@ class ServiceSignalRunner:
                 shutdown.on_flush(signal_log.flush)
         if hasattr(signal_bus, "flush"):
             shutdown.on_flush(signal_bus.flush)
-        shutdown.on_flush(lambda: monitoring.snapshot_metrics(json_path, csv_path))
+
+        def _flush_snapshot() -> None:
+            try:
+                summary, json_str, _ = monitoring.snapshot_metrics(json_path, csv_path)
+                self.logger.info("SNAPSHOT %s", json_str)
+            except Exception:
+                pass
+
+        shutdown.on_flush(_flush_snapshot)
 
         def _write_marker() -> None:
             try:
@@ -745,8 +753,8 @@ class ServiceSignalRunner:
 
         def _final_summary() -> None:
             try:
-                summary_json, _ = monitoring.snapshot_metrics(json_path, csv_path)
-                self.logger.info("SUMMARY %s", summary_json)
+                summary, json_str, _ = monitoring.snapshot_metrics(json_path, csv_path)
+                self.logger.info("SUMMARY %s", json_str)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- Write snapshot metrics using temporary files and `os.fsync` for durability
- Expose structured summary from `snapshot_metrics` and log it on runner flush

## Testing
- `python -m py_compile services/monitoring.py service_signal_runner.py`
- `pytest tests/test_logging_columns.py -q`
- `pytest tests/test_signal_csv_writer.py -q` *(fails: ModuleNotFoundError: No module named 'services')*

------
https://chatgpt.com/codex/tasks/task_e_68c712681edc832f8f94bb4693eee028