### PR TITLE
Persist ops kill switch counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ max_backoff_s: 60.0
 BinancePublicClient rate limiting: delayed=5.00% (6/120), rejected=1.00% (1/120)
 ```
 
+## Operational kill switch reset
+
+The operational kill switch persists its counters in `state/ops_state.json` and
+sets a flag file at `state/ops_kill_switch.flag` when tripped. To recover
+manually, remove the flag and reset the counters:
+
+```bash
+python scripts/reset_kill_switch.py
+```
+
+The script deletes the flag file and calls `ops_kill_switch.manual_reset()`.
+
 ## Large order execution
 
 Orders whose notional exceeds `notional_threshold` are split by a deterministic algorithm.

--- a/scripts/reset_kill_switch.py
+++ b/scripts/reset_kill_switch.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Reset operational kill switch counters and remove flag file."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from services import ops_kill_switch
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Delete the kill switch flag file and reset counters."
+    )
+    parser.add_argument(
+        "--flag-path",
+        default="state/ops_kill_switch.flag",
+        help="Path to kill switch flag file",
+    )
+    parser.add_argument(
+        "--state-path",
+        default="state/ops_state.json",
+        help="Path to kill switch state file",
+    )
+    args = parser.parse_args()
+
+    flag = Path(args.flag_path)
+    try:
+        flag.unlink(missing_ok=True)  # type: ignore[arg-type]
+    except Exception:
+        pass
+
+    ops_kill_switch.init({"flag_path": args.flag_path, "state_path": args.state_path})
+    ops_kill_switch.manual_reset()
+    print("Kill switch counters reset and flag file removed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS = ROOT / "tests"
+
+# Load stdlib logging before project paths are added
+sys.path = [p for p in sys.path if p not in {str(ROOT), str(TESTS)}]
+import logging  # noqa: F401
+sys.path.extend([str(ROOT), str(TESTS)])

--- a/tests/test_state_store_kill_switch.py
+++ b/tests/test_state_store_kill_switch.py
@@ -1,0 +1,21 @@
+import json
+from state_store import kill_switch_counters, load, save
+
+
+def test_kill_switch_counters_persisted(tmp_path):
+    store = tmp_path / "store.json"
+    ops = tmp_path / "ops.json"
+
+    kill_switch_counters.clear()
+    kill_switch_counters.update({"rest": 1, "ws": 2})
+    save(store, ops)
+
+    data = json.loads(ops.read_text())
+    assert data["counters"] == {"rest": 1, "ws": 2}
+
+    kill_switch_counters.clear()
+    load(store, ops)
+    assert kill_switch_counters == {"rest": 1, "ws": 2}
+
+    main_data = json.loads(store.read_text())
+    assert "kill_switch_counters" not in main_data


### PR DESCRIPTION
## Summary
- Persist kill switch counters via dedicated `state/ops_state.json`
- Add `reset_kill_switch.py` helper to clear flag and reset counters
- Document manual reset steps

## Testing
- `pytest tests/test_state_store_kill_switch.py tests/test_ops_kill_switch.py tests/test_signal_bus.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72d61ca78832fb5a6b9e892ba8f23