### PR TITLE
feat: extend no-trade config schema

### DIFF
--- a/configs/no_trade.yaml
+++ b/configs/no_trade.yaml
@@ -2,6 +2,7 @@
 no_trade:
   maintenance:
     format: "HH:MM-HH:MM"      # daily UTC windows in HH:MM-HH:MM format
+    path: null                  # optional external calendar (relative paths are resolved)
     funding_buffer_min: 5
     daily_utc:
       - "00:00-00:05"
@@ -9,17 +10,28 @@ no_trade:
       - "16:00-16:05"
     custom_ms: []
   dynamic:
+    enabled: false              # master switch; keeps legacy guards disabled by default
     guard:
-      enable: false
-      sigma_window: 180         # use a longer history for volatility stability
-      atr_window: 21            # align ATR window with 3 weeks of 1m bars
-      vol_abs: 0.015            # block if 1m returns stddev exceeds 1.5%
-      vol_pctile: 0.995         # or when volatility in top 0.5% of history
-      spread_abs_bps: 15.0      # block if spreads widen beyond 15 bps
-      spread_pctile: 0.995      # or top 0.5% widest spreads
+      enable: false             # legacy flag (still honoured for backwards compatibility)
       log_reason: true          # emit guard reason to logs when triggered
+      volatility:
+        window: 180             # rolling sigma window (bars)
+        min_periods: null       # optional override for sigma min periods
+        pctile_window: null     # optional override for percentile window
+        pctile_min_periods: null
+        abs: 0.015              # block if volatility exceeds 1.5%
+        pctile: 0.995           # ...or top 0.5% percentile
+      spread:
+        window: 21              # ATR/spread window (bars)
+        min_periods: null
+        pctile_window: null
+        pctile_min_periods: null
+        abs_bps: 15.0           # block if spreads widen beyond 15 bps
+        pctile: 0.995           # ...or top 0.5% percentile
     hysteresis:
       ratio: 0.2                # require 20% improvement before unblocking
       cooldown_bars: 20         # keep guard active for 20 bars after recovery
     next_bars_block:
       anomaly: 20               # optional block for N bars after anomaly detection
+# The loader still accepts legacy top-level keys (funding_buffer_min, daily_utc,
+# custom_ms, dynamic_guard) and merges them into this structure.


### PR DESCRIPTION
## Summary
- extend the dynamic no-trade guard models with nested metric config, extra thresholds and an explicit requested/effective enable state
- normalise legacy payloads into the new schema, propagate `dynamic.enabled` and keep maintenance metadata resolved
- refresh the sample no-trade YAML to document the new keys and defaults

## Testing
- pytest tests/test_no_trade_ratio.py tests/test_dynamic_no_trade_guard.py
- python manual check for legacy/new config loading and dynamic.enabled gating

------
https://chatgpt.com/codex/tasks/task_e_68cab7d53348832f98561bd0e7fc5804