### PR TITLE
Add concurrent rest budget support for bulk loaders

### DIFF
--- a/configs/rest_budget.yaml
+++ b/configs/rest_budget.yaml
@@ -1,0 +1,17 @@
+# Default REST budget configuration for Binance data fetch scripts.
+# The worker count controls how many concurrent HTTP requests are dispatched.
+# ``batch_size`` limits the number of outstanding requests before producers wait
+# for the queue to free up (acts as a bounded buffer for futures).
+concurrency:
+  workers: 4
+batch_size: 16
+
+# Optional global token bucket; non-positive values disable the limit.
+global:
+  rps: 8.0
+  burst: 8
+
+retry:
+  max_attempts: 5
+  backoff_base_s: 0.5
+  max_backoff_s: 5.0


### PR DESCRIPTION
## Summary
- extend `RestBudgetSession` with a configurable worker pool, bounded submission queue, async helpers, and time-range chunking utilities
- rework `service_fetch_exchange_specs` to fan out symbol downloads in batches with the new helpers while deduplicating chunked responses
- load REST budgeting defaults from `configs/rest_budget.yaml` via an updated CLI that merges checkpoint settings

## Testing
- pytest tests/test_rest_budget_checkpoint.py


------
https://chatgpt.com/codex/tasks/task_e_68c96e422970832f80c0a52779b4e931