### PR TITLE
Refactor trading state storage schema and backends

### DIFF
--- a/services/state_storage.py
+++ b/services/state_storage.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
+import copy
 import json
 import logging
+import math
 import os
-import re
 import shutil
 import sqlite3
 import threading
-from contextlib import contextmanager
-from dataclasses import dataclass, asdict, field
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, Protocol
+from typing import Any, Dict, Iterable, Mapping, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -19,13 +20,182 @@ logger = logging.getLogger(__name__)
 # State schema
 
 
+CURRENT_STATE_VERSION = 2
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        if value is None:
+            return 0.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass(eq=False)
+class PositionState:
+    qty: float = 0.0
+    avg_price: float = 0.0
+    last_update_ms: int | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "qty": float(self.qty),
+            "avg_price": float(self.avg_price),
+            "last_update_ms": self.last_update_ms,
+        }
+
+    def copy(self) -> "PositionState":
+        return PositionState(self.qty, self.avg_price, self.last_update_ms)
+
+    def update(self, **kwargs: Any) -> None:
+        if "qty" in kwargs:
+            self.qty = _coerce_float(kwargs["qty"])
+        if "avg_price" in kwargs:
+            self.avg_price = _coerce_float(kwargs["avg_price"])
+        if "last_update_ms" in kwargs:
+            self.last_update_ms = _coerce_int(kwargs["last_update_ms"])
+
+    def __eq__(self, other: Any) -> bool:  # pragma: no cover - helper
+        if isinstance(other, PositionState):
+            return (
+                math.isclose(self.qty, other.qty, rel_tol=1e-12, abs_tol=1e-12)
+                and math.isclose(
+                    self.avg_price, other.avg_price, rel_tol=1e-12, abs_tol=1e-12
+                )
+                and self.last_update_ms == other.last_update_ms
+            )
+        if isinstance(other, (int, float)):
+            return math.isclose(self.qty, float(other), rel_tol=1e-12, abs_tol=1e-12)
+        return False
+
+    def __float__(self) -> float:  # pragma: no cover - helper
+        return float(self.qty)
+
+    @classmethod
+    def from_any(cls, value: Any) -> "PositionState":
+        if isinstance(value, PositionState):
+            return value.copy()
+        if isinstance(value, Mapping):
+            qty = value.get("qty")
+            if qty is None:
+                qty = value.get("quantity") or value.get("position_qty") or value.get("size")
+            avg_price = value.get("avg_price") or value.get("avgPrice") or value.get("price")
+            last_update = (
+                value.get("last_update_ms")
+                or value.get("timestamp")
+                or value.get("ts_ms")
+                or value.get("time")
+            )
+            return cls(
+                qty=_coerce_float(qty),
+                avg_price=_coerce_float(avg_price),
+                last_update_ms=_coerce_int(last_update),
+            )
+        if isinstance(value, (list, tuple)):
+            qty = value[0] if len(value) > 0 else 0.0
+            avg_price = value[1] if len(value) > 1 else 0.0
+            last_update = value[2] if len(value) > 2 else None
+            return cls(
+                qty=_coerce_float(qty),
+                avg_price=_coerce_float(avg_price),
+                last_update_ms=_coerce_int(last_update),
+            )
+        if isinstance(value, (int, float)):
+            return cls(qty=float(value))
+        return cls()
+
+
+@dataclass
+class OrderState:
+    symbol: str = ""
+    client_order_id: str | None = None
+    order_id: str | None = None
+    side: str | None = None
+    qty: float = 0.0
+    price: float | None = None
+    status: str | None = None
+    ts_ms: int | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "symbol": self.symbol,
+            "clientOrderId": self.client_order_id,
+            "orderId": self.order_id,
+            "side": self.side,
+            "qty": self.qty,
+            "price": self.price,
+            "status": self.status,
+            "ts_ms": self.ts_ms,
+        }
+        data.update(self.extra)
+        return {k: v for k, v in data.items() if v is not None}
+
+    def copy(self) -> "OrderState":
+        return OrderState(
+            symbol=self.symbol,
+            client_order_id=self.client_order_id,
+            order_id=self.order_id,
+            side=self.side,
+            qty=self.qty,
+            price=self.price,
+            status=self.status,
+            ts_ms=self.ts_ms,
+            extra=copy.deepcopy(self.extra),
+        )
+
+    def update(self, data: Mapping[str, Any]) -> None:
+        for key, value in data.items():
+            if key in {"qty", "quantity", "origQty"}:
+                self.qty = _coerce_float(value)
+            elif key in {"price", "avg_price"}:
+                self.price = _coerce_float(value)
+            elif key in {"ts_ms", "timestamp", "time"}:
+                self.ts_ms = _coerce_int(value)
+            elif key in {"clientOrderId", "client_order_id", "client_id"}:
+                self.client_order_id = str(value) if value is not None else None
+            elif key in {"orderId", "order_id"}:
+                self.order_id = str(value) if value is not None else None
+            elif key == "symbol":
+                self.symbol = str(value or "")
+            elif key == "side":
+                self.side = str(value or "") or None
+            elif key == "status":
+                self.status = str(value or "") or None
+            else:
+                self.extra[key] = value
+
+    @classmethod
+    def from_any(cls, value: Any) -> "OrderState":
+        if isinstance(value, OrderState):
+            return value.copy()
+        if isinstance(value, Mapping):
+            order = cls()
+            order.update(value)
+            return order
+        if hasattr(value, "_asdict"):
+            return cls.from_any(value._asdict())  # type: ignore[attr-defined]
+        return cls()
+
+
 @dataclass
 class TradingState:
     """In-memory representation of runner state."""
 
-    positions: Dict[str, Any] = field(default_factory=dict)
-    open_orders: Dict[str, Any] = field(default_factory=dict)
+    positions: Dict[str, PositionState] = field(default_factory=dict)
+    open_orders: Dict[str, OrderState] = field(default_factory=dict)
     cash: float = 0.0
+    equity: float | None = None
     last_processed_bar_ms: int | None = None
     seen_signals: Iterable[Any] = field(default_factory=list)
     config_snapshot: Dict[str, Any] = field(default_factory=dict)
@@ -35,32 +205,177 @@ class TradingState:
     exposure_state: Dict[str, Any] = field(default_factory=dict)
     total_notional: float = 0.0
     git_hash: str | None = None
-    version: int = 1
+    version: int = CURRENT_STATE_VERSION
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    last_update_ms: int | None = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "TradingState":
-        try:
-            return cls(
-                positions=data.get("positions", {}) or {},
-                open_orders=data.get("open_orders", {}) or {},
-                cash=data.get("cash", 0.0) or 0.0,
-                last_processed_bar_ms=data.get("last_processed_bar_ms"),
-                seen_signals=data.get("seen_signals", []) or [],
-                config_snapshot=data.get("config_snapshot", {}) or {},
-                signal_states=data.get("signal_states", {}) or {},
-                entry_limits=data.get("entry_limits", {}) or {},
-                last_prices=data.get("last_prices", {}) or {},
-                exposure_state=data.get("exposure_state", {}) or {},
-                total_notional=float(data.get("total_notional", 0.0) or 0.0),
-                git_hash=data.get("git_hash"),
-                version=data.get("version", 1) or 1,
-            )
-        except Exception:
+        if not isinstance(data, Mapping):
             logger.warning("Corrupt state data, using defaults")
             return cls()
 
+        known_keys = {
+            "positions",
+            "open_orders",
+            "cash",
+            "equity",
+            "last_processed_bar_ms",
+            "seen_signals",
+            "config_snapshot",
+            "signal_states",
+            "entry_limits",
+            "last_prices",
+            "exposure_state",
+            "total_notional",
+            "git_hash",
+            "version",
+            "metadata",
+            "last_update_ms",
+        }
+
+        positions: Dict[str, PositionState] = {}
+        raw_positions = data.get("positions") or {}
+        if isinstance(raw_positions, Mapping):
+            for key, value in raw_positions.items():
+                symbol = str(key)
+                positions[symbol] = PositionState.from_any(value)
+        elif isinstance(raw_positions, Iterable):
+            for item in raw_positions:
+                if isinstance(item, Mapping):
+                    symbol = str(item.get("symbol") or item.get("asset") or "")
+                    if not symbol:
+                        continue
+                    positions[symbol] = PositionState.from_any(item)
+
+        orders: Dict[str, OrderState] = {}
+        raw_orders = data.get("open_orders") or {}
+        if isinstance(raw_orders, Mapping):
+            for key, value in raw_orders.items():
+                order = OrderState.from_any(value)
+                if not order.order_id:
+                    order.order_id = str(key)
+                orders[str(key)] = order
+        elif isinstance(raw_orders, Iterable):
+            for idx, value in enumerate(raw_orders):
+                order = OrderState.from_any(value)
+                key = order.order_id or order.client_order_id or str(idx)
+                orders[str(key)] = order
+
+        def _ensure_dict(value: Any) -> Dict[str, Any]:
+            if isinstance(value, Mapping):
+                return json.loads(json.dumps(value))
+            return {}
+
+        def _ensure_list(value: Any) -> Iterable[Any]:
+            if isinstance(value, Iterable) and not isinstance(value, (str, bytes, dict)):
+                return list(value)
+            if isinstance(value, Mapping):
+                return list(value.items())
+            return []
+
+        last_prices_raw = data.get("last_prices") or {}
+        last_prices: Dict[str, float] = {}
+        if isinstance(last_prices_raw, Mapping):
+            for key, value in last_prices_raw.items():
+                try:
+                    last_prices[str(key)] = float(value)
+                except (TypeError, ValueError):
+                    continue
+
+        state = cls(
+            positions=positions,
+            open_orders=orders,
+            cash=_coerce_float(data.get("cash")),
+            equity=(
+                float(data.get("equity"))
+                if isinstance(data.get("equity"), (int, float))
+                else None
+            ),
+            last_processed_bar_ms=_coerce_int(data.get("last_processed_bar_ms")),
+            seen_signals=_ensure_list(data.get("seen_signals")),
+            config_snapshot=_ensure_dict(data.get("config_snapshot")),
+            signal_states=_ensure_dict(data.get("signal_states")),
+            entry_limits=_ensure_dict(data.get("entry_limits")),
+            last_prices=last_prices,
+            exposure_state=_ensure_dict(data.get("exposure_state")),
+            total_notional=_coerce_float(data.get("total_notional")),
+            git_hash=(str(data.get("git_hash")) if data.get("git_hash") else None),
+            version=CURRENT_STATE_VERSION,
+            metadata=_ensure_dict(data.get("metadata")),
+            last_update_ms=_coerce_int(data.get("last_update_ms")),
+        )
+
+        leftovers = {
+            str(key): copy.deepcopy(value)
+            for key, value in data.items()
+            if key not in known_keys
+        }
+        if leftovers:
+            state.metadata.setdefault("_legacy", {}).update(leftovers)
+
+        return state
+
     def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
+        return {
+            "positions": {k: v.to_dict() for k, v in self.positions.items()},
+            "open_orders": {k: v.to_dict() for k, v in self.open_orders.items()},
+            "cash": float(self.cash),
+            "equity": float(self.equity) if self.equity is not None else None,
+            "last_processed_bar_ms": self.last_processed_bar_ms,
+            "seen_signals": list(self.seen_signals),
+            "config_snapshot": copy.deepcopy(self.config_snapshot),
+            "signal_states": copy.deepcopy(self.signal_states),
+            "entry_limits": copy.deepcopy(self.entry_limits),
+            "last_prices": {k: float(v) for k, v in self.last_prices.items()},
+            "exposure_state": copy.deepcopy(self.exposure_state),
+            "total_notional": float(self.total_notional),
+            "git_hash": self.git_hash,
+            "version": CURRENT_STATE_VERSION,
+            "metadata": copy.deepcopy(self.metadata),
+            "last_update_ms": self.last_update_ms,
+        }
+
+    def copy(self) -> "TradingState":
+        return TradingState.from_dict(self.to_dict())
+
+    def apply_updates(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            if key == "positions":
+                self.positions = TradingState.from_dict({"positions": value}).positions
+            elif key == "open_orders":
+                self.open_orders = TradingState.from_dict({"open_orders": value}).open_orders
+            elif key == "seen_signals":
+                if isinstance(value, Iterable) and not isinstance(value, (str, bytes, dict)):
+                    self.seen_signals = list(value)
+                elif isinstance(value, Mapping):
+                    self.seen_signals = list(value.items())
+                else:
+                    self.seen_signals = []
+            elif key == "last_prices":
+                if isinstance(value, Mapping):
+                    self.last_prices = {
+                        str(sym): _coerce_float(price) for sym, price in value.items()
+                    }
+                else:
+                    self.last_prices = {}
+            elif key in {
+                "config_snapshot",
+                "signal_states",
+                "entry_limits",
+                "exposure_state",
+                "metadata",
+            }:
+                setattr(self, key, copy.deepcopy(value) if isinstance(value, Mapping) else {})
+            elif key in {"cash", "total_notional", "equity"}:
+                setattr(self, key, _coerce_float(value))
+            elif key in {"last_processed_bar_ms", "last_update_ms"}:
+                setattr(self, key, _coerce_int(value))
+            elif hasattr(self, key):
+                setattr(self, key, copy.deepcopy(value))
+            else:
+                raise AttributeError(key)
+        self.version = CURRENT_STATE_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +387,7 @@ class StateBackend(Protocol):
 
     def load(self, path: Path) -> TradingState: ...
 
-    def save(self, path: Path, state: TradingState) -> None: ...
+    def save(self, path: Path, state: TradingState, backup_keep: int = 0) -> None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -85,31 +400,35 @@ class JsonBackend:
             data = json.load(fh)
         return TradingState.from_dict(data)
 
-    def save(self, path: Path, state: TradingState) -> None:
+    def save(self, path: Path, state: TradingState, backup_keep: int = 0) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        data = json.dumps(state.to_dict(), separators=(",", ":"))
-        with tmp.open("w", encoding="utf-8") as fh:
-            fh.write(data)
-            fh.flush()
-            os.fsync(fh.fileno())
-        bak = path.with_suffix(path.suffix + ".bak")
-        if path.exists():
-            try:
-                os.replace(path, bak)
-            except Exception:
-                logger.warning("Unable to rotate backup for %s", path, exc_info=True)
-        os.replace(tmp, path)
+        tmp_path = path.with_name(path.name + ".tmp")
+        payload = json.dumps(state.to_dict(), separators=(",", ":"), sort_keys=True)
         try:
-            dir_fd = os.open(str(path.parent), os.O_DIRECTORY)
-            os.fsync(dir_fd)
-            os.close(dir_fd)
+            with tmp_path.open("w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, path)
+            with suppress(OSError):
+                dir_fd = os.open(str(path.parent), os.O_DIRECTORY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
         except Exception:
-            pass
-        try:
-            os.remove(tmp)
-        except OSError:
-            pass
+            logger.warning("Failed to persist JSON state to %s", path, exc_info=True)
+            with suppress(Exception):
+                if not path.exists():
+                    for i in range(1, backup_keep + 1):
+                        bak = path.with_suffix(path.suffix + f".bak{i}")
+                        if bak.exists():
+                            shutil.copy2(bak, path)
+                            break
+            raise
+        finally:
+            with suppress(OSError):
+                tmp_path.unlink()
 
 
 # ---------------------------------------------------------------------------
@@ -117,24 +436,38 @@ class JsonBackend:
 
 
 class SQLiteBackend:
-    TABLE_SQL = (
-        "CREATE TABLE IF NOT EXISTS state ("
-        "id INTEGER PRIMARY KEY CHECK (id = 1),"
-        "positions TEXT,"
-        "open_orders TEXT,"
-        "cash REAL,"
-        "last_processed_bar_ms INTEGER,"
-        "seen_signals TEXT,"
-        "config_snapshot TEXT,"
-        "signal_states TEXT,"
-        "entry_limits TEXT,"
-        "last_prices TEXT,"
-        "exposure_state TEXT,"
-        "total_notional REAL,"
-        "git_hash TEXT,"
-        "version INTEGER"
-        ")"
-    )
+    TABLE = "state"
+    COLUMNS: Dict[str, str] = {
+        "positions": "TEXT",
+        "open_orders": "TEXT",
+        "cash": "REAL",
+        "equity": "REAL",
+        "last_processed_bar_ms": "INTEGER",
+        "seen_signals": "TEXT",
+        "config_snapshot": "TEXT",
+        "signal_states": "TEXT",
+        "entry_limits": "TEXT",
+        "last_prices": "TEXT",
+        "exposure_state": "TEXT",
+        "total_notional": "REAL",
+        "git_hash": "TEXT",
+        "version": "INTEGER",
+        "metadata": "TEXT",
+        "last_update_ms": "INTEGER",
+    }
+
+    def _ensure_schema(self, con: sqlite3.Connection) -> None:
+        columns_sql = ",".join(f"{name} {ctype}" for name, ctype in self.COLUMNS.items())
+        con.execute(
+            f"CREATE TABLE IF NOT EXISTS {self.TABLE} ("
+            "id INTEGER PRIMARY KEY CHECK (id = 1),"
+            f"{columns_sql}"
+            ")"
+        )
+        existing = {row[1] for row in con.execute(f"PRAGMA table_info({self.TABLE})")}
+        for name, ctype in self.COLUMNS.items():
+            if name not in existing:
+                con.execute(f"ALTER TABLE {self.TABLE} ADD COLUMN {name} {ctype}")
 
     def load(self, path: Path) -> TradingState:
         if not path.exists():
@@ -142,100 +475,68 @@ class SQLiteBackend:
         con = sqlite3.connect(path)
         con.row_factory = sqlite3.Row
         try:
-            with con:
-                con.execute("PRAGMA journal_mode=WAL;")
-                con.execute(self.TABLE_SQL)
-                cur = con.execute(
-                    "SELECT * FROM state WHERE id = 1"
-                )
-                row = cur.fetchone()
+            con.execute("PRAGMA journal_mode=WAL;")
+            self._ensure_schema(con)
+            cur = con.execute(f"SELECT * FROM {self.TABLE} WHERE id = 1")
+            row = cur.fetchone()
         finally:
             con.close()
         if not row:
             return TradingState()
-        data = {
+        keys = set(row.keys())
+        data: Dict[str, Any] = {
             "positions": json.loads(row["positions"] or "{}"),
             "open_orders": json.loads(row["open_orders"] or "{}"),
-            "cash": row["cash"] or 0.0,
-            "last_processed_bar_ms": row["last_processed_bar_ms"],
+            "cash": row["cash"] if "cash" in keys else 0.0,
+            "equity": row["equity"] if "equity" in keys else None,
+            "last_processed_bar_ms": row["last_processed_bar_ms"] if "last_processed_bar_ms" in keys else None,
             "seen_signals": json.loads(row["seen_signals"] or "[]"),
             "config_snapshot": json.loads(row["config_snapshot"] or "{}"),
-            "signal_states": json.loads(
-                (row["signal_states"] if "signal_states" in row.keys() else "{}")
-                or "{}"
-            ),
-            "entry_limits": json.loads(
-                (row["entry_limits"] if "entry_limits" in row.keys() else "{}")
-                or "{}"
-            ),
-            "last_prices": json.loads(
-                (row["last_prices"] if "last_prices" in row.keys() else "{}")
-                or "{}"
-            ),
-            "exposure_state": json.loads(
-                (row["exposure_state"] if "exposure_state" in row.keys() else "{}")
-                or "{}"
-            ),
-            "total_notional": float(
-                row["total_notional"]
-                if "total_notional" in row.keys() and row["total_notional"] is not None
-                else 0.0
-            ),
-            "git_hash": row["git_hash"],
-            "version": row["version"] or 1,
+            "signal_states": json.loads(row["signal_states"] or "{}"),
+            "entry_limits": json.loads(row["entry_limits"] or "{}"),
+            "last_prices": json.loads(row["last_prices"] or "{}"),
+            "exposure_state": json.loads(row["exposure_state"] or "{}"),
+            "total_notional": row["total_notional"] if "total_notional" in keys and row["total_notional"] is not None else 0.0,
+            "git_hash": row["git_hash"] if "git_hash" in keys else None,
+            "version": row["version"] if "version" in keys and row["version"] else CURRENT_STATE_VERSION,
+            "metadata": json.loads(row["metadata"] or "{}") if "metadata" in keys else {},
+            "last_update_ms": row["last_update_ms"] if "last_update_ms" in keys else None,
         }
         return TradingState.from_dict(data)
 
-    def save(self, path: Path, state: TradingState) -> None:
+    def save(self, path: Path, state: TradingState, backup_keep: int = 0) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        bak = path.with_suffix(path.suffix + ".bak")
-        if path.exists():
-            try:
-                shutil.copy2(path, bak)
-            except Exception:
-                logger.warning("Unable to rotate backup for %s", path, exc_info=True)
         con = sqlite3.connect(path)
         try:
             con.execute("PRAGMA journal_mode=WAL;")
             con.execute("PRAGMA synchronous=NORMAL;")
             cur = con.cursor()
             cur.execute("BEGIN IMMEDIATE;")
-            cur.execute(self.TABLE_SQL)
-            try:
-                columns = {
-                    row[1] for row in cur.execute("PRAGMA table_info(state)")
-                }
-            except Exception:
-                columns = set()
-            if "signal_states" not in columns:
-                cur.execute("ALTER TABLE state ADD COLUMN signal_states TEXT")
-            if "entry_limits" not in columns:
-                cur.execute("ALTER TABLE state ADD COLUMN entry_limits TEXT")
-            if "last_prices" not in columns:
-                cur.execute("ALTER TABLE state ADD COLUMN last_prices TEXT")
-            if "exposure_state" not in columns:
-                cur.execute("ALTER TABLE state ADD COLUMN exposure_state TEXT")
-            if "total_notional" not in columns:
-                cur.execute("ALTER TABLE state ADD COLUMN total_notional REAL")
+            self._ensure_schema(con)
+            payload = state.to_dict()
             cur.execute(
-                "REPLACE INTO state (id, positions, open_orders, cash, last_processed_bar_ms,"
+                f"REPLACE INTO {self.TABLE} ("
+                "id, positions, open_orders, cash, equity, last_processed_bar_ms,"
                 " seen_signals, config_snapshot, signal_states, entry_limits, last_prices,"
-                " exposure_state, total_notional, git_hash, version)"
-                " VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " exposure_state, total_notional, git_hash, version, metadata, last_update_ms"
+                ") VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
-                    json.dumps(state.positions, separators=(",", ":")),
-                    json.dumps(state.open_orders, separators=(",", ":")),
-                    state.cash,
-                    state.last_processed_bar_ms,
-                    json.dumps(list(state.seen_signals), separators=(",", ":")),
-                    json.dumps(state.config_snapshot, separators=(",", ":")),
-                    json.dumps(state.signal_states, separators=(",", ":")),
-                    json.dumps(state.entry_limits, separators=(",", ":")),
-                    json.dumps(state.last_prices, separators=(",", ":")),
-                    json.dumps(state.exposure_state, separators=(",", ":")),
-                    state.total_notional,
-                    state.git_hash,
-                    state.version,
+                    json.dumps(payload["positions"], separators=(",", ":")),
+                    json.dumps(payload["open_orders"], separators=(",", ":")),
+                    payload.get("cash", 0.0),
+                    payload.get("equity"),
+                    payload.get("last_processed_bar_ms"),
+                    json.dumps(payload.get("seen_signals", []), separators=(",", ":")),
+                    json.dumps(payload.get("config_snapshot", {}), separators=(",", ":")),
+                    json.dumps(payload.get("signal_states", {}), separators=(",", ":")),
+                    json.dumps(payload.get("entry_limits", {}), separators=(",", ":")),
+                    json.dumps(payload.get("last_prices", {}), separators=(",", ":")),
+                    json.dumps(payload.get("exposure_state", {}), separators=(",", ":")),
+                    payload.get("total_notional", 0.0),
+                    payload.get("git_hash"),
+                    payload.get("version", CURRENT_STATE_VERSION),
+                    json.dumps(payload.get("metadata", {}), separators=(",", ":")),
+                    payload.get("last_update_ms"),
                 ),
             )
             con.commit()
@@ -253,16 +554,63 @@ _state_lock = threading.RLock()
 
 def get_state() -> TradingState:
     with _state_lock:
-        return TradingState.from_dict(_state.to_dict())
+        return _state.copy()
 
 
 def update_state(**kwargs: Any) -> None:
     with _state_lock:
-        for key, value in kwargs.items():
-            if hasattr(_state, key):
-                setattr(_state, key, value)
-            else:
-                raise AttributeError(key)
+        _state.apply_updates(**kwargs)
+
+
+def update_position(symbol: str, data: Mapping[str, Any] | None = None, **kwargs: Any) -> None:
+    sym = str(symbol or "")
+    if not sym:
+        raise ValueError("symbol must be non-empty")
+    payload: Dict[str, Any] = {}
+    if isinstance(data, PositionState):
+        payload.update(data.to_dict())
+    elif data:
+        payload.update(dict(data))
+    payload.update(kwargs)
+    with _state_lock:
+        if not payload:
+            _state.positions.pop(sym, None)
+        else:
+            current = _state.positions.get(sym)
+            position = current.copy() if current else PositionState()
+            position.update(**payload)
+            _state.positions[sym] = position
+        _state.version = CURRENT_STATE_VERSION
+
+
+def update_open_order(
+    order_key: str,
+    data: Mapping[str, Any] | OrderState | None = None,
+    **kwargs: Any,
+) -> None:
+    key = str(order_key or "")
+    if not key:
+        raise ValueError("order_key must be non-empty")
+    with _state_lock:
+        if isinstance(data, OrderState):
+            order = data.copy()
+            if kwargs:
+                order.update(kwargs)
+        else:
+            payload: Dict[str, Any] = {}
+            if data:
+                payload.update(dict(data))
+            payload.update(kwargs)
+            if not payload:
+                _state.open_orders.pop(key, None)
+                _state.version = CURRENT_STATE_VERSION
+                return
+            order = _state.open_orders.get(key, OrderState()).copy()
+            order.update(payload)
+        if not order.order_id:
+            order.order_id = key
+        _state.open_orders[key] = order
+        _state.version = CURRENT_STATE_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -270,62 +618,49 @@ def update_state(**kwargs: Any) -> None:
 
 
 @contextmanager
-def _file_lock(lock_path: Path):
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as lock_file:
+def _file_lock(lock_path: Path | str):
+    path = Path(lock_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as lock_file:
         try:
             import fcntl
 
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
             yield
         finally:
-            try:
+            with suppress(Exception):
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            except Exception:
-                pass
 
 
-def _rotate_backups(p: Path, keep: int) -> None:
-    bak = p.with_suffix(p.suffix + ".bak")
-    pattern = re.compile(re.escape(p.name) + r"\.bak(\d+)$")
+def _rotate_backups(path: Path, keep: int, *, create_new: bool) -> None:
+    path = Path(path)
+    bak_plain = path.with_suffix(path.suffix + ".bak")
+    with suppress(Exception):
+        if bak_plain.exists():
+            bak_plain.unlink()
+    alt_plain = path.with_name(path.name + ".bak")
+    with suppress(Exception):
+        if alt_plain.exists():
+            alt_plain.unlink()
     if keep <= 0:
-        for old in p.parent.glob(p.name + ".bak*"):
-            try:
+        for old in path.parent.glob(f"{path.name}.bak*"):
+            with suppress(Exception):
                 old.unlink()
-            except Exception:
-                pass
-        if bak.exists():
-            try:
-                bak.unlink()
-            except Exception:
-                pass
         return
-    for old in p.parent.glob(p.name + ".bak*"):
-        m = pattern.match(old.name)
-        if m and int(m.group(1)) > keep:
-            try:
-                old.unlink()
-            except Exception:
-                pass
-    for i in range(keep, 0, -1):
-        src = p.with_suffix(p.suffix + f".bak{i}")
+    for index in range(keep, 0, -1):
+        src = path.with_suffix(path.suffix + f".bak{index}")
         if src.exists():
-            if i == keep:
-                try:
+            if index == keep:
+                with suppress(Exception):
                     src.unlink()
-                except Exception:
-                    pass
             else:
-                dst = p.with_suffix(p.suffix + f".bak{i+1}")
-                try:
-                    src.rename(dst)
-                except Exception:
-                    pass
-    if bak.exists():
-        try:
-            bak.rename(p.with_suffix(p.suffix + ".bak1"))
-        except Exception:
-            pass
+                dst = path.with_suffix(path.suffix + f".bak{index + 1}")
+                with suppress(Exception):
+                    os.replace(src, dst)
+    if create_new and path.exists():
+        dst = path.with_suffix(path.suffix + ".bak1")
+        with suppress(Exception):
+            shutil.copy2(path, dst)
 
 
 def _get_backend(backend: str | StateBackend) -> StateBackend:
@@ -343,7 +678,14 @@ def load_state(
     backend: str | StateBackend = "json",
     lock_path: str | Path | None = None,
     backup_keep: int = 0,
+    enabled: bool = True,
 ) -> TradingState:
+    global _state
+    if not enabled:
+        state = TradingState()
+        with _state_lock:
+            _state = state.copy()
+        return state.copy()
     p = Path(path)
     backend_obj = _get_backend(backend)
     lock_p = Path(lock_path) if lock_path else p.with_suffix(p.suffix + ".lock")
@@ -360,13 +702,14 @@ def load_state(
                     logger.warning("Recovered state from backup %s", bak)
                     break
                 except Exception:
+                    logger.warning("Backup %s is not usable", bak, exc_info=True)
                     continue
             if state is None:
                 state = TradingState()
+    loaded = state.copy()
     with _state_lock:
-        for k, v in state.to_dict().items():
-            setattr(_state, k, v)
-    return state
+        _state = loaded.copy()
+    return loaded
 
 
 def save_state(
@@ -375,12 +718,28 @@ def save_state(
     lock_path: str | Path | None = None,
     backup_keep: int = 0,
     state: TradingState | None = None,
+    enabled: bool = True,
 ) -> None:
+    if not enabled:
+        return
     p = Path(path)
     backend_obj = _get_backend(backend)
     lock_p = Path(lock_path) if lock_path else p.with_suffix(p.suffix + ".lock")
     with _state_lock:
-        state_obj = state or TradingState.from_dict(_state.to_dict())
+        state_obj = state.copy() if state is not None else _state.copy()
+        state_obj.version = CURRENT_STATE_VERSION
     with _file_lock(lock_p):
-        backend_obj.save(p, state_obj)
-        _rotate_backups(p, backup_keep)
+        try:
+            _rotate_backups(p, backup_keep, create_new=backup_keep > 0 and p.exists())
+        except Exception:
+            logger.warning("Failed to rotate backups for %s", p, exc_info=True)
+        try:
+            backend_obj.save(p, state_obj, backup_keep=backup_keep)
+        except Exception:
+            logger.warning("Failed to save state to %s", p, exc_info=True)
+            if backup_keep > 0:
+                bak = p.with_suffix(p.suffix + ".bak1")
+                if bak.exists():
+                    with suppress(Exception):
+                        shutil.copy2(bak, p)
+            raise


### PR DESCRIPTION
## Summary
- introduce typed trading state schema with nested position and order structures, metadata handling, and helper update utilities
- overhaul JSON and SQLite backends plus backup handling, locks, and load/save flows to support the richer schema

## Testing
- pytest tests/test_exposure_state.py

------
https://chatgpt.com/codex/tasks/task_e_68d00a94211c832f930d1d7e61040149