### PR TITLE
Add daily entry limiter integration for policy transitions

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -62,6 +62,13 @@ queue_len = Gauge(
     "Current number of queued signals awaiting tokens",
 )
 
+# Daily entry limiter blocks
+entry_limiter_block_count = Counter(
+    "entry_limiter_block_count",
+    "Signals blocked by the daily entry limiter",
+    ["symbol"],
+)
+
 # Throttling outcomes
 throttle_dropped_count = Counter(
     "throttle_dropped_count",


### PR DESCRIPTION
## Summary
- add a DailyEntryLimiter that reads RiskManager configuration, tracks daily entries and guards policy transitions
- drop entry leg orders when the daily limit is exceeded, revert signal state to flat on reversals, and record the reason via logging and metrics
- teach the SimpleRiskGuard to treat exit orders via the signal_leg metadata so exits remain eligible when entries are throttled

## Testing
- pytest tests/test_pipeline_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68cadfd980b4832fa3d1529f214505ec