### PR TITLE
Document expanded fee configuration

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -79,21 +79,29 @@ adv:
   seasonality_profile: null
 
 fees:
-  maker_bps: 1.0
-  taker_bps: 5.0
-  use_bnb_discount: false
-  maker_discount_mult: 1.0
-  taker_discount_mult: 1.0
+  path: null                     # Путь к JSON/YAML с ставками по символам; null → использовать data/fees/fees_by_symbol.json.
+  refresh_days: null             # Каденс проверки устаревания таблицы (в днях); null отключает проверку (по умолчанию).
+  maker_bps: 1.0                 # Базовая ставка мейкера в bps, когда нет записей в таблице (дефолт 1.0).
+  taker_bps: 5.0                 # Базовая ставка тейкера в bps, когда нет записей в таблице (дефолт 5.0).
+  use_bnb_discount: false        # Применять ли VIP-скидки Binance/BNB; false → множители остаются 1.0 (дефолт).
+  maker_discount_mult: 1.0       # Принудительный множитель скидки мейкера; null → авто (1.0 или 0.75 при скидке).
+  taker_discount_mult: 1.0       # Принудительный множитель скидки тейкера; null → авто (1.0 или 0.75 при скидке).
+  vip_tier: null                 # Номер VIP-уровня (int) для табличных ставок; null → использовать значения по умолчанию.
+  maker_share_default: null      # Override базовой доли maker [0..1]; null → использовать 0.5 из блока maker_taker_share.
+  spread_cost_maker_bps: null    # Override доп. издержек maker (bps) при разделении потока; null → 0.0 по умолчанию.
+  spread_cost_taker_bps: null    # Override доп. издержек taker (bps) при разделении потока; null → 0.0 по умолчанию.
+  taker_fee_override_bps: null   # Жёсткий override тейкерской комиссии (bps) после скидок; null → без override.
   maker_taker_share:
-    enabled: false
-    mode: "fixed"
-    maker_share_default: 0.5
-    spread_cost_maker_bps: 0.0
-    spread_cost_taker_bps: 0.0
-    taker_fee_override_bps: null
-    distance_to_mid: null        # Значение в bps или блок {value,min,max,fallback}
-    latency: null                # Значение в мс или блок {value,min,max,fallback}
-    coefficients: {}
+    enabled: false               # Включить расчёт доли maker/taker; false → использовать maker_share_default.
+    mode: "fixed"                # Режим: fixed | model | predictor; fixed → всегда брать maker_share_default.
+    maker_share_default: 0.5     # Базовая доля maker, когда модель неактивна/нет фичей (дефолт 0.5).
+    spread_cost_maker_bps: 0.0   # Доп. издержки maker (bps) сверх комиссии при активном разделе потока.
+    spread_cost_taker_bps: 0.0   # Доп. издержки taker (bps) сверх комиссии при активном разделе потока.
+    taker_fee_override_bps: null # Опциональный override тейкерской комиссии (bps) в активном режиме.
+    model:
+      distance_to_mid: null      # Фича distance-to-mid в bps или блок {value,min,max,fallback}; null → не используется.
+      latency: null              # Фича latency в мс или блок {value,min,max,fallback}; null → не используется.
+      coefficients: {}           # Линейные коэффициенты модели (intercept, distance_to_mid, latency, …); пусто = дефолт.
 
 slippage:
   k: 0.8

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -63,21 +63,29 @@ quantizer:
   refresh_on_start: false
 
 fees:
-  maker_bps: 1.0
-  taker_bps: 5.0
-  use_bnb_discount: false
-  maker_discount_mult: 1.0
-  taker_discount_mult: 1.0
+  path: null                     # Путь к JSON/YAML с ставками по символам; null → использовать data/fees/fees_by_symbol.json.
+  refresh_days: null             # Каденс проверки устаревания таблицы (в днях); null отключает проверку (по умолчанию).
+  maker_bps: 1.0                 # Базовая ставка мейкера в bps, когда нет записей в таблице (дефолт 1.0).
+  taker_bps: 5.0                 # Базовая ставка тейкера в bps, когда нет записей в таблице (дефолт 5.0).
+  use_bnb_discount: false        # Применять ли VIP-скидки Binance/BNB; false → множители остаются 1.0 (дефолт).
+  maker_discount_mult: 1.0       # Принудительный множитель скидки мейкера; null → авто (1.0 или 0.75 при скидке).
+  taker_discount_mult: 1.0       # Принудительный множитель скидки тейкера; null → авто (1.0 или 0.75 при скидке).
+  vip_tier: null                 # Номер VIP-уровня (int) для табличных ставок; null → использовать значения по умолчанию.
+  maker_share_default: null      # Override базовой доли maker [0..1]; null → использовать 0.5 из блока maker_taker_share.
+  spread_cost_maker_bps: null    # Override доп. издержек maker (bps) при разделении потока; null → 0.0 по умолчанию.
+  spread_cost_taker_bps: null    # Override доп. издержек taker (bps) при разделении потока; null → 0.0 по умолчанию.
+  taker_fee_override_bps: null   # Жёсткий override тейкерской комиссии (bps) после скидок; null → без override.
   maker_taker_share:
-    enabled: false
-    mode: "fixed"
-    maker_share_default: 0.5
-    spread_cost_maker_bps: 0.0
-    spread_cost_taker_bps: 0.0
-    taker_fee_override_bps: null
-    distance_to_mid: null        # Значение в bps или блок {value,min,max,fallback}
-    latency: null                # Значение в мс или блок {value,min,max,fallback}
-    coefficients: {}             # Коэффициенты простого предиктора (intercept, distance_to_mid, latency)
+    enabled: false               # Включить расчёт доли maker/taker; false → использовать maker_share_default.
+    mode: "fixed"                # Режим: fixed | model | predictor; fixed → всегда брать maker_share_default.
+    maker_share_default: 0.5     # Базовая доля maker, когда модель неактивна/нет фичей (дефолт 0.5).
+    spread_cost_maker_bps: 0.0   # Доп. издержки maker (bps) сверх комиссии при активном разделе потока.
+    spread_cost_taker_bps: 0.0   # Доп. издержки taker (bps) сверх комиссии при активном разделе потока.
+    taker_fee_override_bps: null # Опциональный override тейкерской комиссии (bps) в активном режиме.
+    model:
+      distance_to_mid: null      # Фича distance-to-mid в bps или блок {value,min,max,fallback}; null → не используется.
+      latency: null              # Фича latency в мс или блок {value,min,max,fallback}; null → не используется.
+      coefficients: {}           # Линейные коэффициенты модели (intercept, distance_to_mid, latency, …); пусто = дефолт.
 
 slippage:
   k: 0.8

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -47,21 +47,29 @@ quantizer:
   refresh_on_start: false
 
 fees:
-  maker_bps: 1.0
-  taker_bps: 5.0
-  use_bnb_discount: false
-  maker_discount_mult: 1.0
-  taker_discount_mult: 1.0
+  path: null                     # Путь к JSON/YAML с ставками по символам; null → использовать data/fees/fees_by_symbol.json.
+  refresh_days: null             # Каденс проверки устаревания таблицы (в днях); null отключает проверку (по умолчанию).
+  maker_bps: 1.0                 # Базовая ставка мейкера в bps, когда нет записей в таблице (дефолт 1.0).
+  taker_bps: 5.0                 # Базовая ставка тейкера в bps, когда нет записей в таблице (дефолт 5.0).
+  use_bnb_discount: false        # Применять ли VIP-скидки Binance/BNB; false → множители остаются 1.0 (дефолт).
+  maker_discount_mult: 1.0       # Принудительный множитель скидки мейкера; null → авто (1.0 или 0.75 при скидке).
+  taker_discount_mult: 1.0       # Принудительный множитель скидки тейкера; null → авто (1.0 или 0.75 при скидке).
+  vip_tier: null                 # Номер VIP-уровня (int) для табличных ставок; null → использовать значения по умолчанию.
+  maker_share_default: null      # Override базовой доли maker [0..1]; null → использовать 0.5 из блока maker_taker_share.
+  spread_cost_maker_bps: null    # Override доп. издержек maker (bps) при разделении потока; null → 0.0 по умолчанию.
+  spread_cost_taker_bps: null    # Override доп. издержек taker (bps) при разделении потока; null → 0.0 по умолчанию.
+  taker_fee_override_bps: null   # Жёсткий override тейкерской комиссии (bps) после скидок; null → без override.
   maker_taker_share:
-    enabled: false
-    mode: "fixed"
-    maker_share_default: 0.5
-    spread_cost_maker_bps: 0.0
-    spread_cost_taker_bps: 0.0
-    taker_fee_override_bps: null
-    distance_to_mid: null        # Значение в bps или блок {value,min,max,fallback}
-    latency: null                # Значение в мс или блок {value,min,max,fallback}
-    coefficients: {}
+    enabled: false               # Включить расчёт доли maker/taker; false → использовать maker_share_default.
+    mode: "fixed"                # Режим: fixed | model | predictor; fixed → всегда брать maker_share_default.
+    maker_share_default: 0.5     # Базовая доля maker, когда модель неактивна/нет фичей (дефолт 0.5).
+    spread_cost_maker_bps: 0.0   # Доп. издержки maker (bps) сверх комиссии при активном разделе потока.
+    spread_cost_taker_bps: 0.0   # Доп. издержки taker (bps) сверх комиссии при активном разделе потока.
+    taker_fee_override_bps: null # Опциональный override тейкерской комиссии (bps) в активном режиме.
+    model:
+      distance_to_mid: null      # Фича distance-to-mid в bps или блок {value,min,max,fallback}; null → не используется.
+      latency: null              # Фича latency в мс или блок {value,min,max,fallback}; null → не используется.
+      coefficients: {}           # Линейные коэффициенты модели (intercept, distance_to_mid, latency, …); пусто = дефолт.
 
 slippage:
   k: 0.8

--- a/configs/fees.yaml
+++ b/configs/fees.yaml
@@ -1,0 +1,50 @@
+# Пример расширенной конфигурации торговых комиссий.
+# Можно подключить через fees.path в основных конфигурациях.
+fees:
+  enabled: true                    # Глобальный флаг применения комиссий (дефолт true).
+  path: "data/fees/fees_by_symbol.json"  # Файл со ставками по символам (JSON/YAML).
+  refresh_days: 7                  # Проверять свежесть таблицы каждые N дней; null отключает (дефолт null).
+  maker_bps: 1.0                   # Глобальная ставка мейкера (bps) при отсутствии записей (дефолт 1.0).
+  taker_bps: 5.0                   # Глобальная ставка тейкера (bps) при отсутствии записей (дефолт 5.0).
+  use_bnb_discount: false          # Применять ли скидки BNB/VIP; true → множители по умолчанию 0.75.
+  maker_discount_mult: null        # Принудительный множитель мейкера; null → авто по use_bnb_discount.
+  taker_discount_mult: null        # Принудительный множитель тейкера; null → авто по use_bnb_discount.
+  vip_tier: null                   # VIP-уровень Binance (int); null → берём из таблицы/дефолты.
+  maker_share_default: null        # Override доли maker [0..1]; null → использовать значение блока maker_taker_share.
+  spread_cost_maker_bps: null      # Доп. издержки maker (bps) поверх комиссии; null → 0.0.
+  spread_cost_taker_bps: null      # Доп. издержки taker (bps) поверх комиссии; null → 0.0.
+  taker_fee_override_bps: null     # Жёсткий override тейкерской комиссии (bps); null → не применяется.
+  fee_rounding_step: null          # Шаг округления комиссии (например 0.0001); null → без округления.
+  symbol_fee_table:                # Inline-таблица ставок; может дополнять/override внешний файл.
+    BTCUSDT:
+      maker_bps: 1.8
+      taker_bps: 3.6
+      vip_tier: 1
+    ETHUSDT:
+      maker_bps: 2.0
+      taker_bps: 4.0
+  metadata:
+    source: "binance"
+    fetched_at: "2024-01-01T00:00:00Z"
+  maker_taker_share:
+    enabled: false                 # Переключатель динамического деления потока.
+    mode: "fixed"                  # fixed | model | predictor.
+    maker_share_default: 0.5       # Базовая доля maker при отсутствии модели (дефолт 0.5).
+    spread_cost_maker_bps: 0.0     # Доп. издержки maker (bps) при активном делении.
+    spread_cost_taker_bps: 0.0     # Доп. издержки taker (bps) при активном делении.
+    taker_fee_override_bps: null   # Override тейкерской комиссии (bps) при активном делении.
+    model:
+      distance_to_mid:             # Настройка фичи distance-to-mid (bps) для модели.
+        value: null
+        min: 0.0
+        max: null
+        fallback: null
+      latency:                     # Настройка фичи latency (мс) для модели.
+        value: null
+        min: 0.0
+        max: null
+        fallback: null
+      coefficients:                # Линейные коэффициенты модели; ключи приводятся к lower-case.
+        intercept: 0.0
+        distance_to_mid: 0.0
+        latency: 0.0

--- a/configs/legacy_sim.yaml
+++ b/configs/legacy_sim.yaml
@@ -5,21 +5,29 @@ filters:
   strict: true
 
 fees:
-  maker_bps: 1.0
-  taker_bps: 5.0
-  use_bnb_discount: false
-  maker_discount_mult: 1.0
-  taker_discount_mult: 1.0
+  path: null                     # Путь к JSON/YAML с ставками по символам; null → использовать data/fees/fees_by_symbol.json.
+  refresh_days: null             # Каденс проверки устаревания таблицы (в днях); null отключает проверку (по умолчанию).
+  maker_bps: 1.0                 # Базовая ставка мейкера в bps, когда нет записей в таблице (дефолт 1.0).
+  taker_bps: 5.0                 # Базовая ставка тейкера в bps, когда нет записей в таблице (дефолт 5.0).
+  use_bnb_discount: false        # Применять ли VIP-скидки Binance/BNB; false → множители остаются 1.0 (дефолт).
+  maker_discount_mult: 1.0       # Принудительный множитель скидки мейкера; null → авто (1.0 или 0.75 при скидке).
+  taker_discount_mult: 1.0       # Принудительный множитель скидки тейкера; null → авто (1.0 или 0.75 при скидке).
+  vip_tier: null                 # Номер VIP-уровня (int) для табличных ставок; null → использовать значения по умолчанию.
+  maker_share_default: null      # Override базовой доли maker [0..1]; null → использовать 0.5 из блока maker_taker_share.
+  spread_cost_maker_bps: null    # Override доп. издержек maker (bps) при разделении потока; null → 0.0 по умолчанию.
+  spread_cost_taker_bps: null    # Override доп. издержек taker (bps) при разделении потока; null → 0.0 по умолчанию.
+  taker_fee_override_bps: null   # Жёсткий override тейкерской комиссии (bps) после скидок; null → без override.
   maker_taker_share:
-    enabled: false
-    mode: "fixed"
-    maker_share_default: 0.5
-    spread_cost_maker_bps: 0.0
-    spread_cost_taker_bps: 0.0
-    taker_fee_override_bps: null
-    distance_to_mid: null
-    latency: null
-    coefficients: {}
+    enabled: false               # Включить расчёт доли maker/taker; false → использовать maker_share_default.
+    mode: "fixed"                # Режим: fixed | model | predictor; fixed → всегда брать maker_share_default.
+    maker_share_default: 0.5     # Базовая доля maker, когда модель неактивна/нет фичей (дефолт 0.5).
+    spread_cost_maker_bps: 0.0   # Доп. издержки maker (bps) сверх комиссии при активном разделе потока.
+    spread_cost_taker_bps: 0.0   # Доп. издержки taker (bps) сверх комиссии при активном разделе потока.
+    taker_fee_override_bps: null # Опциональный override тейкерской комиссии (bps) в активном режиме.
+    model:
+      distance_to_mid: null      # Фича distance-to-mid в bps или блок {value,min,max,fallback}; null → не используется.
+      latency: null              # Фича latency в мс или блок {value,min,max,fallback}; null → не используется.
+      coefficients: {}           # Линейные коэффициенты модели (intercept, distance_to_mid, latency, …); пусто = дефолт.
 
 funding:
   enabled: false


### PR DESCRIPTION
## Summary
- expand the shared `fees` block across sim/train templates with path/refresh/vip overrides and detailed maker/taker share model comments
- document the predictor inputs under `maker_taker_share` and clarify default overrides for discount multipliers
- provide a standalone `configs/fees.yaml` example illustrating table, metadata and model tuning fields

## Testing
- not run (configuration documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cd98537d54832f959ec50dbd5835f1