### PR TITLE
Filter Binance symbols by quote volume

### DIFF
--- a/script_fetch_exchange_specs.py
+++ b/script_fetch_exchange_specs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 
 from service_fetch_exchange_specs import run
 
@@ -12,9 +13,28 @@ def main() -> None:
     p.add_argument("--market", choices=["spot", "futures"], default="futures", help="Какой рынок опрашивать")
     p.add_argument("--symbols", default="", help="Список символов через запятую; пусто = все")
     p.add_argument("--out", default="data/exchange_specs.json", help="Куда сохранить JSON")
+    p.add_argument(
+        "--volume-threshold",
+        type=float,
+        default=float(os.getenv("QUOTE_VOLUME_THRESHOLD", 0.0)),
+        help="Минимальный средний quote volume за период",
+    )
+    p.add_argument(
+        "--volume-out",
+        default="data/volume_metrics.json",
+        help="Куда сохранить средний quote volume по символам",
+    )
+    p.add_argument("--days", type=int, default=30, help="Число дней для оценки quote volume")
     args = p.parse_args()
 
-    run(market=args.market, symbols=args.symbols, out=args.out)
+    run(
+        market=args.market,
+        symbols=args.symbols,
+        out=args.out,
+        volume_threshold=args.volume_threshold,
+        volume_out=args.volume_out,
+        days=args.days,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fetch daily klines for last 30 days and compute average quote volume
- drop symbols below volume threshold and save volume metrics
- expose threshold and output options through script CLI

## Testing
- `pytest -q` *(fails: KeyboardInterrupt, 12 passed, 3 skipped, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c80d0ed514832fa14c7485df82ec04