### PR TITLE
Wire monitoring aggregator lifecycle through ServiceSignalRunner

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -574,10 +574,10 @@ class MonitoringAggregator:
         self.fill_ratio: Optional[float] = None
         self.daily_pnl: Optional[float] = None
 
-        if self.enabled:
-            set_runtime_aggregator(self)
-        else:
-            clear_runtime_aggregator()
+        # ``ServiceSignalRunner`` is responsible for registering the runtime
+        # aggregator once the full runtime wiring is complete.  This avoids
+        # transient registration in case initialisation fails midway through
+        # ServiceSignalRunner construction.
 
     # ------------------------------------------------------------------
     # Properties and helpers


### PR DESCRIPTION
## Summary
- accept an optional MonitoringAggregator in ServiceSignalRunner, register it once initialised, and attach it to the adapter, market data, and worker while ensuring it is cleared on shutdown
- drive the monitoring tick thread from MonitoringConfig.tick_sec and guard it behind the aggregator being enabled
- stop MonitoringAggregator from self-registering so ServiceSignalRunner controls runtime registration

## Testing
- pytest tests/test_kill_switch.py

------
https://chatgpt.com/codex/tasks/task_e_68d03aceba18832fa46e369b448d857d