### PR TITLE
Point quantizer filters to data bundle

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -58,7 +58,8 @@ model:
   params: {}
 
 quantizer:
-  filters_path: "binance_filters.json"
+  filters_path: "data/binance_filters.json"
+  # Flip the strict/enforce flags below to false to restore legacy permissive behaviour.
   strict: true
   enforce_percent_price_by_side: true
   auto_refresh_days: 30

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -56,7 +56,8 @@ model:
   params: {}
 
 quantizer:
-  filters_path: "binance_filters.json"
+  filters_path: "data/binance_filters.json"
+  # Flip the strict/enforce flags below to false to restore legacy permissive behaviour.
   strict: true
   enforce_percent_price_by_side: true
   auto_refresh_days: 30

--- a/configs/quantizer.yaml
+++ b/configs/quantizer.yaml
@@ -1,6 +1,7 @@
 # Default quantizer configuration shared across run modes.
 quantizer:
-  filters_path: "binance_filters.json"
+  filters_path: "data/binance_filters.json"
+  # Flip the strict/enforce flags below to false to restore legacy permissive behaviour.
   strict: true
   enforce_percent_price_by_side: true
   auto_refresh_days: 30


### PR DESCRIPTION
## Summary
- update the shared quantizer block and sim-oriented configs to load filters from data/binance_filters.json
- document that disabling the strict/enforce flags restores the legacy permissive behaviour

## Testing
- not run (config changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ce9d1d5ce0832fa47c89f697d82d25