### PR TITLE
Refine sandbox dynamic spread handling

### DIFF
--- a/sandbox/backtest_adapter.py
+++ b/sandbox/backtest_adapter.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, replace
+import math
+from dataclasses import dataclass, replace, field
 from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd
@@ -19,28 +20,117 @@ from services.monitoring import skipped_incomplete_bars
 @dataclass
 class DynSpreadConfig:
     enabled: bool = True
-    base_bps: float = 3.0
-    alpha_vol: float = 0.5
-    beta_illiquidity: float = 1.0
-    vol_mode: str = "hl"                 # "hl" или "ret"
-    liq_col: str = "number_of_trades"    # "number_of_trades" или "volume"
-    liq_ref: float = 1000.0
-    min_bps: float = 1.0
-    max_bps: float = 25.0
+    alpha_bps: Optional[float] = None
+    beta_coef: Optional[float] = None
+    min_spread_bps: Optional[float] = None
+    max_spread_bps: Optional[float] = None
+    smoothing_alpha: Optional[float] = None
+    fallback_spread_bps: Optional[float] = None
+    vol_metric: Optional[str] = None
+    vol_window: Optional[int] = None
+    vol_mode: Optional[str] = None
+    liq_col: Optional[str] = None
+    liq_ref: Optional[float] = None
+    # legacy aliases kept for compatibility with older configs
+    base_bps: Optional[float] = None
+    alpha_vol: Optional[float] = None
+    beta_illiquidity: Optional[float] = None
+    min_bps: Optional[float] = None
+    max_bps: Optional[float] = None
+    alpha: Optional[float] = None
+    beta: Optional[float] = None
+    volatility_metric: Optional[str] = None
+    volatility_window: Optional[int] = None
+    use_volatility: bool = False
+    ema_state: Dict[str, float] = field(default_factory=dict, init=False, repr=False)
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "DynSpreadConfig":
-        return cls(
+        if not isinstance(d, dict):
+            d = {}
+
+        def _first_non_null(*keys: str) -> Any:
+            for key in keys:
+                if key in d and d[key] is not None:
+                    return d[key]
+            return None
+
+        def _to_float(value: Any) -> Optional[float]:
+            try:
+                out = float(value)
+            except (TypeError, ValueError):
+                return None
+            if math.isfinite(out):
+                return out
+            return None
+
+        def _to_int(value: Any) -> Optional[int]:
+            try:
+                out = int(value)
+            except (TypeError, ValueError):
+                return None
+            return out
+
+        alpha_val = _to_float(_first_non_null("alpha_bps", "alpha", "base_bps"))
+        beta_val = _to_float(_first_non_null("beta_coef", "beta", "alpha_vol"))
+        min_val = _to_float(_first_non_null("min_spread_bps", "min_bps"))
+        max_val = _to_float(_first_non_null("max_spread_bps", "max_bps"))
+        smoothing_val = _to_float(_first_non_null("smoothing_alpha", "smoothing"))
+        fallback_val = _to_float(d.get("fallback_spread_bps"))
+        vol_metric_val = _first_non_null("vol_metric", "volatility_metric")
+        vol_window_val = _to_int(_first_non_null("vol_window", "volatility_window"))
+        vol_mode_val = _first_non_null("vol_mode", None)
+        liq_col_val = _first_non_null("liq_col", None)
+        liq_ref_val = _to_float(d.get("liq_ref"))
+
+        if vol_mode_val is None and vol_metric_val is None:
+            vol_mode_val = "hl"
+        if liq_col_val is None:
+            liq_col_val = "number_of_trades"
+        if liq_ref_val is None:
+            liq_ref_val = 1000.0
+
+        cfg = cls(
             enabled=bool(d.get("enabled", True)),
-            base_bps=float(d.get("base_bps", 3.0)),
-            alpha_vol=float(d.get("alpha_vol", 0.5)),
-            beta_illiquidity=float(d.get("beta_illiquidity", 1.0)),
-            vol_mode=str(d.get("vol_mode", "hl")),
-            liq_col=str(d.get("liq_col", "number_of_trades")),
-            liq_ref=float(d.get("liq_ref", 1000.0)),
-            min_bps=float(d.get("min_bps", 1.0)),
-            max_bps=float(d.get("max_bps", 25.0)),
+            alpha_bps=alpha_val,
+            beta_coef=beta_val,
+            min_spread_bps=min_val,
+            max_spread_bps=max_val,
+            smoothing_alpha=smoothing_val,
+            fallback_spread_bps=fallback_val,
+            vol_metric=str(vol_metric_val) if vol_metric_val is not None else None,
+            vol_window=vol_window_val,
+            vol_mode=str(vol_mode_val) if vol_mode_val is not None else None,
+            liq_col=str(liq_col_val) if liq_col_val is not None else None,
+            liq_ref=liq_ref_val,
+            base_bps=_to_float(_first_non_null("base_bps", "alpha_bps", "alpha")),
+            alpha_vol=_to_float(d.get("alpha_vol")),
+            beta_illiquidity=_to_float(d.get("beta_illiquidity")),
+            min_bps=_to_float(d.get("min_bps")),
+            max_bps=_to_float(d.get("max_bps")),
+            alpha=_to_float(_first_non_null("alpha", "alpha_bps", "base_bps")),
+            beta=_to_float(_first_non_null("beta", "beta_coef", "alpha_vol")),
+            volatility_metric=str(vol_metric_val) if vol_metric_val is not None else None,
+            volatility_window=vol_window_val,
+            use_volatility=bool(d.get("use_volatility", False)),
         )
+
+        if cfg.base_bps is None:
+            cfg.base_bps = cfg.alpha_bps
+        if cfg.alpha is None:
+            cfg.alpha = cfg.alpha_bps
+        if cfg.beta is None:
+            cfg.beta = cfg.beta_coef
+        if cfg.min_bps is None:
+            cfg.min_bps = cfg.min_spread_bps
+        if cfg.max_bps is None:
+            cfg.max_bps = cfg.max_spread_bps
+        if cfg.volatility_metric is None:
+            cfg.volatility_metric = cfg.vol_metric
+        if cfg.volatility_window is None:
+            cfg.volatility_window = cfg.vol_window
+
+        return cfg
 
 
 @dataclass
@@ -172,11 +262,22 @@ class BacktestAdapter:
 
         estimator.observe(symbol=sym, high=hi, low=lo, close=close_val)
 
-        vol_mode = str(getattr(self._dyn, "vol_mode", "")).lower()
-        metric = "atr" if vol_mode == "hl" else "sigma"
-        value = estimator.value(sym, metric=metric)
+        metric_key = getattr(self._dyn, "vol_metric", None) or getattr(
+            self._dyn, "volatility_metric", None
+        )
+        if not metric_key:
+            vol_mode = str(getattr(self._dyn, "vol_mode", "")).lower()
+            if vol_mode == "hl":
+                metric_key = "range_ratio_bps"
+            elif vol_mode == "ret":
+                metric_key = "sigma"
+        if metric_key is not None:
+            metric_key = str(metric_key).strip().lower()
+            if not metric_key:
+                metric_key = None
+        value = estimator.value(sym, metric=metric_key)
         if value is None:
-            last = estimator.last(sym, metric=metric)
+            last = estimator.last(sym, metric=metric_key)
             if last is not None:
                 return float(last)
             return 0.0
@@ -193,18 +294,90 @@ class BacktestAdapter:
             pass
         return 1.0
 
-    def _synth_quotes(self, *, symbol: str, ref: float, vol_factor: float, liquidity: float) -> (float, float, float):
-        base = float(self._dyn.base_bps)
-        vol_term = float(self._dyn.alpha_vol) * float(vol_factor) * 10000.0
-        illq = 0.0
-        if float(self._dyn.liq_ref) > 0 and liquidity == liquidity:
-            ratio = max(0.0, (float(self._dyn.liq_ref) - float(liquidity)) / float(self._dyn.liq_ref))
-            illq = float(self._dyn.beta_illiquidity) * ratio * base
-        spread_bps = base + vol_term + illq
-        spread_bps = max(float(self._dyn.min_bps), min(float(self._dyn.max_bps), float(spread_bps)))
-        half = float(spread_bps) / 20000.0
-        raw_bid = float(ref) * (1.0 - half)
-        raw_ask = float(ref) * (1.0 + half)
+    def _synth_quotes(
+        self, *, symbol: str, ref: float, vol_factor: float, liquidity: float
+    ) -> (float, float, float):
+        # ``vol_factor`` already corresponds to the configured volatility metric
+        # (for example ``range_ratio_bps``) in ``SimAdapter``.  Legacy configs may
+        # still provide ``base_bps``/``alpha_vol`` which we treat as aliases for
+        # the new ``alpha_bps``/``beta_coef`` knobs.
+
+        def _finite_float(value: Any) -> Optional[float]:
+            try:
+                out = float(value)
+            except (TypeError, ValueError):
+                return None
+            if math.isfinite(out):
+                return out
+            return None
+
+        alpha = _finite_float(self._dyn.alpha_bps)
+        if alpha is None:
+            alpha = _finite_float(self._dyn.base_bps)
+
+        fallback = _finite_float(self._dyn.fallback_spread_bps)
+        if fallback is None:
+            fallback = alpha
+
+        beta = _finite_float(self._dyn.beta_coef)
+        if beta is None:
+            beta = _finite_float(self._dyn.alpha_vol)
+        if beta is None:
+            beta = 0.0
+
+        metric_value = _finite_float(vol_factor)
+        if metric_value is not None and metric_value < 0.0:
+            metric_value = 0.0
+
+        if metric_value is None:
+            spread_candidate = fallback if fallback is not None else alpha
+        else:
+            base_component = alpha if alpha is not None else fallback
+            if base_component is None:
+                base_component = 0.0
+            spread_candidate = base_component + beta * metric_value
+
+        if spread_candidate is None:
+            spread_candidate = fallback if fallback is not None else 0.0
+
+        min_bps = _finite_float(self._dyn.min_spread_bps)
+        if min_bps is None:
+            min_bps = _finite_float(self._dyn.min_bps)
+        if min_bps is not None:
+            spread_candidate = max(min_bps, spread_candidate)
+
+        max_bps = _finite_float(self._dyn.max_spread_bps)
+        if max_bps is None:
+            max_bps = _finite_float(self._dyn.max_bps)
+        if max_bps is not None:
+            spread_candidate = min(max_bps, spread_candidate)
+
+        smoothing = _finite_float(self._dyn.smoothing_alpha)
+        if smoothing is not None:
+            smoothing = min(max(smoothing, 0.0), 1.0)
+            prev = self._dyn.ema_state.get(symbol)
+            if prev is None or not math.isfinite(prev):
+                ema_val = spread_candidate
+            else:
+                ema_val = smoothing * spread_candidate + (1.0 - smoothing) * prev
+            self._dyn.ema_state[symbol] = float(ema_val)
+            spread_candidate = ema_val
+        else:
+            self._dyn.ema_state.pop(symbol, None)
+
+        spread_bps = _finite_float(spread_candidate)
+        if spread_bps is None:
+            spread_bps = fallback if fallback is not None else 0.0
+        if spread_bps < 0.0:
+            spread_bps = 0.0
+
+        ref_price = _finite_float(ref)
+        if ref_price is None or ref_price <= 0.0:
+            ref_price = max(ref_price or 0.0, 0.0)
+
+        half = spread_bps / 20000.0
+        raw_bid = float(ref_price) * (1.0 - half)
+        raw_ask = float(ref_price) * (1.0 + half)
         bid = round_price_to_tick(symbol, raw_bid, self._specs, side="BID")
         ask = round_price_to_tick(symbol, raw_ask, self._specs, side="ASK")
         if ask <= bid:


### PR DESCRIPTION
## Summary
- map new dynamic slippage fields while preserving legacy aliases during extraction
- ensure ServiceBacktest forwards the untouched dynamic spread payload to the backtest adapter
- rework sandbox dynamic spread configuration and quote synthesis to use the alpha + beta * range ratio model with clamps, smoothing, and fallbacks

## Testing
- pytest tests/test_dynamic_spread_calculation.py

------
https://chatgpt.com/codex/tasks/task_e_68cda975bd54832f81ceb8623ed9aaac