### PR TITLE
Allow state config overrides and resets for live runner

### DIFF
--- a/script_live.py
+++ b/script_live.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import argparse
 
+from pathlib import Path
+
+import yaml
+
 from core_config import load_config
 from service_signal_runner import from_config
 
@@ -17,9 +21,36 @@ def main() -> None:
         default="configs/config_live.yaml",
         help="Путь к YAML-конфигу запуска",
     )
+    p.add_argument(
+        "--state-config",
+        default="configs/state.yaml",
+        help="Путь к YAML-конфигу состояния",
+    )
+    p.add_argument(
+        "--reset-state",
+        action="store_true",
+        help="Удалить файлы состояния перед запуском",
+    )
     args = p.parse_args()
 
+    try:
+        with open(args.state_config, "r", encoding="utf-8") as f:
+            state_data = yaml.safe_load(f) or {}
+    except Exception:
+        state_data = {}
+
+    if args.reset_state:
+        for key in ("path", "lock_path"):
+            pth = state_data.get(key)
+            if pth:
+                try:
+                    Path(pth).unlink(missing_ok=True)  # type: ignore[arg-type]
+                except Exception:
+                    pass
+
     cfg = load_config(args.config)
+    if state_data:
+        cfg.state = cfg.state.copy(update=state_data)
 
     for report in from_config(cfg, snapshot_config_path=args.config):
         print(report)

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -1170,28 +1170,6 @@ def from_config(
         except Exception:
             rt_cfg = {}
 
-    # Load state persistence configuration
-    state_data: Dict[str, Any] = {}
-    state_cfg_path = Path("configs/state.yaml")
-    if state_cfg_path.exists():
-        try:
-            with state_cfg_path.open("r", encoding="utf-8") as f:
-                state_data = yaml.safe_load(f) or {}
-        except Exception:
-            state_data = {}
-    if state_data:
-        cfg.state.enabled = bool(state_data.get("enabled", cfg.state.enabled))
-        cfg.state.backend = str(state_data.get("backend", cfg.state.backend))
-        cfg.state.path = str(state_data.get("path", cfg.state.path))
-        cfg.state.snapshot_interval_s = int(
-            state_data.get("snapshot_interval_s", cfg.state.snapshot_interval_s)
-        )
-        cfg.state.flush_on_event = bool(
-            state_data.get("flush_on_event", cfg.state.flush_on_event)
-        )
-        cfg.state.backup_keep = int(state_data.get("backup_keep", cfg.state.backup_keep))
-        cfg.state.lock_path = str(state_data.get("lock_path", cfg.state.lock_path))
-
     # Queue configuration for the asynchronous event bus
     queue_cfg = rt_cfg.get("queue", {})
     queue_capacity = int(queue_cfg.get("capacity", 0))


### PR DESCRIPTION
## Summary
- add `--state-config` and `--reset-state` options to `script_live.py`
- merge loaded state settings into `CommonRunConfig.state`
- remove hardcoded state config loading from `service_signal_runner.from_config`

## Testing
- `pytest tests/test_retry_config.py::test_retry_config_override -q`
- `pytest tests/test_clock.py::test_sync_clock_updates_skew tests/test_clock.py::test_sync_clock_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68c804d7e39c832f8f8d1ca11b00ee48