### PR TITLE
Add aggregator-aware HTTP monitoring

### DIFF
--- a/services/rest_budget.py
+++ b/services/rest_budget.py
@@ -1449,7 +1449,9 @@ class RestBudgetSession:
                 label = self._error_label(exc)
                 with self._stats_lock:
                     self.error_counts[label] += 1
-                monitoring.record_http_error(label)
+                monitoring.record_http_error(
+                    label, timed_out=isinstance(exc, requests.exceptions.Timeout)
+                )
                 raise
 
             status = resp.status_code


### PR DESCRIPTION
## Summary
- expose accessors for the runtime monitoring aggregator and extend HTTP metric helpers with a timeout flag
- ensure `MonitoringAggregator` classifies timeout events correctly when notified
- mark timeout exceptions in `RestBudgetSession` so aggregator statistics capture them

## Testing
- python -m compileall services/monitoring.py services/rest_budget.py

------
https://chatgpt.com/codex/tasks/task_e_68d045a560b0832fbe5c45b2519e381e