### PR TITLE
Enhance refresh_universe REST budgeting and checkpointing

### DIFF
--- a/scripts/refresh_universe.py
+++ b/scripts/refresh_universe.py
@@ -6,6 +6,7 @@ import logging
 import math
 import os
 import random
+import signal
 import sys
 import tempfile
 from pathlib import Path
@@ -49,7 +50,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _load_rest_budget_config(path: Path) -> tuple[dict[str, Any], Any]:
+def _load_rest_budget_config(path: Path) -> tuple[dict[str, Any], Any, Mapping[str, Any] | None]:
     try:
         with path.open("r", encoding="utf-8") as f:
             payload = yaml.safe_load(f) or {}
@@ -67,9 +68,32 @@ def _load_rest_budget_config(path: Path) -> tuple[dict[str, Any], Any]:
     rest_cfg = payload.get("rest_budget", {})
     if not isinstance(rest_cfg, Mapping):
         logging.warning("offline config %s missing rest_budget mapping", path)
-        return {}, None
-    shuffle_cfg = rest_cfg.get("shuffle_symbols")
-    return dict(rest_cfg), shuffle_cfg
+        return {}, None, None
+
+    shuffle_cfg = (
+        rest_cfg.get("shuffle")
+        or rest_cfg.get("shuffle_symbols")
+        or rest_cfg.get("shuffleOptions")
+    )
+
+    session_cfg: Mapping[str, Any] | None = None
+    if isinstance(rest_cfg.get("session"), Mapping):
+        session_cfg = rest_cfg["session"]  # type: ignore[index]
+    elif isinstance(rest_cfg.get("config"), Mapping):
+        session_cfg = rest_cfg["config"]  # type: ignore[index]
+
+    rest_session_cfg: Mapping[str, Any]
+    if session_cfg is not None:
+        rest_session_cfg = session_cfg
+    else:
+        rest_session_cfg = rest_cfg
+
+    cache_controls: Mapping[str, Any] | None = None
+    raw_cache_controls = rest_cfg.get("cache_controls")
+    if isinstance(raw_cache_controls, Mapping):
+        cache_controls = raw_cache_controls
+
+    return dict(rest_session_cfg), shuffle_cfg, cache_controls
 
 
 def _ensure_directory(path: Path) -> None:
@@ -164,6 +188,32 @@ def _parse_shuffle_options(raw: Any) -> tuple[bool, int, int | None]:
     return enabled, max(min_size, 0), seed
 
 
+def _extract_plan_tokens(
+    controls: Mapping[str, Any] | None,
+    aliases: Sequence[str],
+    default: float,
+) -> float:
+    if not isinstance(controls, Mapping):
+        return default
+
+    for alias in aliases:
+        entry = controls.get(alias)
+        if entry is None:
+            continue
+        if isinstance(entry, Mapping):
+            for key in ("tokens", "weight", "weight_tokens", "cost", "token_weight"):
+                if key in entry:
+                    try:
+                        return float(entry[key])
+                    except (TypeError, ValueError):
+                        continue
+        try:
+            return float(entry)
+        except (TypeError, ValueError):
+            continue
+    return default
+
+
 def _log_request_stats(stats: Mapping[str, Any]) -> None:
     requests = stats.get("requests", {})
     tokens = stats.get("request_tokens", {})
@@ -182,13 +232,15 @@ def _log_request_stats(stats: Mapping[str, Any]) -> None:
     )
 
 
-def _fetch_quote_volume(session: RestBudgetSession, symbol: str) -> float:
+def _fetch_quote_volume(
+    session: RestBudgetSession, symbol: str, tokens: float = 1.0
+) -> float:
     payload = session.get(
         TICKER_24HR_URL,
         params={"symbol": symbol},
         endpoint=TICKER_24HR_ENDPOINT,
         budget="ticker24hr",
-        tokens=1.0,
+        tokens=tokens,
     )
     if isinstance(payload, Mapping):
         try:
@@ -207,26 +259,42 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
 
     config_path = _default_offline_config_path()
-    rest_cfg, shuffle_cfg = _load_rest_budget_config(config_path)
+    rest_cfg, shuffle_cfg, cache_controls = _load_rest_budget_config(config_path)
     shuffle_enabled, shuffle_min_size, shuffle_seed = _parse_shuffle_options(shuffle_cfg)
 
-    session_cfg = dict(rest_cfg)
-    if "shuffle_symbols" in session_cfg:
-        session_cfg = dict(session_cfg)
-        session_cfg.pop("shuffle_symbols", None)
+    exchange_info_tokens = _extract_plan_tokens(
+        cache_controls,
+        ("exchangeInfo", "GET /api/v3/exchangeInfo", "exchange_info"),
+        10.0,
+    )
+    ticker_tokens = _extract_plan_tokens(
+        cache_controls,
+        ("ticker24hr", "GET /api/v3/ticker/24hr", "ticker_24hr"),
+        1.0,
+    )
+    if exchange_info_tokens <= 0.0:
+        exchange_info_tokens = 10.0
+    if ticker_tokens <= 0.0:
+        ticker_tokens = 1.0
 
     liquidity_threshold = float(args.liquidity_threshold or 0.0)
     out_path = Path(args.out)
 
-    with RestBudgetSession(session_cfg) as session:
+    with RestBudgetSession(rest_cfg) as session:
         exchange_info = session.get(
             EXCHANGE_INFO_URL,
             endpoint=EXCHANGE_INFO_ENDPOINT,
             budget="exchangeInfo",
-            tokens=10.0,
+            tokens=exchange_info_tokens,
         )
         if not isinstance(exchange_info, Mapping):
             raise RuntimeError("Unexpected exchangeInfo response")
+
+        metadata = session.get_last_response_metadata() or {}
+        if metadata.get("cache_hit"):
+            logging.info("Using cached exchangeInfo snapshot")
+        else:
+            logging.info("Fetched exchangeInfo snapshot from Binance")
 
         symbols = _extract_symbols(exchange_info)
         symbol_set = set(symbols)
@@ -236,6 +304,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         order = list(symbols)
         volumes: dict[str, float] = {}
         start_index = 0
+        processed_count = 0
+        last_symbol_seen: str | None = None
         checkpoint_data = session.load_checkpoint()
         resuming = False
 
@@ -247,9 +317,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                     order = normalized_order
                     resuming = True
             if resuming:
+                saved_processed = checkpoint_data.get("processed") or checkpoint_data.get("processed_count")
                 saved_position = checkpoint_data.get("position")
-                if isinstance(saved_position, (int, float)):
-                    start_index = max(0, min(int(saved_position), len(order)))
+                candidate_position: int | None = None
+                for candidate in (saved_processed, saved_position):
+                    try:
+                        value = int(candidate)
+                    except (TypeError, ValueError):
+                        continue
+                    candidate_position = max(0, min(value, len(order)))
+                    break
+                if candidate_position is not None:
+                    start_index = candidate_position
+                    processed_count = candidate_position
                 saved_volumes = checkpoint_data.get("volumes")
                 if isinstance(saved_volumes, Mapping):
                     for key, value in saved_volumes.items():
@@ -266,8 +346,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                     logging.info("Checkpoint indicates previous run completed; starting fresh")
                     resuming = False
                     start_index = 0
+                    processed_count = 0
                     volumes.clear()
                     order = list(symbols)
+                else:
+                    last_symbol_raw = (
+                        checkpoint_data.get("last_symbol")
+                        or checkpoint_data.get("current_symbol")
+                    )
+                    if isinstance(last_symbol_raw, str):
+                        symbol_text = last_symbol_raw.strip().upper()
+                        last_symbol_seen = symbol_text or None
             else:
                 if saved_order_raw:
                     logging.info("Ignoring checkpoint order that does not match current symbols")
@@ -291,21 +380,71 @@ def main(argv: Sequence[str] | None = None) -> int:
                 liquidity_threshold,
                 planned_ticker_requests,
             )
+            if planned_ticker_requests > 0:
+                session.plan_request(
+                    TICKER_24HR_ENDPOINT,
+                    count=planned_ticker_requests,
+                    tokens=ticker_tokens,
+                )
             stats = session.stats()
+            logging.info("REST session stats: %s", json.dumps(stats, ensure_ascii=False))
             _log_request_stats(stats)
             return 0
 
-        def _save_checkpoint(position: int, *, symbol: str | None = None, completed: bool = False) -> None:
+        checkpoint_state: dict[str, Any] = {
+            "payload": None,
+            "last_symbol": last_symbol_seen,
+            "progress_pct": None,
+            "completed": False,
+        }
+
+        def _save_checkpoint(
+            processed: int,
+            *,
+            symbol: str | None = None,
+            completed: bool = False,
+        ) -> None:
+            total = len(order)
+            safe_processed = max(0, min(int(processed), total)) if total else 0
+            normalized_symbol = symbol.strip().upper() if isinstance(symbol, str) else None
             payload: dict[str, Any] = {
                 "order": order,
-                "position": position,
+                "processed": safe_processed,
+                "processed_count": safe_processed,
+                "total": total,
                 "volumes": {k: float(v) for k, v in volumes.items()},
             }
-            if symbol is not None:
-                payload["current_symbol"] = symbol
+            if normalized_symbol:
+                payload["last_symbol"] = normalized_symbol
             if completed:
                 payload["completed"] = True
-            session.save_checkpoint(payload)
+            progress_pct = 100.0 if total == 0 else (safe_processed / total) * 100.0
+            payload["progress_pct"] = progress_pct
+
+            checkpoint_state["payload"] = payload
+            checkpoint_state["last_symbol"] = normalized_symbol
+            checkpoint_state["progress_pct"] = progress_pct
+            checkpoint_state["completed"] = completed
+
+            session.save_checkpoint(
+                payload,
+                last_symbol=normalized_symbol,
+                progress_pct=progress_pct,
+            )
+
+        handled_signals: dict[int, Any] = {}
+
+        def _handle_signal(signum: int, frame: Any | None) -> None:  # pragma: no cover - signal handler
+            payload = checkpoint_state.get("payload")
+            if isinstance(payload, Mapping):
+                session.save_checkpoint(
+                    payload,
+                    last_symbol=checkpoint_state.get("last_symbol"),
+                    progress_pct=checkpoint_state.get("progress_pct"),
+                )
+            if signum == getattr(signal, "SIGINT", None):
+                raise KeyboardInterrupt
+            raise SystemExit(128 + int(signum))
 
         if liquidity_threshold > 0.0 and order:
             if start_index >= len(order):
@@ -320,33 +459,64 @@ def main(argv: Sequence[str] | None = None) -> int:
             batch_pref = int(getattr(session, "batch_size", 0) or 0)
             worker_pref = int(getattr(session, "max_workers", 0) or 0)
             batch_size = max(1, batch_pref or worker_pref or 1)
+            if processed_count and processed_count <= len(order):
+                last_idx = processed_count - 1
+                if 0 <= last_idx < len(order):
+                    last_symbol_seen = order[last_idx]
 
-            _save_checkpoint(start_index)
+            _save_checkpoint(processed_count, symbol=last_symbol_seen)
 
-            idx = start_index
-            while idx < len(order):
-                batch = order[idx : idx + batch_size]
-                futures: list[tuple[int, str, Any]] = []
-                for offset, symbol in enumerate(batch):
-                    absolute = idx + offset
-                    if symbol in volumes and absolute < start_index:
+            for sig in (signal.SIGINT, getattr(signal, "SIGTERM", None)):
+                if sig is None:
+                    continue
+                try:
+                    handled_signals[sig] = signal.getsignal(sig)
+                    signal.signal(sig, _handle_signal)
+                except (ValueError, OSError):  # pragma: no cover - platform dependent
+                    handled_signals.pop(sig, None)
+
+            try:
+                idx = processed_count
+                while idx < len(order):
+                    batch = order[idx : idx + batch_size]
+                    futures: list[tuple[int, str, Any]] = []
+                    for offset, symbol in enumerate(batch):
+                        absolute = idx + offset
+                        if symbol in volumes and absolute < processed_count:
+                            continue
+                        future = session.submit(
+                            _fetch_quote_volume, session, symbol, ticker_tokens
+                        )
+                        futures.append((absolute, symbol, future))
+                    if not futures:
+                        processed_count = max(processed_count, idx + len(batch))
+                        _save_checkpoint(processed_count, symbol=last_symbol_seen)
+                        idx += max(len(batch), 1)
                         continue
-                    _save_checkpoint(absolute, symbol=symbol)
-                    future = session.submit(_fetch_quote_volume, session, symbol)
-                    futures.append((absolute, symbol, future))
-                for absolute, symbol, future in futures:
+                    last_symbol_batch: str | None = None
+                    for absolute, symbol, future in futures:
+                        try:
+                            volume = float(future.result())
+                        except Exception as exc:  # pragma: no cover - network dependent
+                            logging.warning("Failed to fetch volume for %s: %s", symbol, exc)
+                            volume = 0.0
+                        if not math.isfinite(volume):
+                            volume = 0.0
+                        volumes[symbol] = volume
+                        processed_count = max(processed_count, absolute + 1)
+                        last_symbol_batch = symbol
+                    if last_symbol_batch is not None:
+                        last_symbol_seen = last_symbol_batch
+                    _save_checkpoint(processed_count, symbol=last_symbol_seen)
+                    idx += max(len(batch), 1)
+            finally:
+                for sig, previous in handled_signals.items():
                     try:
-                        volume = float(future.result())
-                    except Exception as exc:  # pragma: no cover - network dependent
-                        logging.warning("Failed to fetch volume for %s: %s", symbol, exc)
-                        volume = 0.0
-                    if not math.isfinite(volume):
-                        volume = 0.0
-                    volumes[symbol] = volume
-                    _save_checkpoint(absolute + 1, symbol=symbol)
-                idx += max(len(batch), 1)
+                        signal.signal(sig, previous)
+                    except (ValueError, OSError):  # pragma: no cover - platform dependent
+                        pass
 
-            _save_checkpoint(len(order), completed=True)
+            _save_checkpoint(len(order), symbol=last_symbol_seen, completed=True)
 
         eligible_symbols = [
             symbol
@@ -364,6 +534,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
 
         stats = session.stats()
+        logging.info("REST session stats: %s", json.dumps(stats, ensure_ascii=False))
         _log_request_stats(stats)
 
     return 0


### PR DESCRIPTION
## Summary
- load the nested rest_budget configuration, exposing shuffle options and cache controls while forwarding the full session payload
- plan ticker requests during dry runs, reuse cached exchangeInfo snapshots, and surface session stats as JSON
- restructure checkpoint handling to capture progress metadata, save atomically after each batch, and flush state via signal handlers

## Testing
- `python -m compileall scripts/refresh_universe.py`
- `pytest tests/test_rest_budget_checkpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf1e289178832fb7f499844c7e91c1