### PR TITLE
Add shared bar boundary helpers and tests

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -60,6 +60,7 @@ except Exception:  # pragma: no cover - optional dependency for legacy setups
 try:
     from utils.time import HOUR_MS, HOURS_IN_WEEK, hour_of_week
     from utils_time import (
+        bar_start_ms,
         get_hourly_multiplier,
         get_liquidity_multiplier,
         load_hourly_seasonality,
@@ -73,6 +74,7 @@ except Exception:  # pragma: no cover - fallback when running as standalone file
     sys.path.append(str(pathlib.Path(__file__).resolve().parent))
     from utils.time import HOUR_MS, HOURS_IN_WEEK, hour_of_week
     from utils_time import (
+        bar_start_ms,
         get_hourly_multiplier,
         get_liquidity_multiplier,
         load_hourly_seasonality,
@@ -3036,7 +3038,7 @@ class ExecutionSimulator:
         if timeframe <= 0:
             timeframe = 1
         try:
-            bar_start = (ts_val // timeframe) * timeframe
+            bar_start = bar_start_ms(ts_val, timeframe)
         except Exception:
             bar_start = ts_val
         if self._capacity_bar_ts is None or bar_start != self._capacity_bar_ts:

--- a/impl_offline_data.py
+++ b/impl_offline_data.py
@@ -21,7 +21,7 @@ import pandas as pd  # предполагается в зависимостях
 import clock
 from core_models import Bar, Tick
 from core_contracts import MarketDataSource
-from utils_time import parse_time_to_ms, floor_to_timeframe, is_bar_closed
+from utils_time import parse_time_to_ms, bar_close_ms, is_bar_closed
 from config import DataDegradationConfig
 
 logger = logging.getLogger(__name__)
@@ -131,7 +131,7 @@ class OfflineCSVBarSource(MarketDataSource):
                             time.sleep(delay_ms / 1000.0)
                     yield prev_bar
                     continue
-                close_ts = floor_to_timeframe(ts, interval_ms_cfg) + interval_ms_cfg
+                close_ts = bar_close_ms(ts, interval_ms_cfg)
                 is_final = True
                 if self.cfg.enforce_closed_bars and not is_bar_closed(
                     close_ts, clock.now_ms(), self.cfg.close_lag_ms

--- a/sandbox/backtest_adapter.py
+++ b/sandbox/backtest_adapter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd
 import clock
-from utils_time import floor_to_timeframe, is_bar_closed
+from utils_time import bar_close_ms, is_bar_closed
 
 from core_contracts import SignalPolicy, PolicyCtx
 from core_models import Order, Side
@@ -558,7 +558,7 @@ class BacktestAdapter:
                     bar_low = None
 
             if self._timing.enforce_closed_bars:
-                close_ts = floor_to_timeframe(ts, self._timing.timeframe_ms) + self._timing.timeframe_ms
+                close_ts = bar_close_ms(ts, self._timing.timeframe_ms)
                 if not is_bar_closed(close_ts, clock.now_ms(), self._timing.close_lag_ms):
                     skip_cnt += 1
                     try:

--- a/tests/test_utils_time_bars.py
+++ b/tests/test_utils_time_bars.py
@@ -1,0 +1,50 @@
+import pytest
+
+from utils_time import (
+    bar_close_ms,
+    bar_start_ms,
+    floor_to_timeframe,
+    next_bar_open_ms,
+)
+
+
+REFERENCE_TS = 1_650_000_000_123
+
+
+@pytest.mark.parametrize(
+    "timeframe_ms, offsets",
+    [
+        (60_000, [0, 1, 59_999, 120_000]),
+        (90_000, [0, 15, 45_000, 135_000]),
+        (3_600_000, [0, 10_000, 1_800_000, 7_200_000]),
+    ],
+)
+def test_bar_boundaries_are_consistent(timeframe_ms: int, offsets):
+    aligned_base = (REFERENCE_TS // timeframe_ms) * timeframe_ms
+    for delta in offsets:
+        ts = aligned_base + delta
+        start = bar_start_ms(ts, timeframe_ms)
+        close = bar_close_ms(ts, timeframe_ms)
+        assert close - start == timeframe_ms
+        assert start == floor_to_timeframe(ts, timeframe_ms)
+        assert start <= ts < close
+        assert next_bar_open_ms(ts, timeframe_ms) == close
+        next_after_close = next_bar_open_ms(close, timeframe_ms)
+        assert next_after_close == close + timeframe_ms
+
+
+@pytest.mark.parametrize("bad_timeframe", [0, -60_000])
+def test_bar_helpers_reject_non_positive_timeframes(bad_timeframe: int) -> None:
+    with pytest.raises(ValueError):
+        bar_start_ms(REFERENCE_TS, bad_timeframe)
+    with pytest.raises(ValueError):
+        bar_close_ms(REFERENCE_TS, bad_timeframe)
+    with pytest.raises(ValueError):
+        next_bar_open_ms(REFERENCE_TS, bad_timeframe)
+
+
+def test_bar_helpers_require_numeric_timestamp() -> None:
+    with pytest.raises(ValueError):
+        bar_start_ms("not-a-timestamp", 60_000)
+    with pytest.raises(ValueError):
+        bar_close_ms("not-a-timestamp", 60_000)


### PR DESCRIPTION
## Summary
- add shared bar boundary helpers in `utils_time` and reuse them for `next_bar_open_ms`
- switch execution simulator and data sources to the new helpers to keep bar handling consistent
- add unit coverage for multiple timeframes and error paths of the helpers

## Testing
- pytest tests/test_utils_time_bars.py
- pytest tests/test_offline_csv_bar_source.py

------
https://chatgpt.com/codex/tasks/task_e_68cf10639bd4832f95daed2ab71024f0