### PR TITLE
Add runtime ADV configuration plumbing

### DIFF
--- a/configs/adv.yaml
+++ b/configs/adv.yaml
@@ -1,0 +1,16 @@
+# Runtime ADV configuration defaults shared across run modes.
+#
+# Copy this block into your config and override the knobs as needed.
+adv: &adv_runtime_defaults
+  enabled: false                # Enable ADV dataset consumption at runtime.
+  path: null                    # Path to parquet/JSON file with ADV quotes (null disables IO).
+  dataset: null                 # Optional dataset identifier when ``path`` points to a directory.
+  window_days: 30               # Lookback window in days for rolling ADV aggregation.
+  refresh_days: 7               # Refresh cadence for ADV cache/materialised views (in days).
+  auto_refresh: true            # Refresh automatically when ``refresh_days`` elapsed.
+  missing_symbol_policy: warn   # warn|skip|error - behaviour when symbol quotes are missing.
+  default_quote: null           # Fallback ADV quote (quote currency) when symbol is missing.
+  floor_quote: null             # Lower bound applied to resolved ADV quotes (quote currency).
+  seasonality_path: null        # Optional path to seasonality multipliers applied to ADV.
+  seasonality_profile: null     # Profile key extracted from ``seasonality_path`` payload.
+  # Any additional keys are preserved in ``adv.extra`` for backwards compatibility.

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -56,6 +56,20 @@ quantizer:
   auto_refresh_days: 30
   refresh_on_start: false
 
+# Runtime ADV dataset configuration (see ``configs/adv.yaml`` for documentation).
+adv:
+  enabled: false
+  path: null
+  dataset: null
+  window_days: 30
+  refresh_days: 7
+  auto_refresh: true
+  missing_symbol_policy: warn
+  default_quote: null
+  floor_quote: null
+  seasonality_path: null
+  seasonality_profile: null
+
 fees:
   maker_bps: 1.0
   taker_bps: 5.0

--- a/di_registry.py
+++ b/di_registry.py
@@ -16,7 +16,13 @@ import logging
 from typing import Any, Dict, Mapping, Optional, Type, TypeVar, get_type_hints
 
 from core_errors import ConfigError
-from core_config import ComponentSpec, Components, CommonRunConfig, RetryConfig
+from core_config import (
+    ComponentSpec,
+    Components,
+    CommonRunConfig,
+    RetryConfig,
+    AdvRuntimeConfig,
+)
 from impl_quantizer import QuantizerImpl
 
 
@@ -113,6 +119,11 @@ def build_graph(components: Components, run_config: Optional[CommonRunConfig] = 
             else:
                 container["quantizer"] = quantizer
                 container[QuantizerImpl] = quantizer
+        adv_cfg = getattr(run_config, "adv", None)
+        if isinstance(adv_cfg, AdvRuntimeConfig):
+            container["adv_runtime_config"] = adv_cfg
+            container[AdvRuntimeConfig] = adv_cfg
+            container.setdefault("adv", adv_cfg)
     build_component("market_data", components.market_data, container)
     build_component("feature_pipe", components.feature_pipe, container)
     build_component("policy", components.policy, container)


### PR DESCRIPTION
## Summary
- add an AdvRuntimeConfig pydantic model and surface it via CommonRunConfig plus loader helpers
- document runtime ADV knobs in configs/adv.yaml and expose defaults in the sim config
- make the DI container publish the parsed ADV runtime config for downstream consumers

## Testing
- python -m compileall core_config.py di_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1b1a3890832f8eb8498861ad2dd6