### PR TITLE
Handle dirty restarts via marker

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -308,6 +308,19 @@ def kill_switch_info() -> Dict[str, Any]:
     return dict(_kill_reason)
 
 
+def reset_kill_switch_counters() -> None:
+    """Reset kill switch metrics and internal state."""
+    ws_failure_count._metrics.clear()
+    signal_boundary_count._metrics.clear()
+    signal_absolute_count._metrics.clear()
+    signal_published_count._metrics.clear()
+    _feed_lag_max.clear()
+    global _kill_triggered, _kill_reason
+    _kill_triggered = False
+    _kill_reason = {}
+    _check_kill_switch()
+
+
 def _check_kill_switch() -> None:
     """Evaluate metrics against thresholds and update kill switch state."""
     global _kill_triggered, _kill_reason
@@ -486,5 +499,6 @@ __all__ = [
     "inc_reason",
     "kill_switch_triggered",
     "kill_switch_info",
+    "reset_kill_switch_counters",
     "snapshot_metrics",
 ]


### PR DESCRIPTION
## Summary
- track clean/dirty restarts via marker file
- reset kill-switch counters and restore state after dirty restart
- expose marker_path configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gymnasium')*


------
https://chatgpt.com/codex/tasks/task_e_68c719324054832f8efef93a3986d400