### PR TITLE
Refactor Binance public client to use RestBudgetSession

### DIFF
--- a/services/rest_budget.py
+++ b/services/rest_budget.py
@@ -829,11 +829,13 @@ class RestBudgetSession:
         headers: Mapping[str, str] | None = None,
         timeout: float | None = None,
         endpoint: str | None = None,
+        budget: str | None = None,
         tokens: float = 1.0,
     ) -> Any:
         """Perform GET request obeying configured budgets."""
 
-        key = self._resolve_endpoint_key("GET", url, endpoint)
+        override = endpoint or budget
+        key = self._resolve_endpoint_key("GET", url, override)
         stats_key = self._normalize_endpoint_key(key) or key
 
         cache_key: str | None = None


### PR DESCRIPTION
## Summary
- refactor `BinancePublicClient` to rely on `RestBudgetSession`, forwarding budgets for key endpoints and cleaning up the legacy signal limiter
- allow `RestBudgetSession.get` to accept a logical budget alias in addition to endpoint overrides
- refresh the Binance public client tests to assert that the session budget wiring works as expected

## Testing
- pytest tests/test_rate_limiter.py
- pytest tests/test_rest_budget_checkpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68c98d2e94c0832fb2f8760c74f292d2