### PR TITLE
Refine alert manager configuration handling

### DIFF
--- a/configs/monitoring.yaml
+++ b/configs/monitoring.yaml
@@ -14,3 +14,6 @@ alerts:
   command: null               # command to execute when alerts trigger
   channel: noop               # alert delivery channel (noop or telegram)
   cooldown_sec: 0             # minimum seconds between repeated alerts of same type
+  telegram:
+    bot_token_env: TELEGRAM_BOT_TOKEN  # env var name with bot token
+    chat_id_env: TELEGRAM_CHAT_ID      # env var name with chat id

--- a/core_config.py
+++ b/core_config.py
@@ -240,6 +240,7 @@ class MonitoringAlertConfig:
     command: Optional[str] = None
     channel: str = "noop"
     cooldown_sec: float = 0.0
+    telegram: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -2628,10 +2628,8 @@ class ServiceSignalRunner:
 
         if self.monitoring_cfg.enabled:
             alert_cfg = getattr(self.monitoring_cfg, "alerts", None)
-            channel = getattr(alert_cfg, "channel", "noop")
-            cooldown = float(getattr(alert_cfg, "cooldown_sec", 0.0))
             try:
-                self.alerts = AlertManager(channel, cooldown)
+                self.alerts = AlertManager(alert_cfg)
                 self.monitoring_agg = MonitoringAggregator(
                     self.monitoring_cfg, self.alerts
                 )

--- a/services/alerts.py
+++ b/services/alerts.py
@@ -1,46 +1,112 @@
+import logging
 import os
 import time
-from typing import Callable, Dict
+from typing import Any, Callable, Dict, Mapping
 
 import requests
 
 
-def send_telegram(text: str) -> None:
+logger = logging.getLogger(__name__)
+
+
+def _get_cfg_value(cfg: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from ``cfg`` supporting both mappings and objects."""
+
+    if cfg is None:
+        return default
+    if isinstance(cfg, Mapping):
+        return cfg.get(key, default)
+    return getattr(cfg, key, default)
+
+
+def send_telegram(text: str, config: Any | None = None) -> bool:
     """Send a Telegram message using bot credentials from environment.
 
     Environment variables:
         TELEGRAM_BOT_TOKEN: Bot token.
         TELEGRAM_CHAT_ID: Chat ID of the recipient.
     """
-    token = os.getenv("TELEGRAM_BOT_TOKEN")
-    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    token_env = _get_cfg_value(config, "bot_token_env", "TELEGRAM_BOT_TOKEN")
+    chat_id_env = _get_cfg_value(config, "chat_id_env", "TELEGRAM_CHAT_ID")
+    token = _get_cfg_value(config, "bot_token") or (
+        os.getenv(token_env) if token_env else None
+    )
+    chat_id = _get_cfg_value(config, "chat_id") or (
+        os.getenv(chat_id_env) if chat_id_env else None
+    )
     if not token or not chat_id:
         raise EnvironmentError("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must be set")
 
-    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    api_base = _get_cfg_value(config, "api_base_url", "https://api.telegram.org")
+    timeout = float(_get_cfg_value(config, "timeout_sec", 10.0) or 10.0)
     payload = {"chat_id": chat_id, "text": text}
-    requests.post(url, json=payload, timeout=10)
+
+    extra_payload = _get_cfg_value(config, "extra_payload")
+    if isinstance(extra_payload, Mapping):
+        payload.update(extra_payload)
+
+    url = f"{api_base.rstrip('/')}/bot{token}/sendMessage"
+    try:
+        response = requests.post(url, json=payload, timeout=timeout)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        logger.warning("failed to send telegram alert: %s", exc, exc_info=exc)
+        return False
+
+    return True
 
 
 class AlertManager:
     """Manage alert notifications with cooldown control."""
 
-    def __init__(self, channel: str, cooldown_sec: float) -> None:
-        self.cooldown_sec = cooldown_sec
+    def __init__(self, settings: Any | None = None) -> None:
+        channel = _get_cfg_value(settings, "channel", "noop") or "noop"
+        cooldown = _get_cfg_value(settings, "cooldown_sec", 0.0)
+        telegram_cfg = _get_cfg_value(settings, "telegram")
+
+        self.cooldown_sec = float(cooldown or 0.0)
         self._last_sent: Dict[str, float] = {}
-        self._channels: Dict[str, Callable[[str], None]] = {
-            "telegram": send_telegram,
-            "noop": lambda text: None,
+        self._channels: Dict[str, Callable[[str], bool]] = {
+            "noop": lambda text: True,
+            "telegram": lambda text, cfg=telegram_cfg: send_telegram(text, cfg),
+            "http": self._unsupported_sender("http"),
+            "webhook": self._unsupported_sender("webhook"),
         }
+
         if channel not in self._channels:
-            raise ValueError(f"Unknown alert channel: {channel}")
+            logger.warning("unknown alert channel '%s', falling back to noop", channel)
+            channel = "noop"
+
+        self._channel = channel
         self._send = self._channels[channel]
 
     def notify(self, key: str, text: str) -> None:
         """Send `text` if `cooldown_sec` has passed for `key`."""
         now = time.time()
-        last_time = self._last_sent.get(key)
-        if last_time is not None and now - last_time < self.cooldown_sec:
+        if self.cooldown_sec > 0:
+            last_time = self._last_sent.get(key)
+            if last_time is not None and now - last_time < self.cooldown_sec:
+                return
+
+        try:
+            result = self._send(text)
+        except Exception:
+            logger.exception("failed to send alert '%s' via %s", key, self._channel)
             return
-        self._last_sent[key] = now
-        self._send(text)
+
+        if result is False:
+            logger.debug(
+                "alert '%s' via %s reported failure, skipping cooldown", key, self._channel
+            )
+            return
+
+        if self.cooldown_sec > 0:
+            self._last_sent[key] = now
+
+    @staticmethod
+    def _unsupported_sender(channel: str) -> Callable[[str], bool]:
+        def _send(_: str) -> bool:
+            logger.info("alert channel '%s' is not implemented", channel)
+            return False
+
+        return _send


### PR DESCRIPTION
## Summary
- allow AlertManager to accept structured configuration objects and pre-register channel senders, including a noop default and webhook/http placeholders
- extend the Telegram sender to use configurable environment variable names and gracefully handle request errors
- expose telegram-specific configuration in MonitoringAlertConfig and sample YAML, updating the runner to pass the full alert config

## Testing
- python -m compileall services/alerts.py
- python -m compileall service_signal_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68d031b7a9d8832fac89ca34f4f9d6f5