### PR TITLE
Expand monitoring configuration options

### DIFF
--- a/configs/monitoring.yaml
+++ b/configs/monitoring.yaml
@@ -1,10 +1,16 @@
 monitoring:
   enabled: false              # disable monitoring, snapshots and kill switch
   snapshot_metrics_sec: 60    # interval for metrics snapshots in seconds
+  tick_sec: 1.0               # frequency of monitoring aggregator loop in seconds
 thresholds:
   feed_lag_ms: 0              # enter safe mode if worst feed lag exceeds this; 0 disables
   ws_failures: 0              # enter safe mode if websocket failures exceed this; 0 disables
   error_rate: 0.0             # enter safe mode if signal error rate exceeds this; 0 disables
+  fill_ratio_min: 0.0         # alert if order fill ratio drops below this; 0 disables
+  pnl_min: 0.0                # alert if daily PnL drops below this; 0 disables
+  zero_signals: 0             # alert after N consecutive zero-signal bars; 0 disables
 alerts:
   enabled: false              # disable external alerting
   command: null               # command to execute when alerts trigger
+  channel: noop               # alert delivery channel (noop or telegram)
+  cooldown_sec: 0             # minimum seconds between repeated alerts of same type

--- a/core_config.py
+++ b/core_config.py
@@ -229,6 +229,7 @@ class MonitoringThresholdsConfig:
     error_rate: float = 0.0
     fill_ratio_min: float = 0.0
     pnl_min: float = 0.0
+    zero_signals: int = 0
 
 
 @dataclass
@@ -237,6 +238,8 @@ class MonitoringAlertConfig:
 
     enabled: bool = False
     command: Optional[str] = None
+    channel: str = "noop"
+    cooldown_sec: float = 0.0
 
 
 @dataclass
@@ -245,6 +248,7 @@ class MonitoringConfig:
 
     enabled: bool = False
     snapshot_metrics_sec: int = 60
+    tick_sec: float = 1.0
     thresholds: MonitoringThresholdsConfig = field(
         default_factory=MonitoringThresholdsConfig
     )


### PR DESCRIPTION
## Summary
- extend monitoring configuration dataclasses with tick interval, zero-signal and alert channel controls while keeping sensible defaults
- teach `service_signal_runner` to load the new monitoring settings from `configs/monitoring.yaml`
- document the new monitoring options in the sample configuration

## Testing
- python -m compileall core_config.py service_signal_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68d02ed18854832f9a5d2cbfa8fa3f16