### PR TITLE
Add ops kill switch configuration

### DIFF
--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -15,6 +15,13 @@ kill_switch:
   feed_lag_ms: 60000       # Enter safe mode if worst feed lag exceeds this; 0 disables
   ws_failures: 100         # Enter safe mode if WS failures exceed this count; 0 disables
   error_rate: 0.2          # Enter safe mode if signal error rate exceeds this fraction; 0 disables
+  enabled: false           # Enable or disable the ops kill switch
+  error_limit: 0           # Maximum allowed consecutive errors; 0 disables
+  duplicate_limit: 0       # Maximum allowed duplicate signals; 0 disables
+  stale_intervals_limit: 0 # Maximum allowed stale intervals; 0 disables
+  reset_cooldown_sec: 60   # Cooldown period before counters reset in seconds
+  flag_path: null          # File path acting as external kill flag
+  alert_command: null      # Command to execute when kill switch triggers
 
 shutdown:
   grace_period: 5.0           # Seconds to wait between stop and flush phases

--- a/configs/runtime.yaml
+++ b/configs/runtime.yaml
@@ -30,3 +30,10 @@ ops:
     feed_lag_ms: 60000       # Enter safe mode if worst feed lag exceeds this; 0 disables
     ws_failures: 100         # Enter safe mode if WS failures exceed this count; 0 disables
     error_rate: 0.2          # Enter safe mode if signal error rate exceeds this fraction; 0 disables
+    enabled: false           # Enable or disable the ops kill switch
+    error_limit: 0           # Maximum allowed consecutive errors; 0 disables
+    duplicate_limit: 0       # Maximum allowed duplicate signals; 0 disables
+    stale_intervals_limit: 0 # Maximum allowed stale intervals; 0 disables
+    reset_cooldown_sec: 60   # Cooldown period before counters reset in seconds
+    flag_path: null          # File path acting as external kill flag
+    alert_command: null      # Command to execute when kill switch triggers

--- a/core_config.py
+++ b/core_config.py
@@ -131,6 +131,18 @@ class KillSwitchConfig(BaseModel):
     )
 
 
+class OpsKillSwitchConfig(BaseModel):
+    """Operational kill switch settings."""
+
+    enabled: bool = False
+    error_limit: int = 0
+    duplicate_limit: int = 0
+    stale_intervals_limit: int = 0
+    reset_cooldown_sec: int = 60
+    flag_path: Optional[str] = None
+    alert_command: Optional[str] = None
+
+
 class CommonRunConfig(BaseModel):
     run_id: Optional[str] = Field(
         default=None, description="Идентификатор запуска; если None — генерируется."
@@ -160,6 +172,7 @@ class CommonRunConfig(BaseModel):
     ttl: TTLConfig = Field(default_factory=TTLConfig)
     throttle: ThrottleConfig = Field(default_factory=ThrottleConfig)
     kill_switch: KillSwitchConfig = Field(default_factory=KillSwitchConfig)
+    kill_switch_ops: OpsKillSwitchConfig = Field(default_factory=OpsKillSwitchConfig)
     components: Components
 
 
@@ -355,6 +368,7 @@ __all__ = [
     "TTLConfig",
     "ThrottleConfig",
     "KillSwitchConfig",
+    "OpsKillSwitchConfig",
     "CommonRunConfig",
     "SimulationDataConfig",
     "SimulationConfig",

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -948,6 +948,31 @@ def from_config(
         cfg.kill_switch.error_rate = float(
             kill_cfg.get("error_rate", cfg.kill_switch.error_rate)
         )
+        cfg.kill_switch_ops.enabled = bool(
+            kill_cfg.get("enabled", cfg.kill_switch_ops.enabled)
+        )
+        cfg.kill_switch_ops.error_limit = int(
+            kill_cfg.get("error_limit", cfg.kill_switch_ops.error_limit)
+        )
+        cfg.kill_switch_ops.duplicate_limit = int(
+            kill_cfg.get("duplicate_limit", cfg.kill_switch_ops.duplicate_limit)
+        )
+        cfg.kill_switch_ops.stale_intervals_limit = int(
+            kill_cfg.get(
+                "stale_intervals_limit", cfg.kill_switch_ops.stale_intervals_limit
+            )
+        )
+        cfg.kill_switch_ops.reset_cooldown_sec = int(
+            kill_cfg.get(
+                "reset_cooldown_sec", cfg.kill_switch_ops.reset_cooldown_sec
+            )
+        )
+        cfg.kill_switch_ops.flag_path = kill_cfg.get(
+            "flag_path", cfg.kill_switch_ops.flag_path
+        )
+        cfg.kill_switch_ops.alert_command = kill_cfg.get(
+            "alert_command", cfg.kill_switch_ops.alert_command
+        )
 
     # Pipeline configuration
     def _parse_pipeline(data: Dict[str, Any]) -> PipelineConfig:


### PR DESCRIPTION
## Summary
- support ops kill switch configuration in common config via new `OpsKillSwitchConfig`
- parse runtime ops.kill_switch section into new config
- document ops kill switch settings in ops and runtime configs

## Testing
- `pytest tests/test_kill_switch_config.py tests/test_kill_switch.py tests/test_metric_kill_switch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7234116fc832f99e6a4a1f8e20f46