### PR TITLE
Add signal CSV writer stats and UI controls

### DIFF
--- a/configs/signals.yaml
+++ b/configs/signals.yaml
@@ -2,3 +2,6 @@ enabled: false            # Enable or disable signal generation
 out_csv: "signals.csv"    # Path to write signals CSV (null to disable)
 ttl_seconds: 60           # Time-to-live for signal cache entries
 dedup_persist: null       # Path to dedup persistence file or null for in-memory only
+fsync_mode: "batch"       # Fsync mode for CSV writer: always/batch/off
+rotate_daily: true        # Rotate CSV into <name>-YYYY-MM-DD.csv on day change
+flush_interval_s: 5       # Flush interval in seconds for batch/off fsync modes

--- a/services/signal_csv_writer.py
+++ b/services/signal_csv_writer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import os
+import time
 from datetime import datetime, date
 from typing import Dict, Sequence, Any
 
@@ -24,15 +25,52 @@ class SignalCSVWriter:
         "features_hash",
     ]
 
-    def __init__(self, path: str, header: Sequence[str] | None = None) -> None:
+    def __init__(
+        self,
+        path: str,
+        header: Sequence[str] | None = None,
+        *,
+        fsync_mode: str = "batch",
+        rotate_daily: bool = True,
+        flush_interval_s: float | None = 5.0,
+    ) -> None:
         self.path = str(path)
         self.header = list(header) if header is not None else list(self.DEFAULT_HEADER)
         self._file: Any | None = None
         self._writer: csv.DictWriter | None = None
         self._day: date | None = None
+        self._fsync_mode = self._normalize_fsync_mode(fsync_mode)
+        self._rotate_daily = bool(rotate_daily)
+        self._flush_interval_s = self._normalize_flush_interval(flush_interval_s)
+        self._last_flush_ts = time.monotonic()
+        self._written = 0
+        self._retries = 0
+        self._errors = 0
+        self._dropped = 0
         self._ensure_dir()
         self._rotate_existing()
         self._open_file(initial=True)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_fsync_mode(mode: str) -> str:
+        value = (mode or "off").lower()
+        if value not in {"always", "batch", "off"}:
+            return "off"
+        return value
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_flush_interval(interval: float | None) -> float:
+        if interval is None:
+            return 0.0
+        try:
+            value = float(interval)
+        except (TypeError, ValueError):
+            return 0.0
+        if value < 0:
+            return 0.0
+        return value
 
     # ------------------------------------------------------------------
     def _ensure_dir(self) -> None:
@@ -76,9 +114,16 @@ class SignalCSVWriter:
         if need_header:
             self._writer.writeheader()
             self._file.flush()
+            self._last_flush_ts = time.monotonic()
+        else:
+            self._last_flush_ts = time.monotonic()
 
     # ------------------------------------------------------------------
     def _maybe_rotate(self, ts_ms: int) -> None:
+        if not self._rotate_daily:
+            if self._day is None:
+                self._day = datetime.utcfromtimestamp(int(ts_ms) / 1000).date()
+            return
         day = datetime.utcfromtimestamp(int(ts_ms) / 1000).date()
         if self._day is None:
             self._day = day
@@ -98,22 +143,108 @@ class SignalCSVWriter:
         self._open_file()
 
     # ------------------------------------------------------------------
-    def write(self, row: Dict[str, Any]) -> None:
+    def _write_row(self, row: Dict[str, Any], ts_ms: int) -> None:
         if self._writer is None:
-            return
-        ts_ms = int(row.get("ts_ms", 0))
+            raise RuntimeError("writer is closed")
         self._maybe_rotate(ts_ms)
-        self._writer.writerow({k: row.get(k, "") for k in self.header})
+        self._writer.writerow(row)
+        self._maybe_flush()
 
     # ------------------------------------------------------------------
-    def flush_fsync(self) -> None:
+    def _maybe_flush(self) -> None:
+        if not self._file:
+            return
+        mode = self._fsync_mode
+        if mode == "always":
+            self.flush_fsync()
+            return
+        interval = self._flush_interval_s
+        if interval <= 0:
+            if mode != "off":
+                self.flush_fsync()
+            elif self._file:
+                try:
+                    self._file.flush()
+                    self._last_flush_ts = time.monotonic()
+                except Exception as exc:
+                    self._errors += 1
+                    raise exc
+            return
+        now = time.monotonic()
+        if now - self._last_flush_ts < interval:
+            return
+        if mode == "off":
+            try:
+                self._file.flush()
+                self._last_flush_ts = now
+            except Exception as exc:
+                self._errors += 1
+                raise exc
+            return
+        self.flush_fsync()
+
+    # ------------------------------------------------------------------
+    def write(self, row: Dict[str, Any]) -> None:
+        if self._writer is None:
+            self._dropped += 1
+            return
+        ts_ms = int(row.get("ts_ms", 0))
+        payload = {k: row.get(k, "") for k in self.header}
+        last_exc: Exception | None = None
+        for attempt in range(2):
+            try:
+                self._write_row(payload, ts_ms)
+            except Exception as exc:
+                last_exc = exc
+                self._errors += 1
+                if attempt == 0:
+                    try:
+                        self.reopen()
+                    except Exception:
+                        break
+                    else:
+                        self._retries += 1
+                        continue
+                break
+            else:
+                self._written += 1
+                return
+        self._dropped += 1
+        if last_exc is not None:
+            raise last_exc
+
+    # ------------------------------------------------------------------
+    def flush_fsync(self, *, force: bool = False) -> None:
         if not self._file:
             return
         try:
             self._file.flush()
-            atomic_write_with_retry(self.path, None, retries=3, backoff=0.1)
-        except Exception:
-            pass
+            if force or self._fsync_mode != "off":
+                atomic_write_with_retry(self.path, None, retries=3, backoff=0.1)
+            self._last_flush_ts = time.monotonic()
+        except Exception as exc:
+            self._errors += 1
+            raise exc
+
+    # ------------------------------------------------------------------
+    def reopen(self) -> None:
+        self.flush_fsync(force=True)
+        self.close()
+        self._open_file()
+
+    # ------------------------------------------------------------------
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "path": self.path,
+            "fsync_mode": self._fsync_mode,
+            "rotate_daily": self._rotate_daily,
+            "flush_interval_s": self._flush_interval_s,
+            "written": self._written,
+            "retries": self._retries,
+            "errors": self._errors,
+            "dropped": self._dropped,
+            "open": self._file is not None,
+        }
 
     # ------------------------------------------------------------------
     def close(self) -> None:


### PR DESCRIPTION
## Summary
- extend `SignalCSVWriter` with fsync modes, write counters, stats reporting, and reopen support
- propagate writer configuration and status through `ServiceSignalRunner`, including reopen flag handling and new signals config fields
- surface writer controls, metrics, and CSV preview in the app and optimize tail reading helper

## Testing
- pytest tests/test_signal_csv_writer.py

------
https://chatgpt.com/codex/tasks/task_e_68d084952300832f8562cb83787495ff