### PR TITLE
Add hysteresis thresholds to momentum strategy

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -111,7 +111,9 @@ components:
     params: {}
   policy:
     target: strategies.momentum:MomentumStrategy
-    params: {}
+    params:
+      enter_threshold: 0.0  # enter >= exit; defaults to legacy ``threshold`` if omitted
+      exit_threshold: 0.0   # fallback when only ``threshold`` is provided
   risk_guards:
     target: impl_risk_basic:RiskBasicImpl
     params: {}

--- a/configs/legacy_realtime.yaml
+++ b/configs/legacy_realtime.yaml
@@ -43,7 +43,8 @@ policy:
   class: "MomentumStrategy"
   params:
     lookback: 5
-    threshold: 0.0
+    enter_threshold: 0.0  # enter >= exit; falls back to legacy ``threshold`` when set
+    exit_threshold: 0.0   # exit hysteresis threshold; uses ``threshold`` as fallback
     order_qty: 0.1  # доля позиции
 
 features:

--- a/configs/legacy_sandbox.yaml
+++ b/configs/legacy_sandbox.yaml
@@ -45,7 +45,8 @@ policy:
   class: "MomentumStrategy"
   params:
     lookback: 5
-    threshold: 0.0
+    enter_threshold: 0.0  # enter >= exit; falls back to legacy ``threshold`` when set
+    exit_threshold: 0.0   # exit hysteresis threshold; uses ``threshold`` as fallback
     order_qty: 0.1  # доля позиции
 
 data:

--- a/configs/legacy_sim.yaml
+++ b/configs/legacy_sim.yaml
@@ -75,3 +75,12 @@ logging:
   trades_path: "logs/log_trades_<runid>.csv"
   reports_path: "logs/report_equity_<runid>.csv"
   flush_every: 1000
+
+policy:
+  module: "strategies.momentum"
+  class: "MomentumStrategy"
+  params:
+    lookback: 5
+    enter_threshold: 0.0  # enter >= exit; falls back to legacy ``threshold`` when set
+    exit_threshold: 0.0   # exit hysteresis threshold; uses ``threshold`` as fallback
+    order_qty: 0.1  # доля позиции

--- a/tests/test_momentum_policy.py
+++ b/tests/test_momentum_policy.py
@@ -1,7 +1,10 @@
 from decimal import Decimal
 
+import pytest
+
 from core_contracts import PolicyCtx
 from core_models import Side
+from strategies.base import SignalPosition
 from strategies.momentum import MomentumStrategy
 
 
@@ -9,24 +12,53 @@ def _ctx(ts: int) -> PolicyCtx:
     return PolicyCtx(ts=ts, symbol="BTCUSDT")
 
 
-def test_momentum_policy_produces_orders():
+def test_momentum_policy_transitions_and_orders():
     policy = MomentumStrategy()
-    policy.setup({"lookback": 3, "order_qty": 1.0})
+    policy.setup(
+        {
+            "lookback": 2,
+            "order_qty": 1.0,
+            "enter_threshold": 2.0,
+            "exit_threshold": 1.0,
+        }
+    )
 
-    # first two observations - insufficient window
+    # warm-up window
     assert policy.decide({"ref_price": 100.0}, _ctx(1)) == []
-    assert policy.decide({"ref_price": 101.0}, _ctx(2)) == []
 
-    # third observation triggers BUY
+    # crossing +enter_threshold -> LONG
+    orders = policy.decide({"ref_price": 104.0}, _ctx(2))
+    assert len(orders) == 1
+    assert orders[0].side == Side.BUY
+    assert orders[0].quantity == Decimal("1")
+    assert policy.get_signal_state("BTCUSDT") is SignalPosition.LONG
+
+    # signal falls below exit_threshold -> close LONG
     orders = policy.decide({"ref_price": 103.0}, _ctx(3))
     assert len(orders) == 1
-    o = orders[0]
-    assert o.side == Side.BUY
-    assert o.quantity == Decimal("1")
+    assert orders[0].side == Side.SELL
+    assert policy.get_signal_state("BTCUSDT") is SignalPosition.FLAT
 
-    # price drops below average -> SELL
-    orders = policy.decide({"ref_price": 90.0}, _ctx(4))
+    # large negative signal -> open SHORT
+    orders = policy.decide({"ref_price": 96.0}, _ctx(4))
     assert len(orders) == 1
-    o = orders[0]
-    assert o.side == Side.SELL
-    assert o.quantity == Decimal("1")
+    assert orders[0].side == Side.SELL
+    assert policy.get_signal_state("BTCUSDT") is SignalPosition.SHORT
+
+    # reversal SHORT -> LONG emits two BUY orders
+    orders = policy.decide({"ref_price": 110.0}, _ctx(5))
+    assert len(orders) == 2
+    assert all(order.side == Side.BUY for order in orders)
+    assert policy.get_signal_state("BTCUSDT") is SignalPosition.LONG
+
+
+def test_momentum_policy_threshold_fallback_and_validation():
+    policy = MomentumStrategy()
+
+    policy.setup({"threshold": 1.5})
+    assert policy.enter_threshold == 1.5
+    assert policy.exit_threshold == 1.5
+    assert policy.threshold == 1.5
+
+    with pytest.raises(ValueError):
+        policy.setup({"enter_threshold": 0.5, "exit_threshold": 1.0})


### PR DESCRIPTION
## Summary
- add explicit enter/exit thresholds with hysteresis-aware state transitions in `MomentumStrategy`
- validate new configuration parameters with fallback to legacy `threshold`
- update configs and tests to document and exercise the dual-threshold behaviour

## Testing
- pytest tests/test_momentum_policy.py

------
https://chatgpt.com/codex/tasks/task_e_68cad26c2028832f9e5d702db5b85394