### PR TITLE
Add status metadata to simulation step reports

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -478,6 +478,8 @@ class SimStepReport:
     fill_ratio: float = 1.0
     capacity_reason: str = ""
     exec_status: str = ""
+    status: str = ""
+    reason: Mapping[str, Any] | None = None
     maker_share: float = 0.0
     expected_fee_bps: float = 0.0
     expected_spread_bps: Optional[float] = None
@@ -505,6 +507,18 @@ class SimStepReport:
                     cost_components[name] = None
                     continue
                 cost_components[name] = float(num)
+        if self.reason is None:
+            reason_payload: Dict[str, Any] | None = None
+        elif isinstance(self.reason, Mapping):
+            try:
+                reason_payload = {str(k): v for k, v in self.reason.items()}
+            except Exception:
+                reason_payload = dict(self.reason)
+        else:
+            reason_payload = {
+                str(k): v for k, v in getattr(self.reason, "__dict__", {}).items()
+            }
+
         return {
             "trades": trades_payload,
             "cancelled_ids": list(self.cancelled_ids),
@@ -548,6 +562,8 @@ class SimStepReport:
             "fill_ratio": float(self.fill_ratio),
             "capacity_reason": str(self.capacity_reason),
             "exec_status": str(self.exec_status),
+            "status": str(self.status),
+            "reason": reason_payload,
             "maker_share": float(self.maker_share),
             "expected_fee_bps": float(self.expected_fee_bps),
             "expected_spread_bps": (

--- a/tests/test_execution_bar_capacity_base.py
+++ b/tests/test_execution_bar_capacity_base.py
@@ -3,7 +3,7 @@ import json
 import pathlib
 import sys
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -52,6 +52,8 @@ class _CompatReport:
     latency_timeout_ratio: float = 0.0
     execution_profile: str = ""
     vol_raw: Optional[Dict[str, float]] = None
+    status: str = ""
+    reason: Optional[Dict[str, Any]] = None
 
 
 exec_mod.SimStepReport = _CompatReport  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- add status and reason fields with defaults to `SimStepReport` and include them in the serialized payload
- update the compatibility test report stub so the `ExecReport` alias remains usable in tests

## Testing
- pytest tests/test_execution_bar_capacity_base.py

------
https://chatgpt.com/codex/tasks/task_e_68ce781b7f64832fb5627a53e205062a