### PR TITLE
Align execution simulator tests with quantizer integration

### DIFF
--- a/tests/test_mediator_quantization.py
+++ b/tests/test_mediator_quantization.py
@@ -1,10 +1,14 @@
-import types
+import json
 import importlib.util
 import pathlib
 import sys
+import types
+
+import pytest
 
 base = pathlib.Path(__file__).resolve().parents[1]
-sys.path.append(str(base))
+if str(base) not in sys.path:
+    sys.path.append(str(base))
 
 spec_med = importlib.util.spec_from_file_location("mediator", base / "mediator.py")
 med_mod = importlib.util.module_from_spec(spec_med)
@@ -23,7 +27,12 @@ spec_quant = importlib.util.spec_from_file_location("quantizer", base / "quantiz
 quant_mod = importlib.util.module_from_spec(spec_quant)
 sys.modules["quantizer"] = quant_mod
 spec_quant.loader.exec_module(quant_mod)
-Quantizer = quant_mod.Quantizer
+
+spec_impl = importlib.util.spec_from_file_location("impl_quantizer", base / "impl_quantizer.py")
+impl_mod = importlib.util.module_from_spec(spec_impl)
+sys.modules["impl_quantizer"] = impl_mod
+spec_impl.loader.exec_module(impl_mod)
+QuantizerImpl = impl_mod.QuantizerImpl
 
 spec_const = importlib.util.spec_from_file_location("core_constants", base / "core_constants.py")
 const_mod = importlib.util.module_from_spec(spec_const)
@@ -31,18 +40,41 @@ sys.modules["core_constants"] = const_mod
 spec_const.loader.exec_module(const_mod)
 PRICE_SCALE = const_mod.PRICE_SCALE
 
+
 class DummyLOB:
     def __init__(self):
         self.next_id = 1
-    def add_limit_order(self, is_buy_side, price_ticks, volume, timestamp, taker_is_agent=True):
+
+    def add_limit_order(
+        self,
+        is_buy_side,
+        price_ticks,
+        volume,
+        timestamp,
+        taker_is_agent=True,
+    ):
         oid = self.next_id
         self.next_id += 1
         return oid, 0
+
     def remove_order(self, is_buy_side, price_ticks, order_id):
         return True
-    def match_market_order(self, is_buy_side, volume, timestamp, taker_is_agent, out_prices=None, out_volumes=None,
-                           out_is_buy=None, out_is_self=None, out_ids=None, max_len: int = 0):
+
+    def match_market_order(
+        self,
+        is_buy_side,
+        volume,
+        timestamp,
+        taker_is_agent,
+        out_prices=None,
+        out_volumes=None,
+        out_is_buy=None,
+        out_is_self=None,
+        out_ids=None,
+        max_len: int = 0,
+    ):
         return 0, 0.0
+
 
 class DummyState:
     def __init__(self):
@@ -50,14 +82,30 @@ class DummyState:
         self.cash = 0.0
         self.max_position = 10.0
 
+
 class DummyEnv:
-    def __init__(self, lob, symbol="BTCUSDT"):
+    def __init__(
+        self,
+        lob,
+        symbol: str = "BTCUSDT",
+        quantizer_path: pathlib.Path | None = None,
+    ):
         self.state = DummyState()
         self.lob = lob
         self.symbol = symbol
         self.last_mid = 100.0
         self.last_mtm_price = 100.0
-        self.run_config = types.SimpleNamespace()
+        quantizer_cfg: dict[str, object] = {}
+        if quantizer_path is not None:
+            path_str = str(quantizer_path)
+            quantizer_cfg = {
+                "path": path_str,
+                "filters_path": path_str,
+                "strict_filters": True,
+                "enforce_percent_price_by_side": True,
+            }
+        self.run_config = types.SimpleNamespace(quantizer=quantizer_cfg)
+
 
 filters = {
     "BTCUSDT": {
@@ -68,26 +116,42 @@ filters = {
     }
 }
 
-quantizer = Quantizer(filters, strict=True)
+
+@pytest.fixture
+def filters_file(tmp_path: pathlib.Path) -> pathlib.Path:
+    path = tmp_path / "filters.json"
+    path.write_text(json.dumps({"filters": filters}), encoding="utf-8")
+    return path
 
 
-def make_mediator():
-    env = DummyEnv(DummyLOB())
-    med = Mediator(env, use_exec_sim=False)
-    med.quantizer = quantizer
-    med.enforce_ppbs = True
+def make_mediator(filters_path: pathlib.Path, *, use_exec: bool = False):
+    env = DummyEnv(DummyLOB(), quantizer_path=filters_path)
+    med = Mediator(env, use_exec_sim=use_exec)
+    assert med.quantizer is not None
+    assert med.quantizer_impl is not None
     return med
 
 
-def test_unquantized_order_rejected():
-    med = make_mediator()
+def test_unquantized_order_rejected(filters_file: pathlib.Path):
+    med = make_mediator(filters_file)
     price = int(100.3 * PRICE_SCALE)
-    oid, qpos = med.add_limit_order(is_buy_side=True, price_ticks=price, volume=0.25, timestamp=0)
+    oid, qpos = med.add_limit_order(
+        is_buy_side=True, price_ticks=price, volume=0.25, timestamp=0
+    )
     assert (oid, qpos) == (0, 0)
 
 
-def test_quantized_order_accepted():
-    med = make_mediator()
+def test_quantized_order_accepted(filters_file: pathlib.Path):
+    med = make_mediator(filters_file)
     price = int(100.5 * PRICE_SCALE)
-    oid, qpos = med.add_limit_order(is_buy_side=True, price_ticks=price, volume=0.2, timestamp=0)
+    oid, qpos = med.add_limit_order(
+        is_buy_side=True, price_ticks=price, volume=0.2, timestamp=0
+    )
     assert oid != 0
+
+
+def test_exec_simulator_receives_quantizer(filters_file: pathlib.Path):
+    med = make_mediator(filters_file, use_exec=True)
+    assert med.exec is not None
+    assert getattr(med.exec, "quantizer", None) is med.quantizer
+    assert getattr(med.exec, "quantizer_impl", None) is med.quantizer_impl


### PR DESCRIPTION
## Summary
- update the execution simulator initialisation to accept QuantizerImpl instances, delegate metadata handling, and surface attachment helpers
- teach the mediator to build QuantizerImpl objects from run config, attaching them to the simulator when available
- refresh mediator and execution rule tests to exercise the new quantizer API and cover metadata logging paths

## Testing
- pytest tests/test_execution_rules.py::test_unquantized_limit_rejected_strict -q
- pytest tests/test_execution_rules.py::test_ttl_two_steps_sim -q
- pytest tests/test_execution_rules.py::test_attach_quantizer_sets_metadata -q
- pytest tests/test_mediator_quantization.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cfdaaaefbc832fb6313acd7e821fc3