### PR TITLE
Add bar capacity base defaults to execution configs

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -14,6 +14,14 @@ execution:
   timeframe_ms: null
   use_latency_from: null
   latency_constant_ms: null
+  bar_capacity_base:
+    enabled: false           # Переключатель ограничения объёма сделок по ADV базовой валюты.
+    capacity_frac_of_ADV_base: 1.0  # Доля дневного ADV (1.0 = 100%), доступная в каждом баре после пересчёта.
+    adv_base_path: "data/liquidity/adv_base.json"  # JSON с дневным ADV по базовой валюте.
+    # Формат файла: {"meta": {...}, "data": {"SYMBOL": {"adv_base": <float>, "days": <int>,
+    #   "days_total": <int>, "last_day": "<ISO8601>"}, ...}}; значения указываются в базовой валюте.
+    floor_base: null         # Минимальный дневной ADV (в базовой валюте): используется как фолбек и нижняя граница.
+    timeframe_ms: null       # Необязательный override размера бара (в мс) для конвертации дневного ADV в per-bar.
   bridge:
     intrabar_price_model: null
     timeframe_ms: null

--- a/configs/execution.yaml
+++ b/configs/execution.yaml
@@ -4,6 +4,12 @@ execution:
   timeframe_ms: null
   use_latency_from: null
   latency_constant_ms: null
+  bar_capacity_base:
+    enabled: false
+    capacity_frac_of_ADV_base: 1.0
+    adv_base_path: "data/liquidity/adv_base.json"
+    floor_base: null
+    timeframe_ms: null
   bridge:
     intrabar_price_model: null
     timeframe_ms: null


### PR DESCRIPTION
## Summary
- add default bar capacity base configuration to execution overrides
- document the expected ADV base dataset format and explain the floor fallback in the sim config

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd4345cecc832f8d3124a8f6da4d0f