### PR TITLE
Add refreshed Binance filters dataset

### DIFF
--- a/data/binance_filters.json
+++ b/data/binance_filters.json
@@ -1,0 +1,47 @@
+{
+  "filters": {
+    "BTCUSDT": {
+      "LOT_SIZE": {
+        "maxQty": "1000",
+        "minQty": "0.00001",
+        "stepSize": "0.00001"
+      },
+      "MIN_NOTIONAL": {
+        "minNotional": "10"
+      },
+      "PERCENT_PRICE_BY_SIDE": {
+        "multiplierDown": "0.8",
+        "multiplierUp": "1.2"
+      },
+      "PRICE_FILTER": {
+        "maxPrice": "1000000",
+        "minPrice": "0.01",
+        "tickSize": "0.01"
+      }
+    },
+    "ETHUSDT": {
+      "LOT_SIZE": {
+        "maxQty": "100000",
+        "minQty": "0.0001",
+        "stepSize": "0.0001"
+      },
+      "MIN_NOTIONAL": {
+        "minNotional": "10"
+      },
+      "PERCENT_PRICE_BY_SIDE": {
+        "multiplierDown": "0.8",
+        "multiplierUp": "1.2"
+      },
+      "PRICE_FILTER": {
+        "maxPrice": "1000000",
+        "minPrice": "0.01",
+        "tickSize": "0.01"
+      }
+    }
+  },
+  "metadata": {
+    "built_at": "2025-09-15T16:57:30.622478+00:00",
+    "source": "/api/v3/exchangeInfo",
+    "symbols_count": 2
+  }
+}


### PR DESCRIPTION
## Summary
- add the latest `data/binance_filters.json` generated via the fetch helper so downstream jobs have access to filters metadata

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c844c15fa8832f9eea07010938e667