### PR TITLE
Add shutdown configuration and pass to ShutdownManager

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -25,6 +25,14 @@ clock_sync:
   kill_threshold_ms: 2000 # Terminate if drift exceeds this many milliseconds
   max_step_ms: 1000       # Max single adjustment step in milliseconds
   attempts: 5             # Number of sync attempts before giving up
+
+shutdown:
+  grace_period: 5.0           # Seconds to wait between stop and flush phases
+  drain_policy: graceful      # How to drain outstanding work
+  timeouts:
+    stop: 10.0                # Seconds to wait for stop callbacks
+    flush: 10.0               # Seconds to wait for flush callbacks
+    finalize: 5.0             # Seconds to wait for finalize callbacks
 ttl:
   enabled: false
   ttl_seconds: 60

--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -16,6 +16,14 @@ kill_switch:
   ws_failures: 100         # Enter safe mode if WS failures exceed this count; 0 disables
   error_rate: 0.2          # Enter safe mode if signal error rate exceeds this fraction; 0 disables
 
+shutdown:
+  grace_period: 5.0           # Seconds to wait between stop and flush phases
+  drain_policy: graceful      # How to drain outstanding work
+  timeouts:
+    stop: 10.0                # Seconds to wait for stop callbacks
+    flush: 10.0               # Seconds to wait for flush callbacks
+    finalize: 5.0             # Seconds to wait for finalize callbacks
+
 ttl:
   enabled: false
   ttl_seconds: 60


### PR DESCRIPTION
## Summary
- add shutdown settings to live and ops configs
- load shutdown config in service_signal_runner and pass to ShutdownManager

## Testing
- `pytest` *(fails: assert [] == [1], Unsupported action type, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c718327e60832f828b9f2cef404f4a