### PR TITLE
Enhance spread handling in execution simulator

### DIFF
--- a/impl_slippage.py
+++ b/impl_slippage.py
@@ -327,6 +327,10 @@ class SlippageImpl:
         if self._cfg_obj is not None:
             setattr(sim, "slippage_cfg", self._cfg_obj)
         try:
+            setattr(sim, "_slippage_get_spread", self.get_spread_bps)
+        except Exception:
+            logger.exception("Failed to attach _slippage_get_spread to simulator")
+        try:
             setattr(sim, "get_spread_bps", self.get_spread_bps)
         except Exception:
             logger.exception("Failed to attach get_spread_bps to simulator")


### PR DESCRIPTION
## Summary
- capture an optional slippage spread getter on the simulator and expose helpers for resolving effective/default spread values
- apply the getter when updating market snapshots and run_step state while reusing a central fallback when recording trades
- attach the spread getter from SlippageImpl to the simulator so dynamic spread logic can be invoked

## Testing
- python -m compileall execution_sim.py impl_slippage.py

------
https://chatgpt.com/codex/tasks/task_e_68cc0f9b4670832f921d0f0a8e708181