### PR TITLE
Add commission precision support to Binance filters

### DIFF
--- a/binance_public.py
+++ b/binance_public.py
@@ -218,6 +218,16 @@ class BinancePublicClient:
                     ftype = f.get("filterType")
                     if ftype in {"PRICE_FILTER", "LOT_SIZE", "MIN_NOTIONAL", "PERCENT_PRICE_BY_SIDE", "PERCENT_PRICE"}:
                         d[ftype] = {k: v for k, v in f.items() if k != "filterType"}
+                precision_keys = (
+                    "baseAssetPrecision",
+                    "quotePrecision",
+                    "quoteAssetPrecision",
+                    "baseCommissionPrecision",
+                    "quoteCommissionPrecision",
+                )
+                for key in precision_keys:
+                    if key in s:
+                        d[key] = s[key]
                 if sym and d:
                     out[sym] = d
         return out

--- a/data/binance_filters.json
+++ b/data/binance_filters.json
@@ -17,7 +17,12 @@
         "maxPrice": "1000000",
         "minPrice": "0.01",
         "tickSize": "0.01"
-      }
+      },
+      "baseAssetPrecision": 8,
+      "baseCommissionPrecision": 8,
+      "quoteAssetPrecision": 8,
+      "quoteCommissionPrecision": 8,
+      "quotePrecision": 8
     },
     "ETHUSDT": {
       "LOT_SIZE": {
@@ -36,12 +41,17 @@
         "maxPrice": "1000000",
         "minPrice": "0.01",
         "tickSize": "0.01"
-      }
+      },
+      "baseAssetPrecision": 8,
+      "baseCommissionPrecision": 8,
+      "quoteAssetPrecision": 8,
+      "quoteCommissionPrecision": 8,
+      "quotePrecision": 8
     }
   },
   "metadata": {
-    "built_at": "2025-09-15T16:57:30.622478+00:00",
-    "source": "/api/v3/exchangeInfo",
-    "symbols_count": 2
+    "generated_at": "2025-09-19T20:48:45Z",
+    "source_dataset": "binance_exchange_filters",
+    "version": 1
   }
 }

--- a/fetch_binance_filters.py
+++ b/fetch_binance_filters.py
@@ -23,6 +23,24 @@ def main():
         print(f"ERROR: failed to fetch exchangeInfo: {e}", file=sys.stderr)
         sys.exit(1)
 
+    precision_keys = {
+        "baseAssetPrecision",
+        "quoteAssetPrecision",
+        "baseCommissionPrecision",
+        "quoteCommissionPrecision",
+        "quotePrecision",
+    }
+    for sym_data in normalized.values():
+        if not isinstance(sym_data, dict):
+            continue
+        for key in precision_keys:
+            if key not in sym_data:
+                continue
+            try:
+                sym_data[key] = int(sym_data[key])
+            except (TypeError, ValueError):
+                continue
+
     meta = {
         "generated_at": datetime.utcnow().isoformat() + "Z",
         "source_dataset": "binance_exchange_filters",

--- a/tests/test_quantizer_commission_step.py
+++ b/tests/test_quantizer_commission_step.py
@@ -1,0 +1,43 @@
+import math
+
+
+from quantizer import Quantizer
+
+
+def test_commission_step_from_quote_commission_precision():
+    filters = {
+        "BTCUSDT": {
+            "quoteCommissionPrecision": 4,
+            "PRICE_FILTER": {},
+        }
+    }
+    quantizer = Quantizer(filters, strict=True)
+    assert math.isclose(quantizer.get_commission_step("BTCUSDT"), 10.0 ** -4)
+
+
+def test_commission_step_falls_back_to_quote_precision():
+    filters = {
+        "ETHUSDT": {
+            "quotePrecision": "5",
+            "PRICE_FILTER": {},
+        }
+    }
+    quantizer = Quantizer(filters, strict=True)
+    assert math.isclose(quantizer.get_commission_step("ETHUSDT"), 10.0 ** -5)
+
+
+def test_commission_step_uses_direct_value_when_present():
+    filters = {
+        "BNBUSDT": {
+            "commission_step": "0.0005",
+            "PRICE_FILTER": {},
+        }
+    }
+    quantizer = Quantizer(filters, strict=True)
+    assert math.isclose(quantizer.get_commission_step("BNBUSDT"), 0.0005)
+
+
+def test_commission_step_missing_symbol_returns_zero():
+    quantizer = Quantizer({}, strict=True)
+    assert quantizer.get_commission_step("UNKNOWN") == 0.0
+


### PR DESCRIPTION
## Summary
- include Binance precision metadata alongside normalized exchange filters
- ensure the filter fetch script preserves the new precision keys in stored snapshots
- expose commission step inference in the quantizer with unit coverage

## Testing
- pytest tests/test_quantizer_commission_step.py tests/test_mediator_quantization.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc03f4bac832f8378c54fb47c23a6