### PR TITLE
Add new quantizer configuration settings

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -63,6 +63,13 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
+quantizer:
+  filters_path: "binance_filters.json"
+  strict: true
+  enforce_percent_price_by_side: true
+  auto_refresh_days: 30
+  refresh_on_start: false
+ 
 pipeline:
   enabled: true
   stages:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -40,9 +40,11 @@ model:
   params: {}
 
 quantizer:
-  path: "binance_filters.json"
+  filters_path: "binance_filters.json"
   strict: true
   enforce_percent_price_by_side: true
+  auto_refresh_days: 30
+  refresh_on_start: false
 
 fees:
   maker_bps: 1.0

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -46,9 +46,11 @@ model:
   params: {}
 
 quantizer:
-  path: "binance_filters.json"
+  filters_path: "binance_filters.json"
   strict: true
   enforce_percent_price_by_side: true
+  auto_refresh_days: 30
+  refresh_on_start: false
 
 fees:
   maker_bps: 1.0

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -40,9 +40,11 @@ model:
   params: {}
 
 quantizer:
-  path: "binance_filters.json"
+  filters_path: "binance_filters.json"
   strict: true
   enforce_percent_price_by_side: true
+  auto_refresh_days: 30
+  refresh_on_start: false
 
 fees:
   maker_bps: 1.0

--- a/configs/quantizer.yaml
+++ b/configs/quantizer.yaml
@@ -1,0 +1,7 @@
+# Default quantizer configuration shared across run modes.
+quantizer:
+  filters_path: "binance_filters.json"
+  strict: true
+  enforce_percent_price_by_side: true
+  auto_refresh_days: 30
+  refresh_on_start: false

--- a/mediator.py
+++ b/mediator.py
@@ -197,7 +197,7 @@ class Mediator:
         self.quantizer = None
         self.enforce_ppbs = True
         qcfg = getattr(rc, "quantizer", {}) if rc is not None else {}
-        filters_path = qcfg.get("path", "")
+        filters_path = str(qcfg.get("filters_path") or qcfg.get("path") or "")
         strict = bool(qcfg.get("strict", True))
         self.enforce_ppbs = bool(qcfg.get("enforce_percent_price_by_side", True))
         if Quantizer is not None and filters_path:


### PR DESCRIPTION
## Summary
- add quantizer block with the new filters_path and refresh fields to the live, sim, template, and train configs
- provide a reusable quantizer snippet in configs/quantizer.yaml
- update the mediator to read quantizer.filters_path when loading filters

## Testing
- python -m compileall mediator.py

------
https://chatgpt.com/codex/tasks/task_e_68c84960be18832fabe6cfcd233d2f03