### PR TITLE
Add execution runtime config plumbing

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -9,6 +9,16 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution:
+  intrabar_price_model: null
+  timeframe_ms: null
+  use_latency_from: null
+  latency_constant_ms: null
+  bridge:
+    intrabar_price_model: null
+    timeframe_ms: null
+    use_latency_from: null
+    latency_constant_ms: null
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -15,6 +15,16 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution:
+  intrabar_price_model: null
+  timeframe_ms: null
+  use_latency_from: null
+  latency_constant_ms: null
+  bridge:
+    intrabar_price_model: null
+    timeframe_ms: null
+    use_latency_from: null
+    latency_constant_ms: null
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP

--- a/configs/execution.yaml
+++ b/configs/execution.yaml
@@ -1,0 +1,11 @@
+# Standalone execution configuration overrides
+execution:
+  intrabar_price_model: null
+  timeframe_ms: null
+  use_latency_from: null
+  latency_constant_ms: null
+  bridge:
+    intrabar_price_model: null
+    timeframe_ms: null
+    use_latency_from: null
+    latency_constant_ms: null

--- a/core_config.py
+++ b/core_config.py
@@ -265,6 +265,36 @@ class LatencyConfig(BaseModel):
         return super().dict(*args, **kwargs)
 
 
+class ExecutionBridgeConfig(BaseModel):
+    """Configuration payload for execution bridge adapters."""
+
+    intrabar_price_model: Optional[str] = Field(default=None)
+    timeframe_ms: Optional[int] = Field(default=None)
+    use_latency_from: Optional[str] = Field(default=None)
+    latency_constant_ms: Optional[int] = Field(default=None)
+
+    class Config:
+        extra = "allow"
+
+
+class ExecutionRuntimeConfig(BaseModel):
+    """Runtime execution configuration shared across run modes."""
+
+    intrabar_price_model: Optional[str] = Field(default=None)
+    timeframe_ms: Optional[int] = Field(default=None)
+    use_latency_from: Optional[str] = Field(default=None)
+    latency_constant_ms: Optional[int] = Field(default=None)
+    bridge: ExecutionBridgeConfig = Field(default_factory=ExecutionBridgeConfig)
+
+    class Config:
+        extra = "allow"
+
+    def dict(self, *args, **kwargs):  # type: ignore[override]
+        if "exclude_unset" not in kwargs:
+            kwargs["exclude_unset"] = False
+        return super().dict(*args, **kwargs)
+
+
 class CommonRunConfig(BaseModel):
     run_id: Optional[str] = Field(
         default=None, description="Идентификатор запуска; если None — генерируется."
@@ -300,6 +330,7 @@ class CommonRunConfig(BaseModel):
     state: StateConfig = Field(default_factory=StateConfig)
     risk: RiskConfigSection = Field(default_factory=RiskConfigSection)
     latency: LatencyConfig = Field(default_factory=LatencyConfig)
+    execution: ExecutionRuntimeConfig = Field(default_factory=ExecutionRuntimeConfig)
     components: Components
 
 
@@ -345,6 +376,7 @@ class SimulationConfig(CommonRunConfig):
         default=ExecutionProfile.MKT_OPEN_NEXT_H1
     )
     execution_params: ExecutionParams = Field(default_factory=ExecutionParams)
+    execution: ExecutionRuntimeConfig = Field(default_factory=ExecutionRuntimeConfig)
 
     @root_validator(pre=True)
     def _sync_symbols(cls, values):
@@ -549,6 +581,8 @@ __all__ = [
     "KillSwitchConfig",
     "OpsKillSwitchConfig",
     "LatencyConfig",
+    "ExecutionBridgeConfig",
+    "ExecutionRuntimeConfig",
     "MonitoringThresholdsConfig",
     "MonitoringAlertConfig",
     "MonitoringConfig",


### PR DESCRIPTION
## Summary
- add ExecutionBridgeConfig/ExecutionRuntimeConfig to the core runtime models
- surface the execution block in configuration templates and add a reusable execution config file
- propagate execution runtime settings into the simulator/backtest plumbing

## Testing
- pytest tests/test_execution_profiles.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe6a8cc5c832fb88e1e36180c0a66