### PR TITLE
Integrate operational kill switch

### DIFF
--- a/configs/ops.yaml
+++ b/configs/ops.yaml
@@ -22,6 +22,7 @@ kill_switch:
   reset_cooldown_sec: 60   # Cooldown period before counters reset in seconds
   flag_path: null          # File path acting as external kill flag
   alert_command: null      # Command to execute when kill switch triggers
+  # Manual reset: delete the flag file or call ops_kill_switch.manual_reset()
 
 shutdown:
   grace_period: 5.0           # Seconds to wait between stop and flush phases

--- a/configs/runtime.yaml
+++ b/configs/runtime.yaml
@@ -37,3 +37,4 @@ ops:
     reset_cooldown_sec: 60   # Cooldown period before counters reset in seconds
     flag_path: null          # File path acting as external kill flag
     alert_command: null      # Command to execute when kill switch triggers
+    # Manual reset: delete the flag file or call ops_kill_switch.manual_reset()

--- a/tests/test_ops_kill_switch.py
+++ b/tests/test_ops_kill_switch.py
@@ -1,0 +1,39 @@
+import json, pathlib, sys
+
+# Ensure stdlib logging is used instead of local logging.py
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_orig_sys_path = list(sys.path)
+sys.path = [p for p in sys.path if p not in ("", str(REPO_ROOT))]
+import logging as std_logging  # type: ignore
+sys.modules["logging"] = std_logging
+sys.path = _orig_sys_path
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from services import ops_kill_switch
+
+
+def test_flag_file_trips_safe_mode(tmp_path):
+    flag = tmp_path / "flag"
+    state = tmp_path / "state.json"
+    cfg = {"flag_path": str(flag), "state_path": str(state)}
+    ops_kill_switch.init(cfg)
+    assert not ops_kill_switch.tripped()
+    flag.write_text("1")
+    ops_kill_switch.init(cfg)
+    assert ops_kill_switch.tripped()
+    ops_kill_switch.manual_reset()
+    assert not ops_kill_switch.tripped()
+    assert not flag.exists()
+
+
+def test_tick_persists_state(tmp_path):
+    flag = tmp_path / "flag"
+    state = tmp_path / "state.json"
+    cfg = {"flag_path": str(flag), "state_path": str(state)}
+    ops_kill_switch.init(cfg)
+    ops_kill_switch.record_error("rest")
+    ops_kill_switch.tick()
+    data = json.loads(state.read_text())
+    assert data["counters"]["rest"] == 1
+    ops_kill_switch.manual_reset()


### PR DESCRIPTION
## Summary
- wire up operational kill switch and periodic persistence in service runner
- add persistent ops kill switch module with manual reset docs and tick helper
- document reset instructions in ops runtime configs

## Testing
- `pytest tests/test_ops_kill_switch.py tests/test_kill_switch.py tests/test_metric_kill_switch.py tests/test_kill_switch_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c724cf67fc832f90365f8943691869