### PR TITLE
Align quantizer configs with refreshed Binance filters

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -91,8 +91,10 @@ risk:
   max_total_exposure_pct: null    # Hard cap on exposure as a fraction of equity
   exposure_buffer_frac: 0.0       # Fractional buffer applied before tripping the caps
 quantizer:
-  filters_path: "binance_filters.json"
-  strict: true
+  filters_path: "data/binance_filters.json"
+  # strict_filters=true → строго придерживаться актуальных фильтров; false включает мягкий фолбек к кешу/легаси-логике.
+  # Поле strict остаётся легаси-алиасом для strict_filters и может опускаться в новых конфигурациях.
+  strict_filters: true
   enforce_percent_price_by_side: true
   auto_refresh_days: 30
   refresh_on_start: false

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -64,6 +64,7 @@ model:
 quantizer:
   filters_path: "data/binance_filters.json"
   # strict_filters=true → строго придерживаться актуальных фильтров; false включает мягкий фолбек к кешу/легаси-логике.
+  # Поле strict остаётся легаси-алиасом для strict_filters и может опускаться в новых конфигурациях.
   strict_filters: true
   # quantize_mode управляет округлением; "inward" (дефолт) поджимает цену/объём внутрь биржевых ограничений.
   quantize_mode: "inward"

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -61,8 +61,9 @@ model:
 
 quantizer:
   filters_path: "data/binance_filters.json"
-  # Flip the strict/enforce flags below to false to restore legacy permissive behaviour.
-  strict: true
+  # strict_filters=true → строго придерживаться актуальных фильтров; false включает мягкий фолбек к кешу/легаси-логике.
+  # Поле strict остаётся легаси-алиасом для strict_filters и может опускаться в новых конфигурациях.
+  strict_filters: true
   enforce_percent_price_by_side: true
   auto_refresh_days: 30
   refresh_on_start: false

--- a/configs/config_train.yaml
+++ b/configs/config_train.yaml
@@ -45,8 +45,10 @@ model:
   params: {}
 
 quantizer:
-  filters_path: "binance_filters.json"
-  strict: true
+  filters_path: "data/binance_filters.json"
+  # strict_filters=true → строго придерживаться актуальных фильтров; false включает мягкий фолбек к кешу/легаси-логике.
+  # Поле strict остаётся легаси-алиасом для strict_filters и может опускаться в новых конфигурациях.
+  strict_filters: true
   enforce_percent_price_by_side: true
   auto_refresh_days: 30
   refresh_on_start: false

--- a/configs/quantizer.yaml
+++ b/configs/quantizer.yaml
@@ -2,6 +2,7 @@
 quantizer:
   filters_path: "data/binance_filters.json"
   # strict_filters=true → строго придерживаться актуальных фильтров; false включает мягкий фолбек к кешу/легаси-логике.
+  # Поле strict остаётся легаси-алиасом для strict_filters и может опускаться в новых конфигурациях.
   strict_filters: true
   # quantize_mode управляет округлением; "inward" (дефолт) поджимает цену/объём внутрь биржевых ограничений.
   quantize_mode: "inward"

--- a/data/binance_filters.json
+++ b/data/binance_filters.json
@@ -50,8 +50,8 @@
     }
   },
   "metadata": {
-    "generated_at": "2025-09-19T20:48:45Z",
-    "source_dataset": "binance_exchange_filters",
-    "version": 1
+    "built_at": "2025-09-21T05:39:15.889068+00:00",
+    "source": "GET /api/v3/exchangeInfo",
+    "symbols_count": 2
   }
 }


### PR DESCRIPTION
## Summary
- align quantizer sections across live, sim, train, template, and shared configs with the new strict_filters guidance and refresh settings
- regenerate data/binance_filters.json via the updated fetch CLI to add built_at/source/symbols_count metadata while keeping precision details

## Testing
- python -m json.tool data/binance_filters.json

------
https://chatgpt.com/codex/tasks/task_e_68cf8e76190c832fae11247f3d8788d4