### PR TITLE
Handle quantizer filter availability when attaching to simulator

### DIFF
--- a/impl_sim_executor.py
+++ b/impl_sim_executor.py
@@ -284,7 +284,11 @@ class SimExecutor(TradeExecutor):
 
         # последовательное подключение компонентов к симулятору
         if quantizer is not None:
-            quantizer.attach_to(self._sim, strict=True, enforce_percent_price_by_side=True)
+            quantizer.attach_to(
+                self._sim,
+                strict=quantizer.cfg.strict,
+                enforce_percent_price_by_side=quantizer.cfg.enforce_percent_price_by_side,
+            )
         if risk is not None:
             risk.attach_to(self._sim)
         if latency is not None:
@@ -371,7 +375,11 @@ class SimExecutor(TradeExecutor):
                 pass
 
         if q_impl is not None:
-            q_impl.attach_to(sim, strict=True, enforce_percent_price_by_side=True)
+            q_impl.attach_to(
+                sim,
+                strict=q_impl.cfg.strict,
+                enforce_percent_price_by_side=q_impl.cfg.enforce_percent_price_by_side,
+            )
         if r_impl is not None:
             r_impl.attach_to(sim)
         if l_impl is not None:


### PR DESCRIPTION
## Summary
- store a copy of the loaded quantizer filters so they can be reapplied when attaching to a simulator
- make QuantizerImpl.attach_to reapply the raw filters when available and gracefully disable strict settings when filters are missing
- use the quantizer configuration when wiring simulators instead of forcing strict enforcement flags

## Testing
- python -m compileall impl_quantizer.py impl_sim_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68ce84ff01d0832facf03b6d63ebde4c