### PR TITLE
Trigger alert command on ops kill switch trip

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -680,7 +680,9 @@ class ServiceSignalRunner:
         if self.cfg.kill_switch_ops.flag_path:
             ops_cfg["flag_path"] = self.cfg.kill_switch_ops.flag_path
         if self.cfg.kill_switch_ops.alert_command:
-            ops_cfg["alert_cmd"] = shlex.split(self.cfg.kill_switch_ops.alert_command)
+            ops_cfg["alert_command"] = shlex.split(
+                self.cfg.kill_switch_ops.alert_command
+            )
         ops_kill_switch.init(ops_cfg)
 
         ops_flush_stop = threading.Event()


### PR DESCRIPTION
## Summary
- execute optional `alert_command` via `subprocess.run` when ops kill switch trips
- wire up `alert_command` config for signal runner
- test alert command execution and failure handling

## Testing
- `pytest tests/test_ops_kill_switch.py tests/test_signal_bus.py`

------
https://chatgpt.com/codex/tasks/task_e_68c72efb26c4832fb0109527d503a997