### PR TITLE
Enhance Binance REST budgeting and metadata tracking

### DIFF
--- a/scripts/refresh_universe.py
+++ b/scripts/refresh_universe.py
@@ -187,6 +187,8 @@ def _fetch_quote_volume(session: RestBudgetSession, symbol: str) -> float:
         TICKER_24HR_URL,
         params={"symbol": symbol},
         endpoint=TICKER_24HR_ENDPOINT,
+        budget="ticker24hr",
+        tokens=1.0,
     )
     if isinstance(payload, Mapping):
         try:
@@ -217,7 +219,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     out_path = Path(args.out)
 
     with RestBudgetSession(session_cfg) as session:
-        exchange_info = session.get(EXCHANGE_INFO_URL, endpoint=EXCHANGE_INFO_ENDPOINT)
+        exchange_info = session.get(
+            EXCHANGE_INFO_URL,
+            endpoint=EXCHANGE_INFO_ENDPOINT,
+            budget="exchangeInfo",
+            tokens=10.0,
+        )
         if not isinstance(exchange_info, Mapping):
             raise RuntimeError("Unexpected exchangeInfo response")
 


### PR DESCRIPTION
## Summary
- document Binance REST budget mappings and add token heuristics plus metadata exposure in the public client
- capture last-response metadata (including Binance weight headers) in RestBudgetSession for cache hits and live requests
- ensure offline fetch utilities pass explicit budgets and representative token weights consistent with Binance guidance
- extend tests to validate budget tokens and surfaced metadata

## Testing
- pytest tests/test_rate_limiter.py tests/test_rest_budget_checkpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1af2d00c832f8c3dc01b110b2812