### PR TITLE
Add fill ratio and PnL monitoring to aggregator

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -167,6 +167,8 @@ class MonitoringThresholdsConfig:
     feed_lag_ms: float = 0.0
     ws_failures: float = 0.0
     error_rate: float = 0.0
+    fill_ratio_min: float = 0.0
+    pnl_min: float = 0.0
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- track fill ratio and daily PnL in `MonitoringAggregator`
- alert when fill ratio or PnL fall below configured thresholds
- expose new `fill_ratio_min` and `pnl_min` thresholds in config

## Testing
- `python -m py_compile services/monitoring.py core_config.py`
- `pytest` *(fails: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f760dd5c832f8a2fd05a914ffd93