### PR TITLE
Run targeted pipeline tests

### DIFF
--- a/configs/config_live.yaml
+++ b/configs/config_live.yaml
@@ -36,6 +36,10 @@ shutdown:
 ttl:
   enabled: false
   ttl_seconds: 60
+  mode: relative
+  guard_ms: 5000
+  absolute_failsafe_ms: 900000
+  state_path: state/ttl_state.json
   out_csv: null
   dedup_persist: null
 api:
@@ -113,6 +117,12 @@ pipeline:
     policy:
       enabled: true
     risk:
+      enabled: true
+    ttl:
+      enabled: true
+    dedup:
+      enabled: true
+    throttle:
       enabled: true
     publish:
       enabled: true

--- a/pipeline.py
+++ b/pipeline.py
@@ -30,6 +30,9 @@ class Stage(Enum):
     EXTREME = auto()
     POLICY = auto()
     RISK = auto()
+    TTL = auto()
+    DEDUP = auto()
+    THROTTLE = auto()
     PUBLISH = auto()
 
 


### PR DESCRIPTION
## Summary / Status
- ✅ Added extended TTL configuration in `core_config.py` (new fields with validation clamp now handled via `model_validator`) and updated defaults in `configs/config_live.yaml`.
- ✅ Expanded pipeline stages to include TTL/DEDUP/THROTTLE and wrapped relevant logic inside `_Worker` (`service_signal_runner.py`) with stage-aware gating, runtime reload support, runner-status JSON writer, and safe-stop flag handling.
- ✅ Overhauled the Streamlit “Realtime Signaler” tab (`app.py`) with new status columns, pipeline/TTL/throttle/dedup forms using `atomic_write_with_retry`, and reload/safe-stop actions.
- ✅ Refactored runtime pipeline parsing via `_parse_pipeline_config` and ensured workers receive live updates.
- ✅ Re-ran targeted pipeline tests after validator fix.

## Testing
- ✅ `pytest tests/test_pipeline_flow.py tests/test_publish_decision.py`


------
https://chatgpt.com/codex/tasks/task_e_68d04a70cae4832fbdac8441167ccf6d