### PR TITLE
Add dynamic guard config to no-trade settings

### DIFF
--- a/configs/legacy_sandbox.yaml
+++ b/configs/legacy_sandbox.yaml
@@ -28,6 +28,17 @@ no_trade:
     - "08:00-08:05"
     - "16:00-16:05"
   custom_ms: []   # список явных окон [{start_ts_ms: ..., end_ts_ms: ...}]
+  # dynamic_guard:
+  #   enable: false                 # turn on dynamic guard when ready
+  #   sigma_window: 120             # rolling window (bars) for volatility sigma
+  #   atr_window: 14                # ATR window (bars) for spread guard
+  #   vol_abs: null                 # absolute volatility threshold; null to skip
+  #   vol_pctile: 0.99              # trigger when rolling volatility above percentile
+  #   spread_abs_bps: null          # absolute spread threshold in bps
+  #   spread_pctile: 0.99           # percentile-based spread trigger
+  #   hysteresis: 0.1               # relative buffer before re-enabling trading
+  #   cooldown_bars: 10             # bars to wait after trigger clears
+  #   log_reason: true              # emit log message when guard blocks trading
 
 policy:
   module: "strategies.momentum"

--- a/docs/no_trade.md
+++ b/docs/no_trade.md
@@ -10,6 +10,22 @@ This document explains the available fields, dataset masking options, and runtim
 | `funding_buffer_min` | int | Minutes before and after funding events (00:00, 08:00, 16:00 UTC) where trading is blocked. |
 | `daily_utc` | list[str] | Daily repeating windows in `HH:MM-HH:MM` (UTC). Windows should not cross midnight. |
 | `custom_ms` | list[dict] | One-off windows with explicit start and end timestamps in milliseconds since epoch. |
+| `dynamic_guard` | dict | Optional dynamic guard that can pause trading based on volatility/spread metrics. |
+
+### `dynamic_guard` fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enable` | bool | `false` | Enable the dynamic guard when `true`. |
+| `sigma_window` | int or null | `null` | Rolling window (bars) for computing price sigma; guard ignores this trigger when `null`. |
+| `atr_window` | int or null | `null` | Rolling window (bars) for ATR-based spread checks; ignored when `null`. |
+| `vol_abs` | float or null | `null` | Absolute volatility threshold. Leave `null` to disable. |
+| `vol_pctile` | float or null | `null` | Percentile threshold (0-1) for volatility. |
+| `spread_abs_bps` | float or null | `null` | Absolute spread threshold in basis points. |
+| `spread_pctile` | float or null | `null` | Percentile threshold (0-1) for spread. |
+| `hysteresis` | float or null | `null` | Relative buffer before the guard re-enables trading. |
+| `cooldown_bars` | int | `0` | Bars to wait after the guard condition clears. |
+| `log_reason` | bool | `false` | Emit a log entry when the guard blocks trades. |
 
 Example YAML:
 
@@ -22,6 +38,17 @@ no_trade:
     - "16:00-16:05"
   custom_ms:
     - {start_ts_ms: 1696118400000, end_ts_ms: 1696122000000}
+  dynamic_guard:
+    enable: false
+    sigma_window: 120
+    atr_window: 14
+    vol_abs: null
+    vol_pctile: 0.99
+    spread_abs_bps: null
+    spread_pctile: 0.99
+    hysteresis: 0.1
+    cooldown_bars: 10
+    log_reason: true
 ```
 
 ## Applying the mask to datasets


### PR DESCRIPTION
## Summary
- add a DynamicGuardConfig model nested under NoTradeConfig with default instantiation
- document the dynamic guard fields and provide commented YAML examples

## Testing
- python -m compileall no_trade_config.py

------
https://chatgpt.com/codex/tasks/task_e_68ca84a9529c832f8cf5025a23598959