### PR TITLE
Integrate signal quality metrics into feature pipeline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import sys
+import types
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -8,3 +11,19 @@ TESTS = ROOT / "tests"
 sys.path = [p for p in sys.path if p not in {str(ROOT), str(TESTS)}]
 import logging  # noqa: F401
 sys.path.extend([str(ROOT), str(TESTS)])
+
+_requests_stub = types.ModuleType("requests")
+
+
+def _unavailable(*args, **kwargs):  # pragma: no cover - network calls disabled in tests
+    raise RuntimeError("requests module is not available in the test environment")
+
+
+_requests_stub.get = _unavailable
+_requests_stub.post = _unavailable
+_requests_stub.put = _unavailable
+_requests_stub.delete = _unavailable
+_requests_stub.request = _unavailable
+
+
+sys.modules.setdefault("requests", _requests_stub)

--- a/tests/test_signal_quality_metrics.py
+++ b/tests/test_signal_quality_metrics.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from decimal import Decimal
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+import pytest
+
+from feature_pipe import FeaturePipe, SignalQualityMetrics
+from transformers import FeatureSpec
+from core_models import Bar
+
+
+def _make_bar(
+    ts: int,
+    price: str,
+    *,
+    symbol: str = "BTCUSDT",
+    volume_quote: str | None = None,
+) -> Bar:
+    px = Decimal(price)
+    vq = Decimal(volume_quote) if volume_quote is not None else None
+    return Bar(
+        ts=ts,
+        symbol=symbol,
+        open=px,
+        high=px,
+        low=px,
+        close=px,
+        volume_quote=vq,
+    )
+
+
+def test_signal_quality_metrics_handles_invalid_close() -> None:
+    metrics = SignalQualityMetrics(sigma_window=2, vol_median_window=2)
+
+    metrics.update("BTCUSDT", _make_bar(1, "100", volume_quote="10"))
+    second = metrics.update("BTCUSDT", _make_bar(2, "101", volume_quote="11"))
+    assert second.current_sigma is not None
+
+    third = metrics.update("BTCUSDT", _make_bar(3, "102", volume_quote="12"))
+    assert third.window_ready is True
+
+    snapshot_before = metrics.latest["BTCUSDT"]
+
+    invalid = metrics.update("BTCUSDT", _make_bar(4, "NaN", volume_quote="13"))
+    assert invalid == snapshot_before
+    assert metrics.latest["BTCUSDT"] == snapshot_before
+
+
+def test_feature_pipe_skips_invalid_bar_but_preserves_metrics() -> None:
+    metrics = SignalQualityMetrics(sigma_window=2, vol_median_window=2)
+    pipe = FeaturePipe(FeatureSpec(lookbacks_prices=[2]), metrics=metrics)
+
+    valid_bar = _make_bar(1, "100", volume_quote="10")
+    feats = pipe.update(valid_bar)
+    assert feats["ref_price"] == pytest.approx(100.0)
+    snapshot_before = pipe.signal_quality["BTCUSDT"]
+
+    skipped = pipe.update(_make_bar(2, "NaN", volume_quote="11"))
+    assert skipped == {}
+    assert pipe.signal_quality["BTCUSDT"] == snapshot_before


### PR DESCRIPTION
## Summary
- update `SignalQualityMetrics` to track per-symbol snapshots and tolerate invalid bar data
- call metrics updates from `FeaturePipe` and expose the latest snapshots for downstream consumers
- add regression tests and stub external `requests` dependency for the test environment

## Testing
- pytest tests/test_signal_quality_metrics.py tests/test_read_only_mode.py


------
https://chatgpt.com/codex/tasks/task_e_68ca77aa6e60832f90d409cd13867907