### PR TITLE
Document intrabar configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,25 @@ Runners load the symbol universe from ``data/universe/symbols.json`` by default.
 Override it with the ``--symbols`` CLI flag or an explicit ``data.symbols``
 entry in the YAML configuration.
 
+### Intrabar price configuration
+
+Simulation and training configs now ship with explicit intrabar execution
+settings.  The block ``execution`` in
+[`configs/config_sim.yaml`](configs/config_sim.yaml) defines:
+
+- ``intrabar_price_model`` — choose the price sampling mode.  ``bridge`` keeps
+  the legacy Brownian bridge sampling, while ``reference`` uses an external M1
+  reference feed for deterministic fills.
+- ``timeframe_ms`` — bar length in milliseconds.  Set it to ``3600000`` for H1
+  profiles to align latency fractions with hourly candles.
+- ``reference_prices_path`` — optional path to the precomputed M1 reference
+  dataset required by the ``reference`` mode.  Leave it ``null`` when using
+  ``bridge``/``linear`` sampling.
+
+The nested ``execution.bridge`` block mirrors the same fields for scenarios
+where the simulator works as a bridge adapter.  Override the values there when
+the adapter consumes a different intrabar data source than the main simulator.
+
 The list is managed by ``services/universe.py`` which caches Binance spot
 symbols trading against USDT.  The cache is refreshed on first use if it is
 missing or older than 24 hours and can be updated manually:

--- a/configs/config_sim.yaml
+++ b/configs/config_sim.yaml
@@ -10,8 +10,9 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 execution:
-  intrabar_price_model: null
-  timeframe_ms: null
+  intrabar_price_model: "bridge"  # Модель заполнения внутри бара (например: linear, bridge, reference).
+  timeframe_ms: 3600000           # Размер базового бара в миллисекундах (H1 = 60 минут = 3_600_000 мс).
+  reference_prices_path: null     # Путь к M1-референсу для режима intrabar "reference"; оставьте null для bridge/linear.
   use_latency_from: null
   latency_constant_ms: null
   entry_mode: default         # Режим входа для симулятора; default соответствует текущему легаси-поведению.
@@ -27,8 +28,9 @@ execution:
     floor_base: null         # Минимальный дневной ADV (в базовой валюте): используется как фолбек и нижняя граница.
     timeframe_ms: null       # Необязательный override размера бара (в мс) для конвертации дневного ADV в per-bar.
   bridge:
-    intrabar_price_model: null
-    timeframe_ms: null
+    intrabar_price_model: "bridge"  # Пример конфигурации для симулятора в режиме моста (bridge adapter).
+    timeframe_ms: 3600000           # Должен совпадать с целевым таймфреймом бара.
+    reference_prices_path: null     # Опциональный путь к M1-референсу для bridge/reference адаптера.
     use_latency_from: null
     latency_constant_ms: null
 execution_config:

--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -16,8 +16,9 @@ execution_params:
   ttl_steps: 0           # e.g. 5 to cancel after 5 simulation steps
   tif: GTC               # e.g. IOC or FOK
 execution:
-  intrabar_price_model: null
-  timeframe_ms: null
+  intrabar_price_model: "bridge"  # Intrabar price sampling model (e.g. linear, bridge, reference).
+  timeframe_ms: 3600000           # Base bar length in milliseconds (H1 = 60 minutes = 3_600_000 ms).
+  reference_prices_path: null     # Optional path to an M1 reference dataset used by the "reference" intrabar mode.
   use_latency_from: null
   latency_constant_ms: null
   entry_mode: default         # Entry mode for fills; default keeps the legacy behaviour.
@@ -25,8 +26,9 @@ execution:
     enabled: true             # true preserves legacy clipping; false disables it.
     strict_open_fill: false   # true enforces clipped open fills; false keeps legacy logic.
   bridge:
-    intrabar_price_model: null
-    timeframe_ms: null
+    intrabar_price_model: "bridge"  # Example bridge adapter configuration; align with the main execution block.
+    timeframe_ms: 3600000           # Must match the target bar timeframe in milliseconds.
+    reference_prices_path: null     # Optional path to an intrabar reference dataset for bridge/reference adapters.
     use_latency_from: null
     latency_constant_ms: null
 execution_config:

--- a/core_config.py
+++ b/core_config.py
@@ -312,6 +312,10 @@ class ExecutionBridgeConfig(BaseModel):
     timeframe_ms: Optional[int] = Field(default=None)
     use_latency_from: Optional[str] = Field(default=None)
     latency_constant_ms: Optional[int] = Field(default=None)
+    reference_prices_path: Optional[str] = Field(
+        default=None,
+        description="Optional path to an intrabar reference dataset consumed by bridge adapters.",
+    )
 
     class Config:
         extra = "allow"
@@ -344,6 +348,10 @@ class ExecutionRuntimeConfig(BaseModel):
     timeframe_ms: Optional[int] = Field(default=None)
     use_latency_from: Optional[str] = Field(default=None)
     latency_constant_ms: Optional[int] = Field(default=None)
+    reference_prices_path: Optional[str] = Field(
+        default=None,
+        description="Path to M1 reference bars used by the 'reference' intrabar price model.",
+    )
     entry_mode: ExecutionEntryMode = Field(
         default=ExecutionEntryMode.DEFAULT,
         description="Режим выбора точки входа; ``default`` соответствует текущему поведению.",


### PR DESCRIPTION
## Summary
- set meaningful defaults for intrabar execution configuration in sample YAMLs and document the new reference dataset hook
- extend execution runtime models with a reference price path so the simulator exports it to intrabar settings
- describe intrabar configuration options in the README for easier activation of the reference mode

## Testing
- python -m compileall core_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d110738d08832f92d646b342480e5a