### PR TITLE
Add resilient atomic file writes

### DIFF
--- a/services/signal_csv_writer.py
+++ b/services/signal_csv_writer.py
@@ -5,6 +5,8 @@ import os
 from datetime import datetime, date
 from typing import Dict, Sequence, Any
 
+from .utils_app import atomic_write_with_retry
+
 
 class SignalCSVWriter:
     """Write signal rows to a CSV file with daily rotation.
@@ -109,7 +111,7 @@ class SignalCSVWriter:
             return
         try:
             self._file.flush()
-            os.fsync(self._file.fileno())
+            atomic_write_with_retry(self.path, None, retries=3, backoff=0.1)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- add `atomic_write_with_retry` helper with ALERT logging
- use new atomic helper in CSV writer, monitoring metrics snapshot, and state store persistence

## Testing
- `pytest` *(fails: No module named 'pandas', 'numpy', 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68c71a6d31c0832f892fc90d9a618ce9