### PR TITLE
Integrate dynamic slippage profiles into simulator

### DIFF
--- a/impl_slippage.py
+++ b/impl_slippage.py
@@ -323,6 +323,10 @@ class SlippageImpl:
     def config(self):
         return self._cfg_obj
 
+    @property
+    def dynamic_profile(self) -> Optional[_DynamicSpreadProfile]:
+        return self._dynamic_profile
+
     def attach_to(self, sim) -> None:
         if self._cfg_obj is not None:
             setattr(sim, "slippage_cfg", self._cfg_obj)

--- a/service_backtest.py
+++ b/service_backtest.py
@@ -152,10 +152,17 @@ class ServiceBacktest:
             run_config=self._run_config,
         )
 
+        dyn_spread_cfg = self.cfg.dynamic_spread_config
+        sim_spread_getter = getattr(self.sim, "get_spread_bps", None)
+        if not callable(sim_spread_getter):
+            sim_spread_getter = getattr(self.sim, "_slippage_get_spread", None)
+        if callable(sim_spread_getter):
+            dyn_spread_cfg = {}
+
         self._bt = BacktestAdapter(
             policy=self.policy,
             sim_bridge=self.sim_bridge,
-            dynamic_spread_config=self.cfg.dynamic_spread_config,
+            dynamic_spread_config=dyn_spread_cfg,
             exchange_specs_path=self.cfg.exchange_specs_path,
             guards_config=self.cfg.guards_config,
             signal_cooldown_s=self.cfg.signal_cooldown_s,


### PR DESCRIPTION
## Summary
- expose the slippage dynamic profile and attach it to the simulator when dynamic spread is enabled in the run configuration
- disable legacy backtest dynamic spread configuration when the simulator already provides its own spread getter
- guard the backtest adapter from synthesising quotes when the simulator exposes get_spread_bps while still feeding volatility data

## Testing
- python -m compileall impl_slippage.py impl_sim_executor.py service_backtest.py sandbox/backtest_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68cc13dbdbf8832f89be8ea78b2e0641