### PR TITLE
Add Binance last price caching and worker persistence

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -226,6 +226,12 @@ class BinanceWS:
                 meta["spread_bps"] = float(spread)
             except Exception:
                 pass
+        price = getattr(tick, "price", None)
+        if price is not None:
+            try:
+                meta["price"] = float(price)
+            except Exception:
+                pass
         event = MarketEvent(
             etype=EventType.MARKET_DATA_TICK,
             ts=now_ms(),
@@ -318,6 +324,7 @@ class BinanceWS:
                                         Decimal(str(ask_raw)) if ask_raw is not None else None
                                     )
                                     spread_bps = None
+                                    mid: Decimal | None = None
                                     if (
                                         bid_val is not None
                                         and ask_val is not None
@@ -330,6 +337,7 @@ class BinanceWS:
                                     tick = Tick(
                                         ts=int(data.get("E") or data.get("T") or now_ms()),
                                         symbol=str(data.get("s", "")).upper(),
+                                        price=mid,
                                         bid=bid_val,
                                         ask=ask_val,
                                         bid_qty=Decimal(str(data.get("B")))


### PR DESCRIPTION
## Summary
- populate book ticker ticks with a mid price and include it in emitted metadata
- add BinancePublicClient.get_last_price with a short-lived cache
- persist worker last prices from ticks/bars with REST fallback seeded from saved state

## Testing
- pytest tests/test_rate_limiter.py

------
https://chatgpt.com/codex/tasks/task_e_68caebdd230c832f840682a2ea164ae4