### PR TITLE
Add REST checkpoint handling and resume support

### DIFF
--- a/service_fetch_exchange_specs.py
+++ b/service_fetch_exchange_specs.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import os
+import random
+import signal
 import time
 from datetime import datetime
-from typing import Dict, Sequence
+from typing import Any, Dict, Sequence
 
-import requests
-from binance_public import BinancePublicClient
+from services.rest_budget import RestBudgetSession
 
 
 def _endpoint(market: str) -> str:
@@ -16,6 +17,27 @@ def _endpoint(market: str) -> str:
         return "https://api.binance.com/api/v3/exchangeInfo"
     # по умолчанию возьмём USDT-маржинальные фьючи
     return "https://fapi.binance.com/fapi/v1/exchangeInfo"
+
+
+def _endpoint_key(market: str) -> str:
+    m = str(market).lower().strip()
+    if m == "spot":
+        return "GET /api/v3/exchangeInfo"
+    return "GET /fapi/v1/exchangeInfo"
+
+
+def _klines_endpoint(market: str) -> str:
+    m = str(market).lower().strip()
+    if m == "spot":
+        return "https://api.binance.com/api/v3/klines"
+    return "https://fapi.binance.com/fapi/v1/klines"
+
+
+def _klines_endpoint_key(market: str) -> str:
+    m = str(market).lower().strip()
+    if m == "spot":
+        return "GET /api/v3/klines"
+    return "GET /fapi/v1/klines"
 
 
 def _ensure_dir(path: str) -> None:
@@ -31,19 +53,24 @@ def run(
     volume_threshold: float = 0.0,
     volume_out: str | None = None,
     days: int = 30,
+    *,
+    shuffle: bool = False,
+    session: RestBudgetSession | None = None,
 ) -> Dict[str, Dict[str, float]]:
     """Fetch Binance exchangeInfo and store minimal specs JSON.
 
     Additionally computes average daily quote volume over the last ``days``
     for each symbol and optionally filters out symbols whose average falls
     below ``volume_threshold``.  The computed averages can be stored in
-    ``volume_out`` for transparency.
+    ``volume_out`` for transparency.  When ``shuffle`` is true the symbol
+    processing order is randomised (unless restored from checkpoint).
+    ``session`` controls HTTP budgeting, caching and checkpoint persistence.
     """
 
-    url = _endpoint(market)
-    resp = requests.get(url, timeout=20)
-    resp.raise_for_status()
-    data = resp.json()
+    session = session or RestBudgetSession({})
+    data = session.get(_endpoint(market), endpoint=_endpoint_key(market))
+    if not isinstance(data, dict):
+        raise RuntimeError("Unexpected exchangeInfo response")
 
     if isinstance(symbols, str):
         requested = [s.strip().upper() for s in symbols.split(",") if s.strip()]
@@ -65,33 +92,126 @@ def run(
             elif typ == "LOT_SIZE":
                 step_size = float(f.get("stepSize", 0.0))
             elif typ in ("MIN_NOTIONAL", "NOTIONAL"):
-                # на фьючах ключ называется NOTIONAL
-                min_notional = float(f.get("minNotional", f.get("notional", 0.0)))
+                min_notional = float(
+                    f.get("minNotional", f.get("notional", 0.0))
+                )
         by_symbol[sym] = {
             "tickSize": tick_size,
             "stepSize": step_size,
             "minNotional": min_notional,
         }
 
-    # --- compute average quote volume per symbol ---
-    client = BinancePublicClient()
-    end_ms = int(time.time() * 1000)
-    start_ms = end_ms - int(days) * 86_400_000
+    symbols_order = list(by_symbol.keys())
     avg_quote_vol: Dict[str, float] = {}
-    for sym in list(by_symbol.keys()):
-        try:
-            kl = client.get_klines(
-                market=market,
-                symbol=sym,
-                interval="1d",
-                start_ms=start_ms,
-                end_ms=end_ms,
-                limit=days,
+
+    checkpoint = session.load_checkpoint()
+    start_index = 0
+    if isinstance(checkpoint, dict) and symbols_order:
+        saved_order = checkpoint.get("order") or checkpoint.get("symbols")
+        if isinstance(saved_order, list):
+            normalized = [str(s).upper() for s in saved_order if str(s).strip()]
+            if set(normalized) == set(symbols_order):
+                symbols_order = normalized
+        saved_pos = checkpoint.get("position")
+        if isinstance(saved_pos, (int, float)):
+            start_index = int(saved_pos)
+        saved_vol = checkpoint.get("avg_quote_vol")
+        if isinstance(saved_vol, dict):
+            for key, value in saved_vol.items():
+                sym = str(key).upper()
+                if sym in by_symbol:
+                    try:
+                        avg_quote_vol[sym] = float(value)
+                    except (TypeError, ValueError):
+                        continue
+        start_index = max(0, min(start_index, len(symbols_order)))
+        if start_index > 0:
+            message = (
+                f"Resuming from checkpoint at position {start_index}/{len(symbols_order)}"
             )
-            vols = [float(k[7]) for k in kl]
-            avg_quote_vol[sym] = sum(vols) / len(vols) if vols else 0.0
-        except Exception:
-            avg_quote_vol[sym] = 0.0
+            if start_index < len(symbols_order):
+                message += f" (next={symbols_order[start_index]})"
+            print(message)
+    elif shuffle and symbols_order:
+        rng = random.Random()
+        rng.shuffle(symbols_order)
+
+    handled_signals: dict[int, Any] = {}
+    checkpoint_payload: Dict[str, Any] = {}
+
+    def _update_checkpoint(position: int, *, symbol: str | None = None, completed: bool = False) -> None:
+        nonlocal checkpoint_payload
+        payload: Dict[str, Any] = {
+            "order": symbols_order,
+            "position": position,
+            "avg_quote_vol": {k: float(v) for k, v in avg_quote_vol.items()},
+        }
+        if symbol is not None:
+            payload["current_symbol"] = symbol
+        if completed:
+            payload["completed"] = True
+        checkpoint_payload = payload
+        session.save_checkpoint(checkpoint_payload)
+
+    def _handle_signal(signum: int, frame: Any | None) -> None:  # pragma: no cover - signal handler
+        session.save_checkpoint(checkpoint_payload)
+        if signum == getattr(signal, "SIGINT", None):
+            raise KeyboardInterrupt
+        raise SystemExit(128 + signum)
+
+    _update_checkpoint(start_index)
+
+    for sig in (signal.SIGINT, getattr(signal, "SIGTERM", None)):
+        if sig is None:
+            continue
+        try:
+            handled_signals[sig] = signal.getsignal(sig)
+            signal.signal(sig, _handle_signal)
+        except (ValueError, OSError):  # pragma: no cover - platform dependent
+            handled_signals.pop(sig, None)
+
+    end_ms = int(time.time() * 1000)
+    window_ms = max(1, int(days)) * 86_400_000
+    start_ms = end_ms - window_ms
+    limit = max(1, min(int(days), 1500))
+
+    try:
+        for idx in range(start_index, len(symbols_order)):
+            sym = symbols_order[idx]
+            _update_checkpoint(idx, symbol=sym)
+            params = {
+                "symbol": sym,
+                "interval": "1d",
+                "startTime": start_ms,
+                "endTime": end_ms,
+                "limit": limit,
+            }
+            try:
+                kl = session.get(
+                    _klines_endpoint(market),
+                    params=params,
+                    endpoint=_klines_endpoint_key(market),
+                )
+            except Exception:
+                avg_quote_vol[sym] = 0.0
+            else:
+                vols: list[float] = []
+                if isinstance(kl, list):
+                    for item in kl:
+                        try:
+                            vols.append(float(item[7]))
+                        except (IndexError, TypeError, ValueError):
+                            continue
+                avg_quote_vol[sym] = sum(vols) / len(vols) if vols else 0.0
+            _update_checkpoint(idx + 1, symbol=sym)
+    finally:
+        for sig, handler in handled_signals.items():
+            try:
+                signal.signal(sig, handler)
+            except (ValueError, OSError):  # pragma: no cover - platform dependent
+                pass
+
+    _update_checkpoint(len(symbols_order), completed=True)
 
     if volume_threshold > 0.0:
         before = len(by_symbol)

--- a/tests/test_rest_budget_checkpoint.py
+++ b/tests/test_rest_budget_checkpoint.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("requests")
+
+from services.rest_budget import RestBudgetSession
+
+
+def _session(tmp_path: Path, *, resume: bool = True, enabled: bool = True) -> RestBudgetSession:
+    cfg = {
+        "checkpoint": {
+            "path": str(tmp_path / "ckpt.json"),
+            "enabled": enabled,
+            "resume_from_checkpoint": resume,
+        }
+    }
+    return RestBudgetSession(cfg)
+
+
+def test_save_and_load_checkpoint(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+    payload = {"position": 5, "symbols": ["BTCUSDT", "ETHUSDT"]}
+    session.save_checkpoint(payload)
+
+    ckpt_path = tmp_path / "ckpt.json"
+    assert ckpt_path.exists()
+    on_disk = json.loads(ckpt_path.read_text(encoding="utf-8"))
+    assert on_disk["position"] == 5
+    assert on_disk["symbols"] == ["BTCUSDT", "ETHUSDT"]
+
+    loaded = session.load_checkpoint()
+    assert loaded == on_disk
+
+
+def test_load_checkpoint_disabled(tmp_path: Path) -> None:
+    session = _session(tmp_path, resume=False)
+    session.save_checkpoint({"position": 1})
+    assert session.load_checkpoint() is None
+
+
+def test_save_checkpoint_non_serialisable(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+    class Dummy:
+        pass
+
+    session.save_checkpoint({"obj": Dummy()})
+    assert not (tmp_path / "ckpt.json").exists()


### PR DESCRIPTION
## Summary
- extend `RestBudgetSession` with configurable checkpoint support and helper methods to persist and restore progress
- update `service_fetch_exchange_specs` to use the REST session, shuffle/resume symbol processing, and flush checkpoints on shutdown
- expose new CLI flags for checkpointing in `script_fetch_exchange_specs.py` and add coverage tests for checkpoint behaviour

## Testing
- pytest tests/test_rest_budget_checkpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68c95524c0cc832fb3b3b6c55b56a24f