### PR TITLE
Refactor slippage ADV integration to use shared store

### DIFF
--- a/adv_store.py
+++ b/adv_store.py
@@ -1,0 +1,321 @@
+"""Runtime helpers for accessing ADV/turnover datasets."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _cfg_attr(block: Any, key: str, default: Any = None) -> Any:
+    if block is None:
+        return default
+    if isinstance(block, Mapping):
+        return block.get(key, default)
+    return getattr(block, key, default)
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(num):
+        return None
+    return num
+
+
+def _safe_positive_int(value: Any) -> Optional[int]:
+    try:
+        num = int(value)
+    except (TypeError, ValueError):
+        return None
+    if num <= 0:
+        return None
+    return num
+
+
+def _normalise_policy(value: Any) -> str:
+    if value is None:
+        return "warn"
+    try:
+        policy = str(value).strip().lower()
+    except Exception:
+        return "warn"
+    if policy not in {"warn", "skip", "error"}:
+        return "warn"
+    return policy
+
+
+class ADVStore:
+    """Load, cache and serve ADV quotes for runtime consumers."""
+
+    def __init__(self, cfg: Any) -> None:
+        self._cfg = cfg
+        self._path = self._resolve_path(cfg)
+        self._refresh_days = _safe_positive_int(_cfg_attr(cfg, "refresh_days"))
+        self._default_quote = _safe_float(_cfg_attr(cfg, "default_quote"))
+        self._floor_quote = _safe_float(_cfg_attr(cfg, "floor_quote"))
+        self._missing_policy = _normalise_policy(
+            _cfg_attr(cfg, "missing_symbol_policy", "warn")
+        )
+        self._cache: Dict[str, float] = {}
+        self._meta: Dict[str, Any] = {}
+        self._mtime: float | None = None
+        self._stale = False
+        self._lock = threading.Lock()
+        self._missing_logged: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def path(self) -> Optional[str]:
+        return self._path
+
+    @property
+    def default_quote(self) -> Optional[float]:
+        return self._default_quote if self._default_quote and self._default_quote > 0.0 else None
+
+    @property
+    def floor_quote(self) -> Optional[float]:
+        return self._floor_quote if self._floor_quote and self._floor_quote > 0.0 else None
+
+    @property
+    def missing_symbol_policy(self) -> str:
+        return self._missing_policy
+
+    @property
+    def metadata(self) -> Mapping[str, Any]:
+        with self._lock:
+            return dict(self._meta)
+
+    @property
+    def is_dataset_stale(self) -> bool:
+        with self._lock:
+            return bool(self._stale)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resolve_path(self, cfg: Any) -> Optional[str]:
+        candidates: list[str] = []
+        raw_path = _cfg_attr(cfg, "path")
+        if raw_path:
+            try:
+                text = str(raw_path).strip()
+            except Exception:
+                text = ""
+            if text:
+                candidates.append(text)
+        extra = _cfg_attr(cfg, "extra")
+        if isinstance(extra, Mapping):
+            for key in ("quote_path", "adv_path", "data_path", "path"):
+                candidate = extra.get(key)
+                if candidate:
+                    try:
+                        text = str(candidate).strip()
+                    except Exception:
+                        text = ""
+                    if text:
+                        candidates.append(text)
+        dataset_name = None
+        raw_dataset = _cfg_attr(cfg, "dataset")
+        if raw_dataset is not None:
+            try:
+                dataset_name = str(raw_dataset).strip()
+            except Exception:
+                dataset_name = None
+            if dataset_name == "":
+                dataset_name = None
+        for base in candidates:
+            if dataset_name and os.path.isdir(base):
+                candidate = os.path.join(base, dataset_name)
+                if os.path.exists(candidate):
+                    return candidate
+            if dataset_name and dataset_name not in os.path.basename(base):
+                candidate = os.path.join(base, dataset_name)
+                if os.path.exists(candidate):
+                    return candidate
+            return base
+        return None
+
+    def _ensure_loaded_locked(self) -> None:
+        path = self._path
+        if not path:
+            self._cache.clear()
+            self._meta = {}
+            self._stale = False
+            return
+        try:
+            mtime = os.path.getmtime(path)
+        except (OSError, TypeError, ValueError):
+            if not self._cache:
+                logger.warning("ADV dataset file %s is not accessible", path)
+            self._stale = False
+            return
+        if self._mtime is not None and self._cache and mtime <= self._mtime:
+            self._check_refresh_locked()
+            return
+        payload = self._read_payload(path)
+        if payload is None:
+            self._check_refresh_locked()
+            return
+        data, meta = payload
+        self._cache = data
+        self._meta = meta
+        self._mtime = mtime
+        self._check_refresh_locked()
+
+    def _read_payload(self, path: str) -> tuple[dict[str, float], dict[str, Any]] | None:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+        except FileNotFoundError:
+            logger.warning("ADV dataset file %s not found", path)
+            return {}, {}
+        except Exception:
+            logger.exception("Failed to load ADV dataset from %s", path)
+            return None
+        if not isinstance(payload, Mapping):
+            logger.warning("ADV dataset %s must be a JSON object", path)
+            return {}, {}
+        meta_raw = payload.get("meta")
+        data_raw = payload.get("data")
+        if not isinstance(data_raw, Mapping):
+            logger.warning("ADV dataset %s is missing 'data' mapping", path)
+            data_raw = {}
+        dataset: dict[str, float] = {}
+        for key, value in data_raw.items():
+            try:
+                symbol = str(key).strip().upper()
+            except Exception:
+                continue
+            if not symbol:
+                continue
+            if isinstance(value, Mapping):
+                candidate = value.get("adv_quote")
+            else:
+                candidate = value
+            adv_val = _safe_float(candidate)
+            if adv_val is None or adv_val <= 0.0:
+                continue
+            dataset[symbol] = float(adv_val)
+        meta: dict[str, Any] = dict(meta_raw) if isinstance(meta_raw, Mapping) else {}
+        meta.setdefault("path", path)
+        meta.setdefault("symbol_count", len(dataset))
+        return dataset, meta
+
+    def _extract_timestamp_locked(self) -> Optional[int]:
+        meta = self._meta
+        candidates = [
+            meta.get("generated_at_ms"),
+            meta.get("generated_ms"),
+            meta.get("timestamp_ms"),
+            meta.get("end_ms"),
+        ]
+        for candidate in candidates:
+            ts_val = _safe_positive_int(candidate)
+            if ts_val is not None:
+                return ts_val
+        for key in ("generated_at", "end_at"):
+            value = meta.get(key)
+            if not isinstance(value, str):
+                continue
+            text = value.strip()
+            if not text:
+                continue
+            if text.endswith("Z"):
+                text = text[:-1] + "+00:00"
+            try:
+                dt = datetime.fromisoformat(text)
+            except ValueError:
+                continue
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp() * 1000)
+        if self._mtime is not None:
+            return int(self._mtime * 1000)
+        return None
+
+    def _check_refresh_locked(self) -> None:
+        refresh_days = self._refresh_days
+        if not refresh_days:
+            self._stale = False
+            return
+        ts_ms = self._extract_timestamp_locked()
+        if ts_ms is None:
+            self._stale = True
+            logger.warning("ADV dataset %s lacks timestamp metadata", self._path)
+            return
+        age_ms = int(time.time() * 1000) - ts_ms
+        if age_ms <= 0:
+            self._stale = False
+            return
+        age_days = age_ms / 86_400_000
+        if age_days > float(refresh_days):
+            self._stale = True
+            logger.warning(
+                "ADV dataset %s is older than %.1f days (threshold=%s)",
+                self._path,
+                age_days,
+                refresh_days,
+            )
+        else:
+            self._stale = False
+
+    def _handle_missing_symbol(self, symbol: str) -> None:
+        if symbol in self._missing_logged:
+            return
+        policy = self._missing_policy
+        message = "ADV quote missing for %s (policy=%s)"
+        if policy == "error":
+            logger.error(message, symbol, policy)
+        elif policy == "warn":
+            logger.warning(message, symbol, policy)
+        else:
+            logger.debug(message, symbol, policy)
+        self._missing_logged.add(symbol)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def reset_runtime_state(self) -> None:
+        with self._lock:
+            self._missing_logged.clear()
+
+    def get_adv_quote(self, symbol: str) -> Optional[float]:
+        if not symbol:
+            return None
+        try:
+            sym_key = str(symbol).strip().upper()
+        except Exception:
+            return None
+        if not sym_key:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            if self._stale:
+                return None
+            if not self._cache:
+                return None
+            value = self._cache.get(sym_key)
+        if value is None:
+            self._handle_missing_symbol(sym_key)
+            return None
+        return float(value)
+
+    def get_bar_capacity_quote(self, symbol: str) -> Optional[float]:
+        # For now this mirrors ``get_adv_quote``. Kept separate to allow
+        # future extensions (e.g. per-bar aggregation) without changing call sites.
+        return self.get_adv_quote(symbol)
+
+
+__all__ = ["ADVStore"]

--- a/impl_sim_executor.py
+++ b/impl_sim_executor.py
@@ -197,7 +197,7 @@ class SimExecutor(TradeExecutor):
             cfg_lat.setdefault("symbol", symbol)
             latency = LatencyImpl.from_dict(cfg_lat)
         if slippage is None:
-            slippage = SlippageImpl.from_dict(rc_slippage)
+            slippage = SlippageImpl.from_dict(rc_slippage, run_config=run_config)
         if fees is None:
             fees = FeesImpl.from_dict(rc_fees)
 
@@ -253,7 +253,9 @@ class SimExecutor(TradeExecutor):
 
         q_impl = QuantizerImpl.from_dict(getattr(run_config, "quantizer", {}) or {})
         f_impl = FeesImpl.from_dict(getattr(run_config, "fees", {}) or {})
-        s_impl = SlippageImpl.from_dict(getattr(run_config, "slippage", {}) or {})
+        s_impl = SlippageImpl.from_dict(
+            getattr(run_config, "slippage", {}) or {}, run_config=run_config
+        )
         l_cfg = SimExecutor._latency_dict(getattr(run_config, "latency", None))
         lat_path = getattr(run_config, "latency_seasonality_path", None)
         if lat_path and not l_cfg.get("latency_seasonality_path"):

--- a/service_backtest.py
+++ b/service_backtest.py
@@ -211,7 +211,9 @@ class ServiceBacktest:
                 slip_payload = _slippage_to_dict(rc_slip_cfg)
                 if slip_payload:
                     try:
-                        SlippageImpl.from_dict(slip_payload).attach_to(self.sim)
+                        SlippageImpl.from_dict(
+                            slip_payload, run_config=self._run_config
+                        ).attach_to(self.sim)
                     except Exception:
                         logger.exception("Failed to attach slippage config to simulator")
         elif getattr(self._run_config, "slippage", None):


### PR DESCRIPTION
## Summary
- replace the internal ADV dataset loader with the shared ADVStore resolved from runtime configuration
- expose ADV helper methods (including bar capacity quotes) on the simulator while caching per symbol safely
- plumb run_config.adv into slippage construction across executors and backtest service

## Testing
- python -m compileall adv_store.py impl_slippage.py impl_sim_executor.py service_backtest.py

------
https://chatgpt.com/codex/tasks/task_e_68cd22104174832fab9d60bd7bd1506e