### PR TITLE
Enhance fee rounding and BNB settlement handling

### DIFF
--- a/fees.py
+++ b/fees.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from decimal import (
+    Decimal,
+    DivisionByZero,
+    InvalidOperation,
+    ROUND_DOWN,
+    ROUND_HALF_UP,
+    ROUND_UP,
+)
 from typing import Optional, Dict, Any, Tuple, List, Mapping
 
 
@@ -48,6 +56,188 @@ def _sanitize_rounding_step(value: Any) -> float:
     if sanitized is None or sanitized <= 0.0:
         return 0.0
     return float(sanitized)
+
+
+def _sanitize_positive_float(value: Any) -> Optional[float]:
+    sanitized = _sanitize_optional_non_negative(value)
+    if sanitized is None:
+        return None
+    if sanitized <= 0.0:
+        return None
+    return float(sanitized)
+
+
+def _precision_to_step(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        precision = int(value)
+    except (TypeError, ValueError):
+        return None
+    if precision < 0:
+        return None
+    try:
+        return float(Decimal(1).scaleb(-precision))
+    except (InvalidOperation, ValueError):
+        try:
+            return float(10.0 ** (-precision))
+        except Exception:
+            return None
+
+
+def _extract_commission_step(payload: Any) -> Optional[float]:
+    if payload is None:
+        return None
+
+    if isinstance(payload, Mapping):
+        direct = payload.get("commission_step")
+        if direct is None and "commissionStep" in payload:
+            direct = payload.get("commissionStep")
+        step = _sanitize_positive_float(direct)
+        if step is not None:
+            return step
+
+        precision_candidate = payload.get("commission_precision")
+        if precision_candidate is None and "commissionPrecision" in payload:
+            precision_candidate = payload.get("commissionPrecision")
+        step = _precision_to_step(precision_candidate)
+        if step is not None:
+            return step
+
+        quote_candidate = payload.get("quote_precision")
+        if quote_candidate is None and "quotePrecision" in payload:
+            quote_candidate = payload.get("quotePrecision")
+        step = _precision_to_step(quote_candidate)
+        if step is not None:
+            return step
+
+        for nested_key in ("quantizer", "filters", "symbol_filters"):
+            nested = payload.get(nested_key)
+            if nested is None:
+                continue
+            step = _extract_commission_step(nested)
+            if step is not None:
+                return step
+
+        return None
+
+    step = _sanitize_positive_float(getattr(payload, "commission_step", None))
+    if step is not None:
+        return step
+
+    precision_candidate = getattr(payload, "commission_precision", None)
+    step = _precision_to_step(precision_candidate)
+    if step is not None:
+        return step
+
+    quote_candidate = getattr(payload, "quote_precision", None)
+    return _precision_to_step(quote_candidate)
+
+
+def _round_value_to_decimals(value: float, decimals: int) -> float:
+    if decimals < 0:
+        return float(value)
+    try:
+        quant = Decimal(1).scaleb(-decimals)
+        rounded = Decimal(str(value)).quantize(quant)
+        result = float(rounded)
+        if math.isfinite(result):
+            return result
+    except (InvalidOperation, ValueError):
+        pass
+    return float(round(value, decimals))
+
+
+def _round_value_to_step(value: float, step: float, mode: str) -> float:
+    if step <= 0.0:
+        return float(value)
+
+    mode_normalized = (mode or "").strip().lower()
+    if mode_normalized in {"nearest", "round", "half", "half_up"}:
+        rounding = ROUND_HALF_UP
+    elif mode_normalized in {"down", "floor"}:
+        rounding = ROUND_DOWN
+    else:
+        rounding = ROUND_UP
+
+    try:
+        dec_value = Decimal(str(value))
+        dec_step = Decimal(str(step))
+        if dec_step <= 0:
+            return float(value)
+        units = (dec_value / dec_step).to_integral_value(rounding=rounding)
+        rounded = units * dec_step
+        result = float(rounded)
+        if math.isfinite(result):
+            return result
+    except (DivisionByZero, InvalidOperation, ValueError):
+        pass
+
+    ratio = float(value) / float(step)
+    if mode_normalized in {"nearest", "round", "half", "half_up"}:
+        units = round(ratio)
+    elif mode_normalized in {"down", "floor"}:
+        units = math.floor(ratio + 1e-15)
+    else:
+        units = math.ceil(ratio - 1e-15)
+    return float(units * float(step))
+
+
+def _apply_rounding_rules(
+    value: float, *, step: Optional[float], options: Optional[Mapping[str, Any]]
+) -> float:
+    if not math.isfinite(value) or value <= 0.0:
+        return 0.0
+
+    opts = options or {}
+    mode = str(opts.get("mode", "") or "").strip().lower()
+
+    decimals = opts.get("decimals")
+    precision = opts.get("precision")
+    minimum_fee = opts.get("minimum_fee")
+    maximum_fee = opts.get("maximum_fee")
+
+    result = float(value)
+
+    step_value = step if step is not None and step > 0.0 else None
+    if step_value is not None:
+        result = _round_value_to_step(result, step_value, mode)
+
+    digits: Optional[int] = None
+    if decimals is not None:
+        try:
+            digits = int(decimals)
+        except (TypeError, ValueError):
+            digits = None
+    if digits is None and precision is not None:
+        try:
+            digits = int(precision)
+        except (TypeError, ValueError):
+            digits = None
+    if digits is not None and digits >= 0:
+        result = _round_value_to_decimals(result, digits)
+
+    if minimum_fee is not None:
+        try:
+            min_value = float(minimum_fee)
+        except (TypeError, ValueError):
+            min_value = None
+        else:
+            if math.isfinite(min_value) and min_value > 0.0:
+                result = max(result, min_value)
+
+    if maximum_fee is not None:
+        try:
+            max_value = float(maximum_fee)
+        except (TypeError, ValueError):
+            max_value = None
+        else:
+            if math.isfinite(max_value) and max_value >= 0.0:
+                result = min(result, max_value)
+
+    if result < 0.0 or not math.isfinite(result):
+        return 0.0
+    return float(result)
 
 
 def _sanitize_discount(value: Any, default: float) -> float:
@@ -304,6 +494,7 @@ class SymbolFeeConfig:
     maker_discount_mult: Optional[float] = None
     taker_discount_mult: Optional[float] = None
     fee_rounding_step: Optional[float] = None
+    commission_step: Optional[float] = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.base_rate, FeeRateSpec):
@@ -328,11 +519,21 @@ class SymbolFeeConfig:
 
         self.maker_discount_mult = _sanitize_optional_non_negative(self.maker_discount_mult)
         self.taker_discount_mult = _sanitize_optional_non_negative(self.taker_discount_mult)
-        self.fee_rounding_step = (
-            None
-            if self.fee_rounding_step is None
-            else _sanitize_rounding_step(self.fee_rounding_step)
-        )
+
+        if self.commission_step is not None:
+            commission_step = _sanitize_positive_float(self.commission_step)
+            self.commission_step = commission_step if commission_step is not None else None
+        else:
+            self.commission_step = None
+
+        if self.fee_rounding_step is not None:
+            step = _sanitize_rounding_step(self.fee_rounding_step)
+            self.fee_rounding_step = step if step > 0.0 else None
+        else:
+            self.fee_rounding_step = None
+
+        if self.fee_rounding_step is None and self.commission_step is not None:
+            self.fee_rounding_step = self.commission_step
 
     @classmethod
     def from_dict(cls, data: Any) -> "SymbolFeeConfig":
@@ -359,12 +560,18 @@ class SymbolFeeConfig:
 
         maker_mult = _sanitize_optional_non_negative(data.get("maker_discount_mult"))
         taker_mult = _sanitize_optional_non_negative(data.get("taker_discount_mult"))
-        rounding_step = data.get("fee_rounding_step")
+        rounding_step_raw = data.get("fee_rounding_step")
         rounding_step = (
-            None
-            if rounding_step is None
-            else _sanitize_rounding_step(rounding_step)
+            _sanitize_positive_float(rounding_step_raw)
+            if rounding_step_raw is not None
+            else None
         )
+
+        commission_step = _extract_commission_step(data)
+        if commission_step is not None and commission_step <= 0.0:
+            commission_step = None
+        if rounding_step is None and commission_step is not None:
+            rounding_step = commission_step
 
         return cls(
             base_rate=base,
@@ -372,6 +579,7 @@ class SymbolFeeConfig:
             maker_discount_mult=maker_mult,
             taker_discount_mult=taker_mult,
             fee_rounding_step=rounding_step,
+            commission_step=commission_step,
         )
 
     def resolve_rate(self, vip_tier: int, fallback: FeeRate) -> FeeRate:
@@ -521,6 +729,91 @@ class FeesModel:
             return None
         return self.symbol_fee_table.get(symbol.upper())
 
+    def _resolve_rounding_context(
+        self, symbol: Optional[str]
+    ) -> Tuple[bool, Optional[float], Dict[str, Any]]:
+        rounding_cfg: Mapping[str, Any] = self.rounding if isinstance(self.rounding, Mapping) else {}
+
+        symbol_key = symbol.upper() if isinstance(symbol, str) else None
+        per_symbol_cfg: Optional[Mapping[str, Any]] = None
+        if symbol_key and isinstance(rounding_cfg.get("per_symbol"), Mapping):
+            candidate = rounding_cfg["per_symbol"].get(symbol_key)
+            if isinstance(candidate, Mapping):
+                per_symbol_cfg = candidate
+
+        base_step = _sanitize_positive_float(rounding_cfg.get("step")) if isinstance(rounding_cfg, Mapping) else None
+        symbol_step = _sanitize_positive_float(per_symbol_cfg.get("step")) if per_symbol_cfg else None
+
+        cfg = self._symbol_config(symbol)
+        cfg_step = _sanitize_positive_float(cfg.fee_rounding_step) if cfg and cfg.fee_rounding_step is not None else None
+
+        fallback_step = _sanitize_positive_float(self.fee_rounding_step)
+
+        step_candidates = [symbol_step, cfg_step, base_step, fallback_step]
+        step: Optional[float] = None
+        for candidate in step_candidates:
+            if candidate is not None and candidate > 0.0:
+                step = candidate
+                break
+
+        merged_options: Dict[str, Any] = {}
+        for source in (rounding_cfg, per_symbol_cfg):
+            if not isinstance(source, Mapping):
+                continue
+            for key, value in source.items():
+                if key in {"enabled", "step", "per_symbol"}:
+                    continue
+                merged_options[key] = value
+
+        enabled_override: Optional[bool] = None
+        if per_symbol_cfg and "enabled" in per_symbol_cfg:
+            enabled_override = bool(per_symbol_cfg.get("enabled"))
+        elif isinstance(rounding_cfg, Mapping) and "enabled" in rounding_cfg:
+            enabled_override = bool(rounding_cfg.get("enabled"))
+
+        if enabled_override is not None:
+            enabled = enabled_override
+        else:
+            enabled = bool(step is not None or merged_options)
+
+        return enabled, step, merged_options
+
+    def _resolve_settlement_context(
+        self, symbol: Optional[str]
+    ) -> Tuple[bool, Dict[str, Any]]:
+        settlement_cfg: Mapping[str, Any] = (
+            self.settlement if isinstance(self.settlement, Mapping) else {}
+        )
+
+        symbol_key = symbol.upper() if isinstance(symbol, str) else None
+        per_symbol_cfg: Optional[Mapping[str, Any]] = None
+        if symbol_key and isinstance(settlement_cfg.get("per_symbol"), Mapping):
+            candidate = settlement_cfg["per_symbol"].get(symbol_key)
+            if isinstance(candidate, Mapping):
+                per_symbol_cfg = candidate
+
+        merged: Dict[str, Any] = {}
+        for source in (settlement_cfg, per_symbol_cfg):
+            if not isinstance(source, Mapping):
+                continue
+            for key, value in source.items():
+                if key == "per_symbol":
+                    continue
+                merged[key] = value
+
+        enabled_override: Optional[bool] = None
+        if per_symbol_cfg and "enabled" in per_symbol_cfg:
+            enabled_override = bool(per_symbol_cfg.get("enabled"))
+        elif isinstance(settlement_cfg, Mapping) and "enabled" in settlement_cfg:
+            enabled_override = bool(settlement_cfg.get("enabled"))
+
+        if enabled_override is not None:
+            enabled = enabled_override
+        else:
+            enabled = bool(merged)
+
+        return enabled, merged
+
     def _discount_multiplier(self, symbol: Optional[str], is_maker: bool) -> float:
         base = self.maker_discount_mult if is_maker else self.taker_discount_mult
         cfg = self._symbol_config(symbol)
@@ -533,13 +826,11 @@ class FeesModel:
         return _sanitize_discount(base, 1.0)
 
     def _round_fee(self, fee: float, symbol: Optional[str]) -> float:
-        step = self.fee_rounding_step
-        cfg = self._symbol_config(symbol)
-        if cfg and cfg.fee_rounding_step:
-            step = cfg.fee_rounding_step
-        if step <= 0.0:
-            return float(fee)
-        return round(float(fee) / step) * step
+        enabled, step, options = self._resolve_rounding_context(symbol)
+        if not enabled:
+            return float(_sanitize_non_negative(fee, 0.0))
+        rounded = _apply_rounding_rules(float(fee), step=step, options=options)
+        return float(_sanitize_non_negative(rounded, 0.0))
 
     def get_fee_bps(self, symbol: Optional[str], is_maker: bool) -> float:
         """Возвращает актуальную ставку комиссии в bps для заданного символа."""
@@ -569,6 +860,7 @@ class FeesModel:
         qty: float,
         liquidity: str,
         symbol: Optional[str] = None,
+        bnb_conversion_rate: Optional[float] = None,
     ) -> float:
         """Расчитывает абсолютную комиссию в валюте котировки.
 
@@ -584,11 +876,16 @@ class FeesModel:
             ``"maker"`` или ``"taker"`` — тип исполнения.
         symbol:
             Торговый символ. Если не передан, используются глобальные ставки.
+        bnb_conversion_rate:
+            Цена BNB в валюте котировки. Используется, когда комиссии списываются
+            в BNB (``settlement.mode == "bnb"`` или ``settlement.currency == "BNB"``).
 
         Returns
         -------
         float
             Абсолютная величина комиссии (>= 0). При некорректных данных возвращает ``0``.
+            Если комиссии списываются в BNB и передан ``bnb_conversion_rate``,
+            результат возвращается в BNB.
         """
 
         try:
@@ -610,8 +907,23 @@ class FeesModel:
         fee = notional * (rate_bps / 1e4)
         if not math.isfinite(fee) or fee <= 0.0:
             return 0.0
-        fee = self._round_fee(fee, symbol)
-        return float(_sanitize_non_negative(fee, 0.0))
+
+        settlement_enabled, settlement_cfg = self._resolve_settlement_context(symbol)
+        settlement_mode = str(settlement_cfg.get("mode") or "").lower()
+        settlement_currency = str(settlement_cfg.get("currency") or "").upper()
+
+        use_bnb_settlement = settlement_enabled and (
+            settlement_mode == "bnb" or settlement_currency == "BNB"
+        )
+
+        effective_fee = float(fee)
+        if use_bnb_settlement:
+            conversion = _sanitize_positive_float(bnb_conversion_rate)
+            if conversion is not None and conversion > 0.0:
+                effective_fee = effective_fee / conversion
+
+        effective_fee = self._round_fee(effective_fee, symbol)
+        return float(_sanitize_non_negative(effective_fee, 0.0))
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add helpers to derive commission steps and apply tick-aware rounding with clamping
- let SymbolFeeConfig and FeesModel consume quantizer-derived steps and rounding options
- convert BNB settlements when possible and extend rounding tests for the new behaviour

## Testing
- pytest tests/test_fees_rounding.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc2691c8c832f8006794b0346f9ac