### PR TITLE
Add daily entry limit to risk manager

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -63,6 +63,17 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
+risk:
+  enabled: true
+  max_abs_position_qty: 0.0
+  max_abs_position_notional: 0.0
+  max_order_notional: 0.0
+  max_orders_per_min: 60
+  max_orders_window_s: 60
+  daily_loss_limit: 0.0
+  pause_seconds_on_violation: 300
+  daily_reset_utc_hour: 0  # Час начала нового дня в UTC для PnL и дневных лимитов
+  max_entries_per_day: null  # Максимум новых входов за день; null/-1 = без лимита (счёт по daily_reset_utc_hour, UTC)
 quantizer:
   filters_path: "binance_filters.json"
   strict: true

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -77,7 +77,8 @@ risk:
   max_orders_window_s: 60
   daily_loss_limit: 0.0
   pause_seconds_on_violation: 300
-  daily_reset_utc_hour: 0
+  daily_reset_utc_hour: 0  # Час начала нового дня в UTC для PnL и дневных лимитов
+  max_entries_per_day: null  # Максимум новых входов за день; null/-1 = без лимита (счёт по daily_reset_utc_hour, UTC)
 
 # See ../docs/no_trade.md for details
 no_trade:

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -83,7 +83,8 @@ risk:
   max_orders_window_s: 60
   daily_loss_limit: 0.0
   pause_seconds_on_violation: 300
-  daily_reset_utc_hour: 0
+  daily_reset_utc_hour: 0  # Час начала нового дня в UTC для PnL и дневных лимитов
+  max_entries_per_day: null  # Максимум новых входов за день; null/-1 = без лимита (счёт по daily_reset_utc_hour, UTC)
 
 # See ../docs/no_trade.md for details
 no_trade:

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -77,7 +77,8 @@ risk:
   max_orders_window_s: 60
   daily_loss_limit: 0.0
   pause_seconds_on_violation: 300
-  daily_reset_utc_hour: 0
+  daily_reset_utc_hour: 0  # Час начала нового дня в UTC для PnL и дневных лимитов
+  max_entries_per_day: null  # Максимум новых входов за день; null/-1 = без лимита (счёт по daily_reset_utc_hour, UTC)
 
 # See ../docs/no_trade.md for details
 no_trade:

--- a/configs/legacy_sim.yaml
+++ b/configs/legacy_sim.yaml
@@ -67,7 +67,8 @@ risk:
   max_orders_window_s: 60
   daily_loss_limit: 0.0
   pause_seconds_on_violation: 300
-  daily_reset_utc_hour: 0
+  daily_reset_utc_hour: 0  # Час начала нового дня в UTC для PnL и дневных лимитов
+  max_entries_per_day: null  # Максимум новых входов за день; null/-1 = без лимита (счёт по daily_reset_utc_hour, UTC)
 
 logging:
   enabled: true

--- a/impl_risk_basic.py
+++ b/impl_risk_basic.py
@@ -10,7 +10,7 @@ impl_risk_basic.py
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 try:
     from risk import RiskManager, RiskConfig
@@ -30,6 +30,7 @@ class RiskBasicCfg:
     daily_loss_limit: float = 0.0
     pause_seconds_on_violation: int = 300
     daily_reset_utc_hour: int = 0
+    max_entries_per_day: Optional[int] = None
 
 
 class RiskBasicImpl:
@@ -45,6 +46,9 @@ class RiskBasicImpl:
             "daily_loss_limit": float(cfg.daily_loss_limit),
             "pause_seconds_on_violation": int(cfg.pause_seconds_on_violation),
             "daily_reset_utc_hour": int(cfg.daily_reset_utc_hour),
+            "max_entries_per_day": (
+                None if cfg.max_entries_per_day is None else int(cfg.max_entries_per_day)
+            ),
         })) if (RiskManager is not None and RiskConfig is not None) else None
 
     @property
@@ -67,4 +71,9 @@ class RiskBasicImpl:
             daily_loss_limit=float(d.get("daily_loss_limit", 0.0)),
             pause_seconds_on_violation=int(d.get("pause_seconds_on_violation", 300)),
             daily_reset_utc_hour=int(d.get("daily_reset_utc_hour", 0)),
+            max_entries_per_day=(
+                None
+                if d.get("max_entries_per_day") is None
+                else int(d.get("max_entries_per_day"))
+            ),
         ))


### PR DESCRIPTION
## Summary
- add a `max_entries_per_day` option to `RiskConfig` and enforce the limit inside `RiskManager`
- thread the new option through `impl_risk_basic.RiskBasicCfg` and document it in template configs
- extend risk unit tests to cover daily entry limits

## Testing
- `pytest tests/test_risk_seasonality.py`


------
https://chatgpt.com/codex/tasks/task_e_68cad74db550832fb7547123db736eb8