### PR TITLE
Extend risk exposure limits and update guards

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -1353,12 +1353,22 @@ class ExecutionSimulator:
                 # риск: пауза/клампинг размера перед планом
                 risk_events_local: List[RiskEvent] = []
                 if self.risk is not None:
+                    portfolio_total = None
+                    if ref is not None:
+                        try:
+                            ref_val = float(ref)
+                        except (TypeError, ValueError):
+                            ref_val = None
+                        else:
+                            if math.isfinite(ref_val) and ref_val > 0.0:
+                                portfolio_total = abs(float(self.position_qty)) * ref_val
                     adj_qty = self.risk.pre_trade_adjust(
                         ts_ms=ts,
                         side=side,
                         intended_qty=qty_total,
                         price=ref,
                         position_qty=self.position_qty,
+                        total_notional=portfolio_total,
                     )
                     risk_events_local.extend(self.risk.pop_events())
                     qty_total = float(adj_qty)
@@ -2003,12 +2013,22 @@ class ExecutionSimulator:
 
                 # риск: корректировка/пауза
                 if self.risk is not None:
+                    portfolio_total = None
+                    if ref is not None:
+                        try:
+                            ref_val = float(ref)
+                        except (TypeError, ValueError):
+                            ref_val = None
+                        else:
+                            if math.isfinite(ref_val) and ref_val > 0.0:
+                                portfolio_total = abs(float(self.position_qty)) * ref_val
                     adj_qty = self.risk.pre_trade_adjust(
                         ts_ms=ts,
                         side=side,
                         intended_qty=qty_total,
                         price=ref,
                         position_qty=self.position_qty,
+                        total_notional=portfolio_total,
                     )
                     qty_total = float(adj_qty)
                     for _e in self.risk.pop_events():

--- a/impl_risk_basic.py
+++ b/impl_risk_basic.py
@@ -44,7 +44,7 @@ class RiskBasicCfg:
 class RiskBasicImpl:
     def __init__(self, cfg: RiskBasicCfg) -> None:
         self.cfg = cfg
-        self._manager = RiskManager(RiskConfig.from_dict({
+        payload = {
             "enabled": bool(cfg.enabled),
             "max_abs_position_qty": float(cfg.max_abs_position_qty),
             "max_abs_position_notional": float(cfg.max_abs_position_notional),
@@ -57,7 +57,18 @@ class RiskBasicImpl:
             "max_entries_per_day": (
                 None if cfg.max_entries_per_day is None else int(cfg.max_entries_per_day)
             ),
-        })) if (RiskManager is not None and RiskConfig is not None) else None
+            "exposure_buffer_frac": float(cfg.exposure_buffer_frac or 0.0),
+        }
+        if cfg.max_total_notional is not None:
+            payload["max_total_notional"] = float(cfg.max_total_notional)
+        if cfg.max_total_exposure_pct is not None:
+            payload["max_total_exposure_pct"] = float(cfg.max_total_exposure_pct)
+
+        self._manager = (
+            RiskManager(RiskConfig.from_dict(payload))
+            if (RiskManager is not None and RiskConfig is not None)
+            else None
+        )
 
     @property
     def manager(self):

--- a/tests/test_execution_profiles.py
+++ b/tests/test_execution_profiles.py
@@ -69,7 +69,17 @@ class DummyRisk:
         self.events = []
         self.paused_until_ms = 0
 
-    def pre_trade_adjust(self, *, ts_ms, side, intended_qty, price, position_qty):
+    def pre_trade_adjust(
+        self,
+        *,
+        ts_ms,
+        side,
+        intended_qty,
+        price,
+        position_qty,
+        total_notional=None,
+        equity=None,
+    ):
         return float(intended_qty)
 
     def pop_events(self):

--- a/tests/test_portfolio_limit_guard.py
+++ b/tests/test_portfolio_limit_guard.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+from risk_guard import PortfolioLimitConfig, PortfolioLimitGuard
+
+
+@dataclass
+class SimpleOrder:
+    symbol: str
+    side: str
+    quantity: float
+    reduce_only: bool = False
+    meta: dict | None = None
+
+
+def _make_guard(config: PortfolioLimitConfig, positions: dict[str, float], prices: dict[str, float]) -> PortfolioLimitGuard:
+    return PortfolioLimitGuard(
+        config=config,
+        get_positions=lambda: positions,
+        get_price=lambda sym: prices.get(sym.upper(), prices.get(sym, None)),
+        get_total_notional=None,
+        get_equity=lambda: 1_000.0,
+    )
+
+
+def test_portfolio_guard_buffer_blocks_order():
+    positions = {"BTC": 1.0}
+    prices = {"BTC": 100.0}
+    cfg = PortfolioLimitConfig(max_total_notional=150.0, exposure_buffer_frac=0.2)
+    guard = _make_guard(cfg, positions, prices)
+    order = SimpleOrder(symbol="BTC", side="BUY", quantity=0.5)
+
+    approved, reason = guard.apply(ts_ms=0, symbol="BTC", decisions=[order])
+
+    assert approved == []
+    assert reason == "RISK_PORTFOLIO_LIMIT"
+
+
+def test_portfolio_guard_without_buffer_allows_order():
+    positions = {"BTC": 1.0}
+    prices = {"BTC": 100.0}
+    cfg = PortfolioLimitConfig(max_total_notional=150.0, exposure_buffer_frac=0.0)
+    guard = _make_guard(cfg, positions, prices)
+    order = SimpleOrder(symbol="BTC", side="BUY", quantity=0.5)
+
+    approved, reason = guard.apply(ts_ms=0, symbol="BTC", decisions=[order])
+
+    assert approved == [order]
+    assert reason is None

--- a/tests/test_risk_exposure_limits.py
+++ b/tests/test_risk_exposure_limits.py
@@ -1,0 +1,97 @@
+import pytest
+
+from risk import RiskConfig, RiskManager
+
+
+def _event_codes(manager: RiskManager) -> set[str]:
+    return {ev.code for ev in manager.pop_events()}
+
+
+def test_total_notional_limit_clamps_quantity():
+    cfg = RiskConfig(
+        enabled=True,
+        max_total_notional=600.0,
+        exposure_buffer_frac=0.1,
+    )
+    rm = RiskManager(cfg)
+
+    qty = rm.pre_trade_adjust(
+        ts_ms=0,
+        side="BUY",
+        intended_qty=2.0,
+        price=100.0,
+        position_qty=5.0,
+    )
+
+    assert qty == pytest.approx(0.9090909, rel=1e-6)
+    assert "TOTAL_NOTIONAL_CLAMP" in _event_codes(rm)
+
+
+def test_total_notional_limit_blocks_when_no_capacity():
+    cfg = RiskConfig(
+        enabled=True,
+        max_total_notional=600.0,
+        exposure_buffer_frac=0.05,
+    )
+    rm = RiskManager(cfg)
+
+    qty = rm.pre_trade_adjust(
+        ts_ms=0,
+        side="BUY",
+        intended_qty=1.0,
+        price=100.0,
+        position_qty=6.0,
+    )
+
+    assert qty == 0.0
+    assert "TOTAL_NOTIONAL_BLOCK" in _event_codes(rm)
+
+
+def test_total_exposure_pct_uses_equity():
+    cfg = RiskConfig(enabled=True, max_total_exposure_pct=0.5)
+    rm = RiskManager(cfg)
+    rm.on_mark(ts_ms=0, equity=1_000.0)
+
+    qty = rm.pre_trade_adjust(
+        ts_ms=1,
+        side="BUY",
+        intended_qty=2.0,
+        price=100.0,
+        position_qty=4.0,
+    )
+
+    assert qty == pytest.approx(1.0, rel=1e-9)
+    assert "TOTAL_EXPOSURE_CLAMP" in _event_codes(rm)
+
+
+def test_total_notional_respects_external_total():
+    cfg = RiskConfig(enabled=True, max_total_notional=550.0)
+    rm = RiskManager(cfg)
+
+    qty = rm.pre_trade_adjust(
+        ts_ms=0,
+        side="BUY",
+        intended_qty=5.0,
+        price=100.0,
+        position_qty=2.0,
+        total_notional=500.0,
+    )
+
+    assert qty == pytest.approx(0.5, rel=1e-9)
+    assert "TOTAL_NOTIONAL_CLAMP" in _event_codes(rm)
+
+
+def test_total_notional_allows_reduction():
+    cfg = RiskConfig(enabled=True, max_total_notional=500.0)
+    rm = RiskManager(cfg)
+
+    qty = rm.pre_trade_adjust(
+        ts_ms=0,
+        side="SELL",
+        intended_qty=2.0,
+        price=100.0,
+        position_qty=5.0,
+    )
+
+    assert qty == pytest.approx(2.0, rel=1e-9)
+    assert "TOTAL_NOTIONAL_BLOCK" not in _event_codes(rm)


### PR DESCRIPTION
## Summary
- extend `RiskConfig` with portfolio exposure fields and update `RiskManager.pre_trade_adjust` to cap size increases using buffered total-notional and equity limits
- propagate exposure parameters through the basic risk DI wiring and execution simulator so sizing checks see portfolio totals
- align the portfolio limit guard with the buffered-delta semantics and add regression coverage for the new limits

## Testing
- pytest tests/test_risk_seasonality.py tests/test_risk_exposure_limits.py tests/test_portfolio_limit_guard.py


------
https://chatgpt.com/codex/tasks/task_e_68cafe085a64832f809445f3ad272740