### PR TITLE
Add signal quality config loading

### DIFF
--- a/configs/signal_quality.yaml
+++ b/configs/signal_quality.yaml
@@ -1,0 +1,6 @@
+enabled: false
+sigma_window: 50
+sigma_threshold: 3.0
+vol_median_window: 100
+vol_floor_frac: 0.05
+log_reason: "OTHER"


### PR DESCRIPTION
## Summary
- add a SignalQualityConfig dataclass and log when the guard is enabled
- load configs/signal_quality.yaml (with optional runtime overrides) and pass it to ServiceSignalRunner
- provide a default configs/signal_quality.yaml template with the expected keys

## Testing
- python -m compileall service_signal_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68ca72d34ea8832f804d56507d4e101e