### PR TITLE
Add execution entry mode and clip-to-bar configuration

### DIFF
--- a/configs/config_eval.yaml
+++ b/configs/config_eval.yaml
@@ -9,6 +9,11 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution:
+  entry_mode: default         # Entry mode for fills; ``default`` preserves legacy behaviour.
+  clip_to_bar:                # Controls clipping of simulated prices to the bar range.
+    enabled: true             # true keeps prices within [low, high] of the current bar.
+    strict_open_fill: false   # true forces clipped open-price fills; false keeps legacy behaviour.
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -14,6 +14,10 @@ execution:
   timeframe_ms: null
   use_latency_from: null
   latency_constant_ms: null
+  entry_mode: default         # Режим входа для симулятора; default соответствует текущему легаси-поведению.
+  clip_to_bar:                # Настройки клипа цен по диапазону последнего бара.
+    enabled: true             # true удерживает цены в пределах [low, high] бара (легаси-поведение).
+    strict_open_fill: false   # true → строго применять клип к открытиям; false оставляет прежнюю логику.
   bar_capacity_base:
     enabled: false           # Переключатель ограничения объёма сделок по ADV базовой валюты.
     capacity_frac_of_ADV_base: 1.0  # Доля дневного ADV (1.0 = 100%), доступная в каждом баре после пересчёта.

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -20,6 +20,10 @@ execution:
   timeframe_ms: null
   use_latency_from: null
   latency_constant_ms: null
+  entry_mode: default         # Entry mode for fills; default keeps the legacy behaviour.
+  clip_to_bar:                # Clip simulated prices to the last bar's [low, high] range.
+    enabled: true             # true preserves legacy clipping; false disables it.
+    strict_open_fill: false   # true enforces clipped open fills; false keeps legacy logic.
   bridge:
     intrabar_price_model: null
     timeframe_ms: null

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -9,6 +9,11 @@ execution_params:
   limit_offset_bps: 0.0  # e.g. 25 for 0.25% offset when using LIMIT_MID_BPS
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
+execution:
+  entry_mode: default         # Entry mode for fills; ``default`` mirrors the legacy simulator behaviour.
+  clip_to_bar:                # Controls clipping of simulated prices to the observed bar range.
+    enabled: true             # Keep prices within [low, high] of the current bar (legacy behaviour).
+    strict_open_fill: false   # Force clipped open-price fills when true; false keeps legacy logic.
 execution_config:
   notional_threshold: 10000.0
   large_order_algo: TWAP

--- a/configs/execution.yaml
+++ b/configs/execution.yaml
@@ -4,6 +4,10 @@ execution:
   timeframe_ms: null
   use_latency_from: null
   latency_constant_ms: null
+  entry_mode: default         # Entry mode for simulated fills; default keeps the legacy behaviour.
+  clip_to_bar:                # Control clipping of simulated prices to the bar range.
+    enabled: true             # true keeps prices within the bar [low, high]; false disables clipping.
+    strict_open_fill: false   # true enforces clipped open fills; false preserves legacy behaviour.
   bar_capacity_base:
     enabled: false
     capacity_frac_of_ADV_base: 1.0


### PR DESCRIPTION
## Summary
- introduce an `ExecutionEntryMode` enum and `ClipToBarConfig` sub-model so execution runtime configs expose entry mode and clip-to-bar options with sane defaults
- document the new options across execution YAML configs to keep examples and templates aligned

## Testing
- pytest tests/test_clock_sync_config.py

------
https://chatgpt.com/codex/tasks/task_e_68cece6f4a20832f84ca4e336ed591ec