### PR TITLE
Load symbols from universe file

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,7 +73,6 @@ components:
     target: impl_sim_executor:SimExecutor
     params: {symbol: "BTCUSDT"}
 data:
-  symbols: ["BTCUSDT"]
   timeframe: "1m"
 ```
 
@@ -82,6 +81,9 @@ from core_config import load_config
 
 cfg = load_config("configs/config_sim.yaml")
 ```
+
+The runner loads the symbol universe from ``data/universe/symbols.json`` by default.
+Override it via the ``--symbols`` CLI flag or an explicit ``data.symbols`` field.
 
 Отдельные параметры можно переопределить из командной строки. Например,
 так временно изменяются проскальзывание и задержка:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ python script_fetch_exchange_specs.py --market futures --symbols BTCUSDT,ETHUSDT
 python scripts/validate_seasonality.py --historical path/to/trades.csv --multipliers configs/liquidity_latency_seasonality.json
 ```
 
+Runners load the symbol universe from ``data/universe/symbols.json`` by default.
+Override it with the ``--symbols`` CLI flag or an explicit ``data.symbols``
+entry in the YAML configuration.
+
 ### Обновление биржевых фильтров и спецификаций
 
 JSON‑файлы `binance_filters.json` и `exchange_specs.json` содержат поле

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -42,8 +42,7 @@ api:
   api_key: null
   api_secret: null
 data:
-  symbols: ["BTCUSDT"]
-  timeframe: "1m"
+  timeframe: "1m"  # symbols are loaded from data/universe/symbols.json
 # Optional path to 168 hourly liquidity multipliers (indexed by UTC hour-of-week;
 # values clamped to [0.1, 10.0])
 liquidity_seasonality_path: "configs/liquidity_latency_seasonality.json"

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -31,12 +31,9 @@ latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
 use_seasonality: true
 
 market: spot
-spot_symbols: ["BTCUSDT"]
-futures_symbols: ["BTCUSDT"]
 
 data:
-  symbols: ["BTCUSDT"]
-  timeframe: "1m"
+  timeframe: "1m"  # symbols are loaded from data/universe/symbols.json
 
 model:
   algo: "ppo"

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -37,12 +37,9 @@ latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
 use_seasonality: true
 
 market: spot  # or futures
-spot_symbols: &spot_symbols ["BTCUSDT"]
-futures_symbols: &futures_symbols ["BTCUSDT"]
 
 data:
-  symbols: *spot_symbols
-  timeframe: "1m"
+  timeframe: "1m"  # symbols are loaded from data/universe/symbols.json
 
 model:
   algo: "ppo"

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -31,12 +31,9 @@ latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
 use_seasonality: true
 
 market: spot
-spot_symbols: ["BTCUSDT"]
-futures_symbols: ["BTCUSDT"]
 
 data:
-  symbols: ["BTCUSDT"]
-  timeframe: "1m"
+  timeframe: "1m"  # symbols are loaded from data/universe/symbols.json
 
 model:
   algo: "ppo"

--- a/configs/legacy_realtime.yaml
+++ b/configs/legacy_realtime.yaml
@@ -1,7 +1,6 @@
 # configs/realtime.yaml
 market: "futures"             # "spot" или "futures" (используется для бэкапа REST в backfill)
-symbols:
-  - "BTCUSDT"
+# symbols are loaded from data/universe/symbols.json
 interval: "1m"
 
 max_signals_per_sec: 5.0

--- a/docs/data_degradation.md
+++ b/docs/data_degradation.md
@@ -20,7 +20,6 @@ unchanged.
 
 ```yaml
 # config_sim.yaml
-symbols: ["BTCUSDT"]
 data_degradation:
   stale_prob: 0.1
   drop_prob: 0.05
@@ -28,6 +27,8 @@ data_degradation:
   max_delay_ms: 50
   seed: 42
 ```
+
+By default, runners load symbols from ``data/universe/symbols.json``.
 
 Run:
 
@@ -41,11 +42,12 @@ python script_backtest.py --config config_sim.yaml
 from binance_ws import BinanceWS
 from services.event_bus import EventBus
 from config import DataDegradationConfig
+from services.universe import get_symbols
 
 cfg = DataDegradationConfig(stale_prob=0.05, drop_prob=0.02,
                             dropout_prob=0.1, max_delay_ms=50, seed=7)
 bus = EventBus(queue_size=1000, drop_policy="newest")
-ws = BinanceWS(symbols=["BTCUSDT"], bus=bus, data_degradation=cfg)
+ws = BinanceWS(symbols=get_symbols(), bus=bus, data_degradation=cfg)
 ws.run()
 ```
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -42,13 +42,16 @@ PipelineConfig(
     enabled=True,
     stages={
         "closed_bar": PipelineStageConfig(enabled=True),
-        "windows": PipelineStageConfig(enabled=True, params={"symbols": ["BTCUSDT"]}),
+        "windows": PipelineStageConfig(enabled=True),
         "policy": PipelineStageConfig(enabled=True),
         "risk": PipelineStageConfig(enabled=True),
         "publish": PipelineStageConfig(enabled=True),
     },
 )
 ```
+
+By default, symbol lists come from ``data/universe/symbols.json`` and can be
+overridden via CLI or ``data.symbols`` in the configuration.
 
 Disabling a stage removes it from the processing chain.  Individual stage
 parameters allow finer control, such as no-trade window definitions or risk


### PR DESCRIPTION
## Summary
- Read symbol lists from `data/universe/symbols.json` when configs omit symbols
- Remove explicit symbol arrays from example configs and docs
- Allow overriding symbols via CLI or `data.symbols`

## Testing
- `pytest tests/test_retry_config.py::test_yaml_retry` *(fails: ImportError: cannot import name 'LogRecord' from 'logging')*

------
https://chatgpt.com/codex/tasks/task_e_68c814668eb0832fb8117a069ae6c7df