### PR TITLE
Document Binance filter refresh workflow

### DIFF
--- a/crontab.example
+++ b/crontab.example
@@ -2,5 +2,7 @@ SHELL=/bin/bash
 TZ=UTC
 # Every hour at :02, single-run guarded by flock in the wrapper
 2 * * * * /bin/bash -lc '/path/to/project/deploy/run_update.sh'
+# Daily Binance filters refresh at 04:15 UTC
+15 4 * * * /bin/bash -lc 'cd /path/to/project && python scripts/fetch_binance_filters.py --universe --out data/binance_filters.json'
 # Weekly seasonality rebuild every Monday 03:05 UTC
 5 3 * * 1 /bin/bash -lc '/path/to/project/scripts/cron_update_seasonality.sh'


### PR DESCRIPTION
## Summary
- describe the new scripts/fetch_binance_filters.py invocation and the auto_refresh_days/refresh_on_start behaviour in the README
- show a cron example for daily filter refreshes
- add the cron entry to crontab.example for easy copy/paste

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c9432232f8832fa06ab5162d1e70ef