### PR TITLE
Add monitoring aggregator periodic task

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -630,6 +630,17 @@ class MonitoringAggregator:
                 pass
             self._last_flush = now_sec
 
+    def flush(self) -> None:
+        """Force flush of accumulated metrics to disk."""
+        if not self.enabled:
+            return
+        try:
+            # Reset flush timestamp so that ``tick`` writes out immediately.
+            self._last_flush = 0.0
+            self.tick(int(time.time() * 1000))
+        except Exception:
+            pass
+
 
 def snapshot_metrics(json_path: str, csv_path: str) -> Tuple[Dict[str, Any], str, str]:
     """Persist current metrics snapshot to ``json_path`` and ``csv_path``.


### PR DESCRIPTION
## Summary
- instantiate AlertManager and MonitoringAggregator in `ServiceSignalRunner`
- run background monitoring loop calling `aggregator.tick`
- flush monitoring metrics on shutdown

## Testing
- `pytest -q` *(failed: KeyboardInterrupt after 12 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f03fb458832fbbff0145d112ad70