### PR TITLE
Propagate signal quality config to policy context

### DIFF
--- a/core_contracts.py
+++ b/core_contracts.py
@@ -114,6 +114,7 @@ class PolicyCtx:
     position: Optional[Position] = None
     limits: Optional[PortfolioLimits] = None
     extra: Optional[Dict[str, Any]] = None
+    signal_quality_cfg: Optional[Any] = None
 
 
 @runtime_checkable

--- a/pipeline.py
+++ b/pipeline.py
@@ -206,12 +206,17 @@ def policy_decide(
     bar: Bar,
     *,
     stage_cfg: PipelineStageConfig | None = None,
+    signal_quality_cfg: Any | None = None,
 ) -> PipelineResult:
     inc_stage(Stage.POLICY)
     if stage_cfg is not None and not stage_cfg.enabled:
         return PipelineResult(action="pass", stage=Stage.POLICY, decision=[])
     feats = fp.update(bar)
-    ctx = PolicyCtx(ts=int(bar.ts), symbol=bar.symbol)
+    ctx = PolicyCtx(
+        ts=int(bar.ts),
+        symbol=bar.symbol,
+        signal_quality_cfg=signal_quality_cfg,
+    )
     decisions = list(policy.decide({**feats}, ctx) or [])
     return PipelineResult(action="pass", stage=Stage.POLICY, decision=decisions)
 

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -129,6 +129,7 @@ class _Worker:
         throttle_cfg: ThrottleConfig | None = None,
         no_trade_cfg: NoTradeConfig | None = None,
         pipeline_cfg: PipelineConfig | None = None,
+        signal_quality_cfg: SignalQualityConfig | None = None,
         zero_signal_alert: int = 0,
     ) -> None:
         self._fp = fp
@@ -144,6 +145,7 @@ class _Worker:
         self._throttle_cfg = throttle_cfg
         self._no_trade_cfg = no_trade_cfg
         self._pipeline_cfg = pipeline_cfg
+        self._signal_quality_cfg = signal_quality_cfg or SignalQualityConfig()
         self._zero_signal_alert = int(zero_signal_alert)
         self._zero_signal_streak = 0
         self._global_bucket = None
@@ -480,6 +482,7 @@ class _Worker:
             self._policy,
             bar,
             stage_cfg=self._pipeline_cfg.get("policy") if self._pipeline_cfg else None,
+            signal_quality_cfg=self._signal_quality_cfg,
         )
         if pol_res.action == "drop":
             try:
@@ -876,6 +879,7 @@ class ServiceSignalRunner:
             throttle_cfg=self.throttle_cfg,
             no_trade_cfg=self.no_trade_cfg,
             pipeline_cfg=self.pipeline_cfg,
+            signal_quality_cfg=self.signal_quality_cfg,
             zero_signal_alert=getattr(
                 self.monitoring_cfg.thresholds, "zero_signals", 0
             ),


### PR DESCRIPTION
## Summary
- pass the parsed signal quality configuration into the worker provider instantiation
- extend the policy decision flow so PolicyCtx exposes the signal_quality_cfg field to strategies

## Testing
- pytest tests/test_pipeline_flow.py *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68ca744271d4832f901e2dd2d59f2cd3