### PR TITLE
Enhance maintenance calendar handling in no_trade

### DIFF
--- a/configs/no_trade.yaml
+++ b/configs/no_trade.yaml
@@ -1,8 +1,8 @@
 # Recommended no-trade configuration with structured dynamic guard defaults.
 no_trade:
   maintenance:
-    format: "HH:MM-HH:MM"      # daily UTC windows in HH:MM-HH:MM format
-    path: null                  # optional external calendar (relative paths are resolved)
+    format: "HH:MM-HH:MM"      # "HH:MM-HH:MM" for inline daily windows, use "json"/"csv"/"auto" for external files
+    path: null                  # optional external calendar (relative to this YAML); see data/maintenance/example_schedule.json
     funding_buffer_min: 5
     daily_utc:
       - "00:00-00:05"

--- a/data/maintenance/example_schedule.json
+++ b/data/maintenance/example_schedule.json
@@ -1,0 +1,13 @@
+[
+  {
+    "start_ts_ms": 1704067200000,
+    "end_ts_ms": 1704070800000,
+    "reason": "Daily clearing window",
+    "symbol": "BTCUSDT"
+  },
+  {
+    "start_ts_ms": 1704153600000,
+    "end_ts_ms": 1704159000000,
+    "reason": "Exchange maintenance"
+  }
+]


### PR DESCRIPTION
## Summary
- support explicit maintenance.format hints and resolve calendar paths relative to the sandbox config when loading schedules
- merge overlapping maintenance windows, expose calendar metadata on the maintenance state, and ensure calendar windows propagate to legacy reason columns
- document the expected schedule format, add an example maintenance calendar, and extend tests to cover the new behaviour

## Testing
- pytest tests/test_no_trade_ratio.py


------
https://chatgpt.com/codex/tasks/task_e_68cabe388204832fa0faac66fd23b086