### PR TITLE
Enhance simulator settings UI and bar-level reporting

### DIFF
--- a/legacy_sandbox_config.py
+++ b/legacy_sandbox_config.py
@@ -31,6 +31,7 @@ class SandboxConfig(BaseModel):
     data: DataConfig
     dynamic_spread: Dict[str, Any] = Field(default_factory=dict)
     out_reports: Optional[str] = None
+    bar_report_path: Optional[str] = None
 
 
 def load_config(path: str) -> SandboxConfig:


### PR DESCRIPTION
## Summary
- add bar_report_path plumbing to BacktestConfig and emit per-bar CSV plus aggregate summary during ServiceBacktest runs
- extend Streamlit sim settings tab with execution/clip/capacity controls, validation, and quick backtest preview using the new bar report
- add slippage and t-cost calibration buttons with optional YAML updates and update backtest helper to pass bar_report_path

## Testing
- python -m compileall app.py service_backtest.py legacy_sandbox_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d0729f0724832f94d5d1bc6ebb5948