### PR TITLE
Add fee metadata JSON dataset

### DIFF
--- a/data/fees/README.md
+++ b/data/fees/README.md
@@ -1,0 +1,25 @@
+# Fee schedule data
+
+This directory contains JSON descriptions of maker/taker fee schedules per trading symbol.
+
+## Update process
+
+1. Pull the latest fee schedule from the exchange's official documentation or API.
+2. Update `fees_by_symbol.json`:
+   - Adjust the entries under `fees` to match the new maker/taker basis points (bps) for every affected symbol.
+   - Add or remove symbols as they appear/disappear in the public schedule.
+   - Include `fee_rounding_step_bps` when the exchange specifies a minimum rounding increment for fee calculations.
+   - Set `bnb_discount_bps` (or a similar discount field) only when the exchange confirms the discount level for the symbol.
+3. Refresh the metadata block:
+   - `built_at`: UTC timestamp in ISO-8601 format reflecting when the data was generated.
+   - `source`: Plain-text description of the data source (URL or document title) and retrieval date.
+   - `vip_tier`: The VIP tier the data corresponds to (e.g., "VIP 0").
+   - `schema_version`: Increment if the JSON shape changes.
+4. Validate the JSON formatting before committing:
+
+   ```bash
+   python -m json.tool data/fees/fees_by_symbol.json > /dev/null
+   ```
+
+5. Document any non-obvious assumptions in the commit message or within this README to aid future maintenance.
+

--- a/data/fees/fees_by_symbol.json
+++ b/data/fees/fees_by_symbol.json
@@ -1,0 +1,38 @@
+{
+  "metadata": {
+    "built_at": "2025-09-19T17:59:31Z",
+    "source": "Binance spot fee schedule retrieved via public docs",
+    "vip_tier": "VIP 0",
+    "schema_version": 1
+  },
+  "fees": {
+    "BTCUSDT": {
+      "maker_bps": 10,
+      "taker_bps": 10,
+      "fee_rounding_step_bps": 0.1,
+      "bnb_discount_bps": 7.5
+    },
+    "ETHUSDT": {
+      "maker_bps": 10,
+      "taker_bps": 10,
+      "bnb_discount_bps": 7.5
+    },
+    "BNBUSDT": {
+      "maker_bps": 9,
+      "taker_bps": 9,
+      "fee_rounding_step_bps": 0.1,
+      "bnb_discount_bps": 6.75
+    },
+    "ADAUSDT": {
+      "maker_bps": 10,
+      "taker_bps": 12,
+      "fee_rounding_step_bps": 0.05,
+      "bnb_discount_bps": 9
+    },
+    "SOLUSDT": {
+      "maker_bps": 8,
+      "taker_bps": 10,
+      "bnb_discount_bps": 7.5
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a fee schedule JSON file with metadata and per-symbol maker/taker settings
- document how to maintain the dataset in a README within `data/fees`

## Testing
- python -m json.tool data/fees/fees_by_symbol.json > /dev/null

------
https://chatgpt.com/codex/tasks/task_e_68cd99d10cac832f8e0869179aa89bb0