### PR TITLE
Enhance Binance filter fetch tooling

### DIFF
--- a/binance_public.py
+++ b/binance_public.py
@@ -370,18 +370,18 @@ class BinancePublicClient:
                 d: Dict[str, Any] = {}
                 for f in filts:
                     ftype = f.get("filterType")
-                    if ftype in {"PRICE_FILTER", "LOT_SIZE", "MIN_NOTIONAL", "PERCENT_PRICE_BY_SIDE", "PERCENT_PRICE"}:
+                    if ftype in {
+                        "PRICE_FILTER",
+                        "LOT_SIZE",
+                        "MIN_NOTIONAL",
+                        "PERCENT_PRICE_BY_SIDE",
+                        "PERCENT_PRICE",
+                        "COMMISSION_STEP",
+                    }:
                         d[ftype] = {k: v for k, v in f.items() if k != "filterType"}
-                precision_keys = (
-                    "baseAssetPrecision",
-                    "quotePrecision",
-                    "quoteAssetPrecision",
-                    "baseCommissionPrecision",
-                    "quoteCommissionPrecision",
-                )
-                for key in precision_keys:
-                    if key in s:
-                        d[key] = s[key]
+                for key, value in s.items():
+                    if isinstance(key, str) and key.lower().endswith("precision"):
+                        d[key] = value
                 if sym and d:
                     out[sym] = d
         return out


### PR DESCRIPTION
## Summary
- keep commission step filters and precision hints when reading exchangeInfo data
- refactor `scripts/fetch_binance_filters.py` to load universe JSON paths, perform atomic writes/checkpoints, and raise on missing symbols

## Testing
- python -m compileall binance_public.py scripts/fetch_binance_filters.py

------
https://chatgpt.com/codex/tasks/task_e_68cf823b5c64832fbf4815e6c354c374