### PR TITLE
Add retry configuration support for signal runner

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -143,6 +143,20 @@ class OpsKillSwitchConfig(BaseModel):
     alert_command: Optional[str] = None
 
 
+class RetryConfig(BaseModel):
+    """Retry strategy settings."""
+
+    max_attempts: int = Field(
+        default=5, description="Maximum number of retry attempts; non-positive disables"
+    )
+    backoff_base_s: float = Field(
+        default=2.0, description="Initial backoff in seconds for retry backoff"
+    )
+    max_backoff_s: float = Field(
+        default=60.0, description="Maximum backoff in seconds for retry backoff"
+    )
+
+
 class CommonRunConfig(BaseModel):
     run_id: Optional[str] = Field(
         default=None, description="Идентификатор запуска; если None — генерируется."
@@ -173,6 +187,7 @@ class CommonRunConfig(BaseModel):
     throttle: ThrottleConfig = Field(default_factory=ThrottleConfig)
     kill_switch: KillSwitchConfig = Field(default_factory=KillSwitchConfig)
     kill_switch_ops: OpsKillSwitchConfig = Field(default_factory=OpsKillSwitchConfig)
+    retry: RetryConfig = Field(default_factory=RetryConfig)
     components: Components
 
 
@@ -369,6 +384,7 @@ __all__ = [
     "ThrottleConfig",
     "KillSwitchConfig",
     "OpsKillSwitchConfig",
+    "RetryConfig",
     "CommonRunConfig",
     "SimulationDataConfig",
     "SimulationConfig",

--- a/tests/test_retry_config.py
+++ b/tests/test_retry_config.py
@@ -1,0 +1,71 @@
+import json
+import types
+import sys
+
+import service_signal_runner
+from core_config import (
+    SimulationConfig,
+    SimulationDataConfig,
+    ComponentSpec,
+    Components,
+)
+
+
+class _Guards:
+    def apply(self, ts_ms, symbol, decisions):
+        return decisions, None
+
+
+def _make_stub_module() -> None:
+    mod = types.ModuleType("stub_comp")
+    class MarketData:  # noqa: D401 - simple stub
+        pass
+    class FeaturePipe:
+        def warmup(self):
+            pass
+    class Policy:  # noqa: D401 - simple stub
+        pass
+    class Executor:  # noqa: D401 - simple stub
+        pass
+    mod.MarketData = MarketData
+    mod.FeaturePipe = FeaturePipe
+    mod.Policy = Policy
+    mod.Executor = Executor
+    mod.Guards = _Guards
+    sys.modules["stub_comp"] = mod
+
+
+def test_retry_config_override(tmp_path, monkeypatch):
+    _make_stub_module()
+    configs_dir = tmp_path / "configs"
+    configs_dir.mkdir()
+    (configs_dir / "ops.json").write_text(
+        json.dumps({
+            "retry": {
+                "max_attempts": 7,
+                "backoff_base_s": 0.5,
+                "max_backoff_s": 5.0,
+            }
+        })
+    )
+
+    comps = Components(
+        market_data=ComponentSpec(target="stub_comp:MarketData"),
+        executor=ComponentSpec(target="stub_comp:Executor"),
+        feature_pipe=ComponentSpec(target="stub_comp:FeaturePipe"),
+        policy=ComponentSpec(target="stub_comp:Policy"),
+        risk_guards=ComponentSpec(target="stub_comp:Guards"),
+    )
+    cfg = SimulationConfig(
+        components=comps,
+        data=SimulationDataConfig(symbols=["BTCUSDT"], timeframe="1m"),
+        symbols=["BTCUSDT"],
+    )
+
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        service_signal_runner.from_config(cfg)
+
+    assert cfg.retry.max_attempts == 7
+    assert cfg.retry.backoff_base_s == 0.5
+    assert cfg.retry.max_backoff_s == 5.0


### PR DESCRIPTION
## Summary
- add `RetryConfig` with retry/backoff settings
- load `retry` section from `configs/ops.yaml` or `ops.json` into `CommonRunConfig`
- cover retry loading with a unit test

## Testing
- `pytest tests/test_retry_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b8f10c10832f9176b4468d31f44c