### PR TITLE
Handle latency seasonality mappings and caching

### DIFF
--- a/tests/test_load_seasonality.py
+++ b/tests/test_load_seasonality.py
@@ -94,6 +94,24 @@ def test_hourly_seasonality_clamping(tmp_path):
     assert arr2.max() == SEASONALITY_MULT_MAX
 
 
+def test_hourly_seasonality_mapping(tmp_path):
+    mapping = {str(i): 1.0 for i in range(HOURS_IN_WEEK)}
+    p = tmp_path / "map.json"
+    p.write_text(json.dumps({"latency": mapping}))
+    arr = load_hourly_seasonality(str(p), "latency")
+    assert arr.shape[0] == HOURS_IN_WEEK
+    assert np.allclose(arr, 1.0)
+    data = load_seasonality(str(p))
+    assert np.allclose(data["latency"], 1.0)
+
+    day_mapping = {str(i): 2.0 for i in range(7)}
+    p2 = tmp_path / "map_day.json"
+    p2.write_text(json.dumps({"latency": day_mapping}))
+    arr_day = load_hourly_seasonality(str(p2), "latency")
+    assert arr_day.shape[0] == 7
+    assert np.allclose(arr_day, 2.0)
+
+
 def test_load_seasonality_daily(tmp_path):
     p = tmp_path / "day.json"
     p.write_text(json.dumps({"liquidity": [1.0] * 7}))


### PR DESCRIPTION
## Summary
- extend latency seasonality loading to support disabled configs, mapping payloads, and daily/hourly conversions while logging source metadata
- adjust latency sampling stats to handle daily arrays and cache multipliers for reloads
- expand utils_time seasonality helpers and add regression tests for the new formats

## Testing
- pytest tests/test_load_seasonality.py tests/test_latency_validation.py tests/test_multiplier_checkpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68cbdb91cba0832fa0d5d2f832d77637