### PR TITLE
Extend latency configuration with volatility controls

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -63,6 +63,13 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
+  vol_metric: sigma          # Rolling volatility input used to scale latency adjustments
+  vol_window: 120            # Window (bars) for the volatility metric
+  volatility_gamma: 0.0      # Power/exponent applied to the normalised volatility factor
+  zscore_clip: 3.0           # Clip z-score used when normalising volatility
+  min_ms: 0                  # Lower bound applied after adjustments
+  max_ms: 10000              # Upper bound applied after adjustments
+  debug_log: false           # Emit detailed latency sampling logs
 risk:
   enabled: true
   max_abs_position_qty: 0.0

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -67,6 +67,13 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
+  vol_metric: sigma          # Rolling volatility input used to scale latency adjustments
+  vol_window: 120            # Window (bars) for the volatility metric
+  volatility_gamma: 0.0      # Power/exponent applied to the normalised volatility factor
+  zscore_clip: 3.0           # Clip z-score used when normalising volatility
+  min_ms: 0                  # Lower bound applied after adjustments
+  max_ms: 10000              # Upper bound applied after adjustments
+  debug_log: false           # Emit detailed latency sampling logs
 
 risk:
   enabled: true

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -73,6 +73,13 @@ latency:
   timeout_ms: 2500
   retries: 1
   seed: 0  # RNG seed; seasonality multipliers do not affect RNG state
+  vol_metric: sigma          # Rolling volatility input used to scale latency adjustments
+  vol_window: 120            # Window (bars) for the volatility metric
+  volatility_gamma: 0.0      # Power/exponent applied to the normalised volatility factor
+  zscore_clip: 3.0           # Clip z-score used when normalising volatility
+  min_ms: 0                  # Lower bound applied after adjustments
+  max_ms: 10000              # Upper bound applied after adjustments
+  debug_log: false           # Emit detailed latency sampling logs
 
 risk:
   enabled: true

--- a/impl_latency.py
+++ b/impl_latency.py
@@ -84,6 +84,13 @@ class LatencyCfg:
     seasonality_interpolate: bool = False
     seasonality_day_only: bool = False
     seasonality_auto_reload: bool = False
+    vol_metric: str = "sigma"
+    vol_window: int = 120
+    volatility_gamma: float = 0.0
+    zscore_clip: float = 3.0
+    min_ms: int = 0
+    max_ms: int = 10000
+    debug_log: bool = False
 
 
 class _LatencyWithSeasonality:
@@ -330,6 +337,13 @@ class LatencyImpl:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "LatencyImpl":
+        vol_metric = d.get("vol_metric")
+        vol_window = d.get("vol_window")
+        volatility_gamma = d.get("volatility_gamma")
+        zscore_clip = d.get("zscore_clip")
+        min_ms = d.get("min_ms")
+        max_ms = d.get("max_ms")
+        debug_log = d.get("debug_log", False)
         return LatencyImpl(LatencyCfg(
             base_ms=int(d.get("base_ms", 250)),
             jitter_ms=int(d.get("jitter_ms", 50)),
@@ -347,4 +361,13 @@ class LatencyImpl:
             seasonality_interpolate=bool(d.get("seasonality_interpolate", False)),
             seasonality_day_only=bool(d.get("seasonality_day_only", False)),
             seasonality_auto_reload=bool(d.get("seasonality_auto_reload", False)),
+            vol_metric=str(vol_metric) if vol_metric is not None else "sigma",
+            vol_window=int(vol_window) if vol_window is not None else 120,
+            volatility_gamma=(
+                float(volatility_gamma) if volatility_gamma is not None else 0.0
+            ),
+            zscore_clip=float(zscore_clip) if zscore_clip is not None else 3.0,
+            min_ms=int(min_ms) if min_ms is not None else 0,
+            max_ms=int(max_ms) if max_ms is not None else 10000,
+            debug_log=bool(debug_log),
         ))


### PR DESCRIPTION
## Summary
- add volatility- and clamp-related fields to `LatencyCfg` with sensible defaults
- update `LatencyImpl.from_dict` to coerce the new options when building a configuration
- document the new latency knobs in the sample simulation, template, and live configuration files

## Testing
- `pytest tests/test_latency_seasonality.py`


------
https://chatgpt.com/codex/tasks/task_e_68cb0bd4f838832fbdd9f0d2a1443dd8