### PR TITLE
Add dynamic spread configuration plumbing

### DIFF
--- a/impl_slippage.py
+++ b/impl_slippage.py
@@ -7,12 +7,13 @@ impl_slippage.py
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 try:
-    from slippage import SlippageConfig
+    from slippage import SlippageConfig, DynamicSpreadConfig
 except Exception:  # pragma: no cover
     SlippageConfig = None  # type: ignore
+    DynamicSpreadConfig = None  # type: ignore
 
 
 @dataclass
@@ -21,17 +22,34 @@ class SlippageCfg:
     min_half_spread_bps: float = 0.0
     default_spread_bps: float = 2.0
     eps: float = 1e-12
+    dynamic_spread: Optional[Any] = None
 
 
 class SlippageImpl:
     def __init__(self, cfg: SlippageCfg) -> None:
         self.cfg = cfg
-        self._cfg_obj = SlippageConfig.from_dict({
+        cfg_dict: Dict[str, Any] = {
             "k": float(cfg.k),
             "min_half_spread_bps": float(cfg.min_half_spread_bps),
             "default_spread_bps": float(cfg.default_spread_bps),
             "eps": float(cfg.eps),
-        }) if SlippageConfig is not None else None
+        }
+        if cfg.dynamic_spread is not None:
+            dyn = cfg.dynamic_spread
+            if hasattr(dyn, "to_dict"):
+                dyn_dict = dyn.to_dict()
+            elif isinstance(dyn, dict):
+                dyn_dict = dict(dyn)
+            else:
+                dyn_dict = None
+            if dyn_dict is not None:
+                cfg_dict["dynamic_spread"] = dyn_dict
+
+        self._cfg_obj = (
+            SlippageConfig.from_dict(cfg_dict)
+            if SlippageConfig is not None
+            else None
+        )
 
     @property
     def config(self):
@@ -43,9 +61,20 @@ class SlippageImpl:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SlippageImpl":
-        return SlippageImpl(SlippageCfg(
-            k=float(d.get("k", 0.8)),
-            min_half_spread_bps=float(d.get("min_half_spread_bps", 0.0)),
-            default_spread_bps=float(d.get("default_spread_bps", 2.0)),
-            eps=float(d.get("eps", 1e-12)),
-        ))
+        dyn_block = d.get("dynamic_spread")
+        dyn_cfg: Optional[Any] = None
+        if isinstance(dyn_block, dict):
+            if DynamicSpreadConfig is not None:
+                dyn_cfg = DynamicSpreadConfig.from_dict(dyn_block)
+            else:
+                dyn_cfg = dict(dyn_block)
+
+        return SlippageImpl(
+            SlippageCfg(
+                k=float(d.get("k", 0.8)),
+                min_half_spread_bps=float(d.get("min_half_spread_bps", 0.0)),
+                default_spread_bps=float(d.get("default_spread_bps", 2.0)),
+                eps=float(d.get("eps", 1e-12)),
+                dynamic_spread=dyn_cfg,
+            )
+        )


### PR DESCRIPTION
## Summary
- add DynamicSpreadConfig dataclass for modelling optional dynamic spread settings and expose it via SlippageConfig
- teach SlippageConfig.from_dict to parse the dynamic_spread section when present
- extend impl_slippage bridge so dynamic spread settings are forwarded to the simulator configuration

## Testing
- python -m compileall slippage.py impl_slippage.py

------
https://chatgpt.com/codex/tasks/task_e_68cc0c910684832f997b431398cfcb91