### PR TITLE
Support new slippage dynamic config knobs

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -68,15 +68,21 @@ slippage:
   min_half_spread_bps: 0.0
   default_spread_bps: 2.0
   eps: 1e-12
-  dynamic_spread:
-    enabled: false
+  dynamic:
+    enabled: false           # Отключено → модель использует статический спред (легаси-поведение).
+    alpha_bps: 0.0           # Аддитивная надбавка к базовому спреду (в bps) при активном динамическом режиме.
+    beta_coef: 0.0           # Коэффициент при волатильности/ликвидности; 0.0 отключает масштабирование.
+    min_spread_bps: 0.0      # Нижняя граница рассчитанного динамического спреда.
+    max_spread_bps: 20.0     # Верхняя граница рассчитанного динамического спреда.
+    smoothing_alpha: null    # Опциональная EMA-сглаживание [0,1]; null оставляет спред без сглаживания.
+    vol_metric: null         # Имя метрики волатильности (например, "sigma") для beta_coef; null = по умолчанию.
+    vol_window: null         # Окно (в барах) для vol_metric; null = используем источник данных.
     profile_kind: hourly
-    multipliers: []        # 168 нормированных коэффициентов (например, со средним 1.0)
-    path: null             # Опционально: путь к JSON-профилю (см. data/slippage/hourly_profile.sample.json)
-    min_spread_bps: 0.0
-    max_spread_bps: 20.0
-    smoothing_alpha: 0.2
-    use_volatility: false
+    multipliers: []          # 168 нормированных коэффициентов (например, со средним 1.0)
+    path: null               # Опционально: путь к JSON-профилю (см. data/slippage/hourly_profile.sample.json)
+    override_path: null      # Опциональный путь к локальным поправкам поверх базового профиля.
+    hash: null               # Опциональный SHA256 от базового профиля для контроля целостности.
+    use_volatility: false    # Легаси-переключатель; оставьте false, если используете beta_coef.
     gamma: 0.0
 
 latency:

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -74,15 +74,21 @@ slippage:
   min_half_spread_bps: 0.0
   default_spread_bps: 2.0
   eps: 1e-12
-  dynamic_spread:
-    enabled: false
+  dynamic:
+    enabled: false           # Отключено → модель использует статический спред (легаси-поведение).
+    alpha_bps: 0.0           # Аддитивная надбавка к базовому спреду (в bps) при активном динамическом режиме.
+    beta_coef: 0.0           # Коэффициент при волатильности/ликвидности; 0.0 отключает масштабирование.
+    min_spread_bps: 0.0      # Нижняя граница рассчитанного динамического спреда.
+    max_spread_bps: 20.0     # Верхняя граница рассчитанного динамического спреда.
+    smoothing_alpha: null    # Опциональная EMA-сглаживание [0,1]; null оставляет спред без сглаживания.
+    vol_metric: null         # Имя метрики волатильности (например, "sigma") для beta_coef; null = по умолчанию.
+    vol_window: null         # Окно (в барах) для vol_metric; null = используем источник данных.
     profile_kind: hourly
-    multipliers: []        # 168 нормированных коэффициентов (например, со средним 1.0)
-    path: null             # Опционально: путь к JSON-профилю (см. data/slippage/hourly_profile.sample.json)
-    min_spread_bps: 0.0
-    max_spread_bps: 20.0
-    smoothing_alpha: 0.2
-    use_volatility: false
+    multipliers: []          # 168 нормированных коэффициентов (например, со средним 1.0)
+    path: null               # Опционально: путь к JSON-профилю (см. data/slippage/hourly_profile.sample.json)
+    override_path: null      # Опциональный путь к локальным поправкам поверх базового профиля.
+    hash: null               # Опциональный SHA256 от базового профиля для контроля целостности.
+    use_volatility: false    # Легаси-переключатель; оставьте false, если используете beta_coef.
     gamma: 0.0
 
 latency:

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -58,15 +58,21 @@ slippage:
   min_half_spread_bps: 0.0
   default_spread_bps: 2.0
   eps: 1e-12
-  dynamic_spread:
-    enabled: false
+  dynamic:
+    enabled: false           # Отключено → модель использует статический спред (легаси-поведение).
+    alpha_bps: 0.0           # Аддитивная надбавка к базовому спреду (в bps) при активном динамическом режиме.
+    beta_coef: 0.0           # Коэффициент при волатильности/ликвидности; 0.0 отключает масштабирование.
+    min_spread_bps: 0.0      # Нижняя граница рассчитанного динамического спреда.
+    max_spread_bps: 20.0     # Верхняя граница рассчитанного динамического спреда.
+    smoothing_alpha: null    # Опциональная EMA-сглаживание [0,1]; null оставляет спред без сглаживания.
+    vol_metric: null         # Имя метрики волатильности (например, "sigma") для beta_coef; null = по умолчанию.
+    vol_window: null         # Окно (в барах) для vol_metric; null = используем источник данных.
     profile_kind: hourly
-    multipliers: []        # 168 нормированных коэффициентов (например, со средним 1.0)
-    path: null             # Опционально: путь к JSON-профилю (см. data/slippage/hourly_profile.sample.json)
-    min_spread_bps: 0.0
-    max_spread_bps: 20.0
-    smoothing_alpha: 0.2
-    use_volatility: false
+    multipliers: []          # 168 нормированных коэффициентов (например, со средним 1.0)
+    path: null               # Опционально: путь к JSON-профилю (см. data/slippage/hourly_profile.sample.json)
+    override_path: null      # Опциональный путь к локальным поправкам поверх базового профиля.
+    hash: null               # Опциональный SHA256 от базового профиля для контроля целостности.
+    use_volatility: false    # Легаси-переключатель; оставьте false, если используете beta_coef.
     gamma: 0.0
 
 latency:

--- a/impl_sim_executor.py
+++ b/impl_sim_executor.py
@@ -89,9 +89,13 @@ class SimExecutor(TradeExecutor):
         if cfg is None:
             return False
         if isinstance(cfg, Mapping):
-            dyn_block = cfg.get("dynamic_spread")
+            dyn_block = cfg.get("dynamic")
+            if dyn_block is None:
+                dyn_block = cfg.get("dynamic_spread")
         else:
-            dyn_block = getattr(cfg, "dynamic_spread", None)
+            dyn_block = getattr(cfg, "dynamic", None)
+            if dyn_block is None:
+                dyn_block = getattr(cfg, "dynamic_spread", None)
         if dyn_block is None:
             return False
         if isinstance(dyn_block, Mapping):


### PR DESCRIPTION
## Summary
- extend `DynamicSpreadConfig` to understand the new alpha/beta/volatility fields while keeping legacy aliases
- allow `SlippageCfg`/`SlippageImpl` and helpers to accept either `slippage.dynamic` or `slippage.dynamic_spread`
- refresh the shipped YAML presets to document the new dynamic spread block and defaults

## Testing
- python -m compileall slippage.py impl_slippage.py impl_sim_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68cc3e13a398832fa6767844ed641c4d