### PR TITLE
Gracefully stop BinanceWS streams

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -729,7 +729,10 @@ class ServiceSignalRunner:
 
         ws_client = getattr(self.adapter, "ws", None) or getattr(self.adapter, "source", None)
         if ws_client is not None and hasattr(ws_client, "stop"):
-            shutdown.on_stop(lambda: ws_client.stop())
+            async def _stop_ws_client() -> None:
+                await ws_client.stop()
+
+            shutdown.on_stop(_stop_ws_client)
 
         shutdown.on_stop(worker._drain_queue)
 

--- a/tests/test_degradation_logging.py
+++ b/tests/test_degradation_logging.py
@@ -116,20 +116,31 @@ def test_binance_ws_degradation_logging(monkeypatch, caplog):
         class MockWS:
             def __init__(self, msgs):
                 self.msgs = list(msgs)
+
             async def __aenter__(self):
                 return self
+
             async def __aexit__(self, exc_type, exc, tb):
-                client.stop()
+                await client.stop()
+
             def __aiter__(self):
                 return self
+
             async def __anext__(self):
                 if not self.msgs:
                     raise StopAsyncIteration
                 return self.msgs.pop(0)
+
             async def ping(self):
                 fut = asyncio.Future()
                 fut.set_result(None)
                 return fut
+
+            async def send(self, _msg):
+                return None
+
+            async def close(self):
+                return None
 
         async def dummy_sleep(_):
             pass


### PR DESCRIPTION
## Summary
- track websocket instance and stop flag in BinanceWS
- add async stop with unsubscribe and connection close
- await websocket stop in ServiceSignalRunner shutdown

## Testing
- `pytest tests/test_degradation_logging.py::test_binance_ws_degradation_logging tests/test_rate_limiter.py::test_binance_ws_rate_limit_counters -q`


------
https://chatgpt.com/codex/tasks/task_e_68c717346998832f8836da0ec8b60a3d