### PR TITLE
Add state lock and rotating backups

### DIFF
--- a/configs/state.yaml
+++ b/configs/state.yaml
@@ -3,5 +3,7 @@ backend: json
 path: state/state_store.json
 snapshot_interval_s: 60
 flush_on_event: true
+# number of backup files to keep (rotated as .bak1, .bak2, ...); 0 disables
 backup_keep: 3
+# separate lock file to prevent concurrent state access
 lock_path: state/state.lock


### PR DESCRIPTION
## Summary
- rotate state files into numbered backups and keep configurable count
- load state from newest valid backup when primary is corrupt
- document lock file and backup retention in state config

## Testing
- `pytest` *(fails: Interrupted: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c807166190832f879f5543c39c47be