### PR TITLE
Use simulator quantizer attachment API

### DIFF
--- a/impl_quantizer.py
+++ b/impl_quantizer.py
@@ -431,23 +431,7 @@ class QuantizerImpl:
         if enforce_percent_price_by_side is not None:
             self.cfg.enforce_percent_price_by_side = bool(enforce_percent_price_by_side)
 
-        try:
-            setattr(sim, "validate_order", self.validate_order)
-        except Exception:
-            pass
-
-        try:
-            setattr(sim, "symbol_filters", self.symbol_filters)
-        except Exception:
-            pass
-
         quantizer = self._quantizer
-        if quantizer is not None:
-            try:
-                setattr(sim, "quantizer", quantizer)
-            except Exception:
-                pass
-
         filters_payload: Optional[Dict[str, Dict[str, Any]]] = None
         if self._filters_raw:
             filters_payload = dict(self._filters_raw)
@@ -462,26 +446,12 @@ class QuantizerImpl:
         )
         metadata_for_sim = dict(metadata_view) if metadata_view else {}
 
-        try:
-            setattr(sim, "quantize_mode", str(self.cfg.quantize_mode))
-        except Exception:
-            pass
-        if metadata_for_sim:
-            try:
-                setattr(sim, "quantizer_metadata", dict(metadata_for_sim))
-            except Exception:
-                pass
-
         attach_api = getattr(sim, "attach_quantizer", None)
         if callable(attach_api):
             try:
                 attach_api(
-                    quantizer=quantizer,
-                    filters=filters_payload,
-                    strict_filters=strict_active,
-                    enforce_ppbs=enforce_active,
+                    impl=self,
                     metadata=dict(metadata_for_sim) if metadata_for_sim else None,
-                    quantize_mode=str(self.cfg.quantize_mode),
                 )
             except TypeError:
                 logger.debug(
@@ -496,6 +466,32 @@ class QuantizerImpl:
                 )
             else:
                 return
+
+        try:
+            setattr(sim, "validate_order", self.validate_order)
+        except Exception:
+            pass
+
+        try:
+            setattr(sim, "symbol_filters", self.symbol_filters)
+        except Exception:
+            pass
+
+        if quantizer is not None:
+            try:
+                setattr(sim, "quantizer", quantizer)
+            except Exception:
+                pass
+
+        try:
+            setattr(sim, "quantize_mode", str(self.cfg.quantize_mode))
+        except Exception:
+            pass
+        if metadata_for_sim:
+            try:
+                setattr(sim, "quantizer_metadata", dict(metadata_for_sim))
+            except Exception:
+                pass
 
         filters_attached = False
         warn_message: Optional[str] = None


### PR DESCRIPTION
## Summary
- prefer the simulator `attach_quantizer` API when wiring a `QuantizerImpl` in `SimExecutor`
- let `QuantizerImpl.attach_to` delegate to the simulator hook when available while keeping the legacy fallback
- refresh simulator quantizer attachment in `ServiceBacktest` so backtests expose current filter metadata

## Testing
- python -m compileall impl_sim_executor.py impl_quantizer.py service_backtest.py

------
https://chatgpt.com/codex/tasks/task_e_68cebfc515a0832f8e5a7c1943a02ef4