### PR TITLE
Add bar capacity metadata and metrics to execution simulator

### DIFF
--- a/utils/prometheus.py
+++ b/utils/prometheus.py
@@ -7,7 +7,7 @@ metrics calls do not fail in environments without Prometheus support.
 from __future__ import annotations
 
 try:  # pragma: no cover - simple import
-    from prometheus_client import Counter, Histogram  # type: ignore
+    from prometheus_client import Counter, Histogram, Summary  # type: ignore
 except Exception:  # pragma: no cover - fallback for missing dependency
     class _DummyCounter:
         def __init__(self, *args, **kwargs) -> None:
@@ -29,7 +29,13 @@ except Exception:  # pragma: no cover - fallback for missing dependency
         def observe(self, *args, **kwargs) -> None:
             pass
 
+    class _DummySummary(_DummyHistogram):
+        """Fallback Summary with Histogram-compatible API."""
+
+        pass
+
     Counter = _DummyCounter  # type: ignore
     Histogram = _DummyHistogram  # type: ignore
+    Summary = _DummySummary  # type: ignore
 
-__all__ = ["Counter", "Histogram"]
+__all__ = ["Counter", "Histogram", "Summary"]


### PR DESCRIPTION
## Summary
- extend ExecTrade and SimStepReport with bar capacity metadata and serialization
- record Prometheus counters/summaries and annotate partial or rejected fills with exec status during simulation
- propagate capacity metadata in compat_shims and expose a Prometheus Summary stub

## Testing
- pytest tests/test_execution_bar_capacity_base.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3be947a4832fa6be175fcdd926d3