### PR TITLE
Handle bar gaps and duplicates for signal quality metrics

### DIFF
--- a/feature_pipe.py
+++ b/feature_pipe.py
@@ -70,6 +70,13 @@ class SignalQualityMetrics:
         self._state.clear()
         self._latest.clear()
 
+    def reset_symbol(self, symbol: str) -> None:
+        """Reset state for a specific ``symbol`` if it exists."""
+
+        sym = str(symbol).upper()
+        self._state.pop(sym, None)
+        self._latest.pop(sym, None)
+
     # ------------------------------------------------------------------
     def update(self, symbol: str, bar: Bar) -> SignalQualitySnapshot:
         """Update metrics with a new bar and return current values."""
@@ -218,7 +225,7 @@ class FeaturePipe:
         for b in bars:
             self.update(b)
 
-    def update(self, bar: Bar) -> Mapping[str, Any]:
+    def update(self, bar: Bar, *, skip_metrics: bool = False) -> Mapping[str, Any]:
         """Process a single bar and return computed features."""
         try:
             close_value = float(bar.close)
@@ -246,7 +253,7 @@ class FeaturePipe:
             )
             self._tr._state = state_backup
 
-        if self.metrics is not None:
+        if self.metrics is not None and not skip_metrics:
             try:
                 snapshot = self.metrics.update(symbol, bar)
             except Exception:

--- a/tests/test_signal_quality_filter.py
+++ b/tests/test_signal_quality_filter.py
@@ -19,8 +19,8 @@ class DummyFeaturePipe:
     def warmup(self) -> None:
         return None
 
-    def update(self, bar: Bar) -> dict[str, float]:
-        if self.metrics is not None:
+    def update(self, bar: Bar, *, skip_metrics: bool = False) -> dict[str, float]:
+        if self.metrics is not None and not skip_metrics:
             snapshot = self.metrics.update(bar.symbol, bar)
             self.signal_quality[bar.symbol] = snapshot
             self.signal_quality[bar.symbol.upper()] = snapshot


### PR DESCRIPTION
## Summary
- add UTC timestamp formatting and gap/duplicate detection in Binance websocket/public bar sources
- add per-symbol reset and duplicate handling for signal quality metrics in feature pipe and worker
- extend tests to cover metric resets and skip behavior

## Testing
- pytest tests/test_signal_quality_metrics.py tests/test_signal_quality_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68ca7f257a08832fa84b44f89331b0b7