### PR TITLE
Track duplicate signals via ops kill switch

### DIFF
--- a/services/ops_kill_switch.py
+++ b/services/ops_kill_switch.py
@@ -168,6 +168,16 @@ def record_duplicate() -> None:
     _record_generic("duplicates")
 
 
+def reset_duplicates() -> None:
+    """Reset duplicate message counter."""
+    now = time.time()
+    with _lock:
+        _maybe_reset_all(now)
+        _counters["duplicates"] = 0
+        _last_ts["duplicates"] = now
+        _save_state()
+
+
 def record_stale() -> None:
     """Record a stale interval event."""
     _record_generic("stale")

--- a/tests/test_ops_kill_switch.py
+++ b/tests/test_ops_kill_switch.py
@@ -37,3 +37,14 @@ def test_tick_persists_state(tmp_path):
     data = json.loads(state.read_text())
     assert data["counters"]["rest"] == 1
     ops_kill_switch.manual_reset()
+
+
+def test_reset_duplicates(tmp_path):
+    flag = tmp_path / "flag"
+    state = tmp_path / "state.json"
+    cfg = {"flag_path": str(flag), "state_path": str(state)}
+    ops_kill_switch.init(cfg)
+    ops_kill_switch.record_duplicate()
+    assert json.loads(state.read_text())["counters"]["duplicates"] == 1
+    ops_kill_switch.reset_duplicates()
+    assert json.loads(state.read_text())["counters"]["duplicates"] == 0


### PR DESCRIPTION
## Summary
- route duplicate signal drops to `ops_kill_switch`
- reset kill switch duplicate counter after successful signal send
- expose `reset_duplicates` API and add tests

## Testing
- `pytest tests/test_signal_bus.py tests/test_ops_kill_switch.py`

------
https://chatgpt.com/codex/tasks/task_e_68c72adf3450832f85bcc6b9ce502b69