### PR TITLE
Add monitoring gauge for Binance filters age

### DIFF
--- a/impl_quantizer.py
+++ b/impl_quantizer.py
@@ -166,10 +166,9 @@ class QuantizerImpl:
             missing,
         )
 
+        age = float(age_days) if age_days is not None else float("nan")
         try:
-            monitoring.filters_age_days.set(
-                float(age_days) if age_days is not None else float("nan")
-            )
+            monitoring.filters_age_days.set(age)
         except Exception:
             pass
 

--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -53,7 +53,7 @@ clock_sync_last_sync_ts = Gauge(
 # Binance filters metadata freshness
 filters_age_days = Gauge(
     "filters_age_days",
-    "Age of the Binance symbol filters file in days",
+    "Age of binance_filters.json in days",
 )
 
 # Length of throttling queue


### PR DESCRIPTION
## Summary
- update the Binance filters age gauge description in the monitoring helpers
- push the computed filters age into the monitoring gauge when the quantizer loads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c84b4c6e1c832fb986f57307294428