### PR TITLE
Instantiate quantizer before building services

### DIFF
--- a/tests/di_stubs.py
+++ b/tests/di_stubs.py
@@ -1,0 +1,32 @@
+"""Stub components used for dependency injection tests."""
+
+from __future__ import annotations
+
+
+class DummyMarketData:
+    def __init__(self, *_, **__):
+        self.started = True
+
+
+class DummyFeaturePipe:
+    def __init__(self, *_, **__):
+        self.ready = True
+
+
+class DummyPolicy:
+    def __init__(self, *_, **__):
+        self.initialized = True
+
+
+class DummyRiskGuards:
+    def __init__(self, *_, **__):
+        self.enabled = True
+
+
+class DummyExecutor:
+    def __init__(self, *_, quantizer=None, **__):
+        self.quantizer = quantizer
+        self.attached = False
+
+    def attach(self):
+        self.attached = True

--- a/tests/test_quantizer_entrypoints.py
+++ b/tests/test_quantizer_entrypoints.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import logging
+import sys
+from types import ModuleType, SimpleNamespace
+
+import yaml
+
+# Provide a lightweight ``requests`` stub if the dependency is absent.
+if "requests" not in sys.modules:  # pragma: no cover - test environment helper
+    class _DummyResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+    class _DummyRequests(ModuleType):
+        def get(self, url, params=None, timeout=0):  # pragma: no cover - simple stub
+            if "ticker/24hr" in url:
+                return _DummyResponse([
+                    {"symbol": "BTCUSDT", "quoteVolume": 1_000_000}
+                ])
+            return _DummyResponse({
+                "symbols": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "status": "TRADING",
+                        "quoteAsset": "USDT",
+                        "permissions": ["SPOT"],
+                    }
+                ]
+            })
+
+    sys.modules["requests"] = _DummyRequests("requests")
+
+from core_config import Components, load_config
+from core_config import RetryConfig
+import di_registry
+from impl_quantizer import QuantizerImpl, QuantizerConfig
+
+
+def _components_stub() -> Components:
+    data = {
+        "market_data": {"target": "tests.di_stubs:DummyMarketData", "params": {}},
+        "executor": {"target": "tests.di_stubs:DummyExecutor", "params": {}},
+        "feature_pipe": {"target": "tests.di_stubs:DummyFeaturePipe", "params": {}},
+        "policy": {"target": "tests.di_stubs:DummyPolicy", "params": {}},
+        "risk_guards": {"target": "tests.di_stubs:DummyRiskGuards", "params": {}},
+    }
+    return Components.parse_obj(data)
+
+
+def test_load_config_preserves_quantizer_section(tmp_path):
+    config_path = tmp_path / "live.yaml"
+    filters_path = tmp_path / "filters.json"
+    cfg_dict = {
+        "mode": "live",
+        "api": {"api_key": "k", "api_secret": "s", "testnet": True},
+        "data": {"symbols": ["BTCUSDT"], "timeframe": "1m"},
+        "components": {
+            "market_data": {"target": "tests.di_stubs:DummyMarketData"},
+            "executor": {"target": "tests.di_stubs:DummyExecutor"},
+            "feature_pipe": {"target": "tests.di_stubs:DummyFeaturePipe"},
+            "policy": {"target": "tests.di_stubs:DummyPolicy"},
+            "risk_guards": {"target": "tests.di_stubs:DummyRiskGuards"},
+        },
+        "quantizer": {
+            "path": str(filters_path),
+            "filters_path": str(filters_path),
+            "auto_refresh_days": 5,
+            "refresh_on_start": False,
+        },
+    }
+    config_path.write_text(yaml.safe_dump(cfg_dict), encoding="utf-8")
+
+    cfg = load_config(str(config_path))
+    assert hasattr(cfg, "quantizer")
+    assert cfg.quantizer == cfg_dict["quantizer"]
+
+
+def test_build_graph_provides_quantizer_instance(tmp_path):
+    filters_path = tmp_path / "filters.json"
+    filters_path.write_text("{\"filters\": {}}", encoding="utf-8")
+    components = _components_stub()
+    run_cfg = SimpleNamespace(quantizer={"path": str(filters_path)}, retry=RetryConfig())
+
+    container = di_registry.build_graph(components, run_cfg)
+
+    assert "quantizer" in container
+    quantizer = container["quantizer"]
+    assert isinstance(quantizer, QuantizerImpl)
+    executor = container["executor"]
+    assert getattr(executor, "quantizer") is quantizer
+
+
+def test_quantizer_warnings_are_logged(monkeypatch, caplog, tmp_path):
+    import impl_quantizer
+
+    filters_path = tmp_path / "filters.json"
+    filters_path.write_text("{\"filters\": {}}", encoding="utf-8")
+
+    def _fake_load_filters(path, max_age_days=0, fatal=False):
+        import warnings
+
+        warnings.warn("refresh recommended soon")
+        return {"BTCUSDT": {"PRICE_FILTER": {}}}, {"generated_at": "2023-01-01T00:00:00Z"}
+
+    monkeypatch.setattr(
+        impl_quantizer.Quantizer,
+        "load_filters",
+        staticmethod(_fake_load_filters),
+    )
+
+    caplog.set_level(logging.WARNING, logger="impl_quantizer")
+    QuantizerImpl(QuantizerConfig(path=str(filters_path), filters_path=str(filters_path)))
+
+    assert any("refresh recommended soon" in record.message for record in caplog.records)
+
+
+def test_quantizer_refresh_is_debounced(monkeypatch, tmp_path):
+    import impl_quantizer
+
+    QuantizerImpl._REFRESH_GUARD.clear()
+
+    filters_path = tmp_path / "filters.json"
+    filters_path.write_text("{\"filters\": {}}", encoding="utf-8")
+
+    def _fake_load_filters(path, max_age_days=0, fatal=False):
+        return {}, {}
+
+    refresh_calls: list[str] = []
+
+    def _fake_refresh(path):
+        refresh_calls.append(path)
+        return False
+
+    monkeypatch.setattr(
+        impl_quantizer.Quantizer,
+        "load_filters",
+        staticmethod(_fake_load_filters),
+    )
+    monkeypatch.setattr(
+        QuantizerImpl,
+        "_refresh_filters",
+        staticmethod(_fake_refresh),
+    )
+
+    cfg = QuantizerConfig(
+        path=str(filters_path),
+        filters_path=str(filters_path),
+        refresh_on_start=True,
+        auto_refresh_days=1,
+    )
+
+    QuantizerImpl(cfg)
+    QuantizerImpl(cfg)
+
+    assert len(refresh_calls) == 1


### PR DESCRIPTION
## Summary
- ensure quantizer settings survive config parsing for all run modes
- build the shared QuantizerImpl in the DI container before wiring components and forward its warnings to logs
- debounce repeated refresh attempts and add tests that cover config preservation, DI injection, logging, and refresh behaviour

## Testing
- pytest tests/test_quantizer_entrypoints.py

------
https://chatgpt.com/codex/tasks/task_e_68c93e58f270832fafc7a142bda631fd