### PR TITLE
Refactor offline REST budget config layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,23 @@ endpoint `tradeFee`. Если Binance публикует CSV-файл, его м
 ### Offline REST budget configuration
 
 Файл `configs/offline.yaml` содержит общие параметры для офлайн‑скриптов,
-использующих `services.rest_budget.RestBudgetSession`. Ключ `rest_budget` включает
-лимитер (`enabled`), задаёт глобальный токен‑бакет (`global.qps` и `burst`) и
-опции кэширования (`cache.dir`, `ttl_days`, `mode`). В секции `endpoints`
-переопределяются квоты и дополнительные параметры для отдельных маршрутов API
-(`min_refresh_days`). Блок `checkpoint` управляет путём и режимом восстановления
-прогресса, а `concurrency.workers`/`batch_size` ограничивают параллелизм.
-Флаг `shuffle_symbols` включает случайную перестановку символов при обновлении
-вселенной.
+использующих `services.rest_budget.RestBudgetSession`. Ключ `rest_budget`
+сгруппирован по блокам:
+
+- `limits.global` задаёт базовый токен‑бакет (`qps`, `burst`) и паузы
+  (`jitter_ms`, `cooldown_sec`).
+- `limits.endpoints` позволяет переопределять квоты и вспомогательные параметры
+  для конкретных REST‑маршрутов Binance (например, `exchangeInfo.min_refresh_days`).
+- `cache` управляет путём к каталогу, режимом (`read`, `read_write`, `off`) и TTL
+  кэшированных ответов.
+- `checkpoint.enabled`/`checkpoint.path` переключают сохранение прогресса и путь
+  до файла контрольной точки.
+- `concurrency.workers` и `concurrency.batch_size` ограничивают число рабочих
+  потоков и размер очереди задач внутри `RestBudgetSession`.
+- `shuffle.enabled` включает перемешивание очереди символов, чтобы равномернее
+  распределять нагрузку между запусками.
+- Флаг `dynamic_from_headers` разрешает автоматически подстраивать вес запросов
+  согласно заголовкам Binance, если они присутствуют.
 
 Параметры симуляции можно временно переопределить через CLI:
 

--- a/configs/offline.yaml
+++ b/configs/offline.yaml
@@ -1,11 +1,30 @@
 rest_budget:
-  enabled: true
-  global: { qps: 8, burst: 16, jitter_ms: 50, cooldown_sec: 5 }
-  endpoints:
-    klines: { qps: 5, burst: 10 }
-    exchangeInfo: { qps: 0.1, burst: 1, min_refresh_days: 1 }
-  cache: { dir: "cache/http", ttl_days: 7, mode: "read_write" }
-  checkpoint: { enabled: true, path: "state/offline_checkpoint.json" }
-  concurrency: { workers: 4, batch_size: 500 }
-  dynamic_from_headers: false
-  shuffle_symbols: true
+  # Global rate limiter applied to every request unless overridden below.
+  limits:
+    global:
+      qps: 8            # Target requests per second across all endpoints.
+      burst: 16         # Maximum burst size before throttling kicks in.
+      jitter_ms: 50     # Randomised jitter added before sleeps to avoid sync.
+      cooldown_sec: 5   # Optional cooldown when the global bucket is exhausted.
+    endpoints:
+      # Endpoint specific overrides inherit from the global limiter.
+      klines:
+        qps: 5
+        burst: 10
+      exchangeInfo:
+        qps: 0.1
+        burst: 1
+        min_refresh_days: 1  # Minimum age before forcing a refresh when cached.
+  cache:
+    path: "cache/http"         # Directory where REST responses are cached.
+    ttl_days: 7                 # Expiration window for cached responses.
+    mode: "read_write"          # Set to read or off to disable storing new entries.
+  checkpoint:
+    enabled: true               # Toggle on-disk progress checkpoints between runs.
+    path: "state/offline_checkpoint.json"
+  concurrency:
+    workers: 4                  # Number of worker threads dispatching HTTP requests.
+    batch_size: 500             # Max in-flight futures per producer before blocking.
+  shuffle:
+    enabled: true               # Shuffle symbol order to spread load across runs.
+  dynamic_from_headers: false   # Respect Binance weight headers when available.


### PR DESCRIPTION
## Summary
- restructure `configs/offline.yaml` to use the new `limits`/`cache`/`concurrency` blocks with inline guidance
- normalize rest-budget parsing in `refresh_universe`, `fetch_binance_filters`, and `build_adv` so the new layout and legacy keys are both supported
- document the new configuration knobs for offline scripts in the README

## Testing
- python -m compileall build_adv.py scripts/refresh_universe.py scripts/fetch_binance_filters.py

------
https://chatgpt.com/codex/tasks/task_e_68cf7dd4c354832fb11213168d445c09