### PR TITLE
Update quantizer configuration options

### DIFF
--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -59,8 +59,10 @@ model:
 
 quantizer:
   filters_path: "data/binance_filters.json"
-  # Flip the strict/enforce flags below to false to restore legacy permissive behaviour.
-  strict: true
+  # strict_filters=true → строго придерживаться актуальных фильтров; false включает мягкий фолбек к кешу/легаси-логике.
+  strict_filters: true
+  # quantize_mode управляет округлением; "inward" (дефолт) поджимает цену/объём внутрь биржевых ограничений.
+  quantize_mode: "inward"
   enforce_percent_price_by_side: true
   auto_refresh_days: 30
   refresh_on_start: false

--- a/configs/quantizer.yaml
+++ b/configs/quantizer.yaml
@@ -1,8 +1,10 @@
 # Default quantizer configuration shared across run modes.
 quantizer:
   filters_path: "data/binance_filters.json"
-  # Flip the strict/enforce flags below to false to restore legacy permissive behaviour.
-  strict: true
+  # strict_filters=true → строго придерживаться актуальных фильтров; false включает мягкий фолбек к кешу/легаси-логике.
+  strict_filters: true
+  # quantize_mode управляет округлением; "inward" (дефолт) поджимает цену/объём внутрь биржевых ограничений.
+  quantize_mode: "inward"
   enforce_percent_price_by_side: true
   auto_refresh_days: 30
   refresh_on_start: false


### PR DESCRIPTION
## Summary
- add explicit strict_filters and quantize_mode settings to the shared quantizer config with inline guidance
- sync the simulation config quantizer block with the new fields while keeping the Binance filters path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cec1c2735c832fa65d1947259ecc38