### PR TITLE
Enhance Binance filter fetching

### DIFF
--- a/binance_public.py
+++ b/binance_public.py
@@ -364,20 +364,21 @@ class BinancePublicClient:
         )
         out: Dict[str, Dict[str, Any]] = {}
         if isinstance(data, dict):
+            recognized_filters = {
+                "PRICE_FILTER",
+                "LOT_SIZE",
+                "MIN_NOTIONAL",
+                "PERCENT_PRICE_BY_SIDE",
+                "PERCENT_PRICE",
+                "COMMISSION_STEP",
+            }
             for s in data.get("symbols", []):
                 sym = s.get("symbol")
                 filts = s.get("filters", [])
                 d: Dict[str, Any] = {}
                 for f in filts:
                     ftype = f.get("filterType")
-                    if ftype in {
-                        "PRICE_FILTER",
-                        "LOT_SIZE",
-                        "MIN_NOTIONAL",
-                        "PERCENT_PRICE_BY_SIDE",
-                        "PERCENT_PRICE",
-                        "COMMISSION_STEP",
-                    }:
+                    if ftype in recognized_filters:
                         d[ftype] = {k: v for k, v in f.items() if k != "filterType"}
                 for key, value in s.items():
                     if isinstance(key, str) and key.lower().endswith("precision"):

--- a/scripts/fetch_binance_filters.py
+++ b/scripts/fetch_binance_filters.py
@@ -38,11 +38,12 @@ def _parse_args(argv: List[str] | None = None) -> argparse.Namespace:
         nargs="?",
         type=Path,
         const=DEFAULT_UNIVERSE_PATH,
-        default=None,
+        default=DEFAULT_UNIVERSE_PATH,
         metavar="PATH",
         help=(
-            "Path to a JSON file containing universe symbols. "
-            "Use --universe without PATH to default to data/universe/symbols.json."
+            "Path to a JSON file containing universe symbols (default: "
+            f"{DEFAULT_UNIVERSE_PATH}). Use --universe without PATH to use the "
+            "default path, or pass '-' to disable loading a universe file."
         ),
     )
     parser.add_argument(
@@ -307,7 +308,7 @@ def _load_universe_symbols(path: Path) -> List[str]:
 
 def _load_symbols(args: argparse.Namespace) -> List[str]:
     symbols: List[str] = []
-    if args.universe:
+    if args.universe and str(args.universe) != "-":
         symbols.extend(_load_universe_symbols(args.universe))
     if args.symbols:
         symbols.extend(args.symbols)


### PR DESCRIPTION
## Summary
- ensure the Binance public client keeps the commission-step filter and precision hints when parsing exchangeInfo
- default the filter-fetch script to load the standard universe file while allowing an opt-out sentinel for full-book runs

## Testing
- python -m compileall binance_public.py scripts/fetch_binance_filters.py

------
https://chatgpt.com/codex/tasks/task_e_68cfa4201d3c832f8be7a049752eec5b