### PR TITLE
Add latency seasonality config defaults

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -33,6 +33,10 @@ input:
   trades_path: "data/trades.csv"
 
 latency:
+  use_seasonality: true          # Enable hourly latency multipliers
+  latency_seasonality_path: null # Optional override; defaults to global latency_seasonality_path
+  refresh_period_days: 30        # Refresh cadence for latency multipliers (days)
+  seasonality_default: 1.0       # Fallback multiplier when seasonality data is unavailable
   base_ms: 250
   jitter_ms: 50
   spike_p: 0.01

--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -56,6 +56,10 @@ latency_seasonality_path: "configs/liquidity_latency_seasonality.json"
 # Set false to ignore liquidity and latency multipliers
 use_seasonality: true
 latency:
+  use_seasonality: true          # Enable hourly latency multipliers
+  latency_seasonality_path: null # Optional override; defaults to global latency_seasonality_path
+  refresh_period_days: 30        # Refresh cadence for latency multipliers (days)
+  seasonality_default: 1.0       # Fallback multiplier when seasonality data is unavailable
   base_ms: 250
   jitter_ms: 50
   spike_p: 0.01

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -60,6 +60,10 @@ slippage:
   eps: 1e-12
 
 latency:
+  use_seasonality: true          # Enable hourly latency multipliers
+  latency_seasonality_path: null # Optional override; defaults to global latency_seasonality_path
+  refresh_period_days: 30        # Refresh cadence for latency multipliers (days)
+  seasonality_default: 1.0       # Fallback multiplier when seasonality data is unavailable
   base_ms: 250
   jitter_ms: 50
   spike_p: 0.01

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -66,6 +66,10 @@ slippage:
   eps: 1e-12
 
 latency:
+  use_seasonality: true          # Enable hourly latency multipliers
+  latency_seasonality_path: null # Optional override; defaults to global latency_seasonality_path
+  refresh_period_days: 30        # Refresh cadence for latency multipliers (days)
+  seasonality_default: 1.0       # Fallback multiplier when seasonality data is unavailable
   base_ms: 250
   jitter_ms: 50
   spike_p: 0.01

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -60,6 +60,10 @@ slippage:
   eps: 1e-12
 
 latency:
+  use_seasonality: true          # Enable hourly latency multipliers
+  latency_seasonality_path: null # Optional override; defaults to global latency_seasonality_path
+  refresh_period_days: 30        # Refresh cadence for latency multipliers (days)
+  seasonality_default: 1.0       # Fallback multiplier when seasonality data is unavailable
   base_ms: 250
   jitter_ms: 50
   spike_p: 0.01


### PR DESCRIPTION
## Summary
- add latency seasonality toggles and defaults to latency sections across config templates
- extend CommonRunConfig with a LatencyConfig model that preserves the new fields
- update LatencyImpl and SimExecutor to consume the new latency seasonality settings and defaults

## Testing
- pytest tests/test_latency_seasonality.py

------
https://chatgpt.com/codex/tasks/task_e_68cbd9059404832f9570a350cc475a97