### PR TITLE
Add retry config wiring and ops error tracking

### DIFF
--- a/di_registry.py
+++ b/di_registry.py
@@ -15,7 +15,7 @@ import inspect
 from typing import Any, Dict, Mapping, Optional, Type, TypeVar, get_type_hints
 
 from core_errors import ConfigError
-from core_config import ComponentSpec, Components, CommonRunConfig
+from core_config import ComponentSpec, Components, CommonRunConfig, RetryConfig
 
 
 def _load_class(dotted: str):
@@ -95,13 +95,14 @@ def build_graph(components: Components, run_config: Optional[CommonRunConfig] = 
     (BacktestEngine опционален.)
     """
     container: Dict[Any, Any] = {}
+    if run_config is not None:
+        container["run_config"] = run_config
+        container["retry_cfg"] = run_config.retry
+        container[RetryConfig] = run_config.retry
     build_component("market_data", components.market_data, container)
     build_component("feature_pipe", components.feature_pipe, container)
     build_component("policy", components.policy, container)
     build_component("risk_guards", components.risk_guards, container)
-    # пробрасываем конфиг до сборки executor, чтобы он мог получить run_config
-    if run_config is not None:
-        container["run_config"] = run_config
     build_component("executor", components.executor, container)
     if components.backtest_engine:
         build_component("backtest_engine", components.backtest_engine, container)


### PR DESCRIPTION
## Summary
- track consecutive REST/WS errors in SignalRunner and kill switch flush thread
- pass retry configuration to DI-created clients

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gymnasium')*
- `pytest tests/test_ops_kill_switch.py tests/test_signal_bus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7c6d3832c832fb1d250350315ef41