### PR TITLE
Add market regime propagation through simulator logs

### DIFF
--- a/aggregate_exec_logs.py
+++ b/aggregate_exec_logs.py
@@ -36,7 +36,27 @@ def _normalize_trades(df: pd.DataFrame) -> pd.DataFrame:
     Supports legacy schema: ts, price, volume, side, agent_flag, order_id
     """
     if df is None or df.empty:
-        return pd.DataFrame(columns=["ts","run_id","symbol","side","order_type","price","quantity","fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json"])
+        return pd.DataFrame(
+            columns=[
+                "ts",
+                "run_id",
+                "symbol",
+                "side",
+                "order_type",
+                "price",
+                "quantity",
+                "fee",
+                "fee_asset",
+                "pnl",
+                "exec_status",
+                "liquidity",
+                "client_order_id",
+                "order_id",
+                "execution_profile",
+                "market_regime",
+                "meta_json",
+            ]
+        )
 
     cols = set(df.columns)
 
@@ -47,10 +67,41 @@ def _normalize_trades(df: pd.DataFrame) -> pd.DataFrame:
             if c in df.columns:
                 df[c] = pd.to_numeric(df[c], errors="coerce")
         # ensure required cols exist
-        for c in ["fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json","execution_profile"]:
+        for c in [
+            "fee",
+            "fee_asset",
+            "pnl",
+            "exec_status",
+            "liquidity",
+            "client_order_id",
+            "order_id",
+            "meta_json",
+            "execution_profile",
+            "market_regime",
+        ]:
             if c not in df.columns:
                 df[c] = None
-        return df[["ts","run_id","symbol","side","order_type","price","quantity","fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","execution_profile","meta_json"]]
+        return df[
+            [
+                "ts",
+                "run_id",
+                "symbol",
+                "side",
+                "order_type",
+                "price",
+                "quantity",
+                "fee",
+                "fee_asset",
+                "pnl",
+                "exec_status",
+                "liquidity",
+                "client_order_id",
+                "order_id",
+                "execution_profile",
+                "market_regime",
+                "meta_json",
+            ]
+        ]
 
     # Legacy -> map
     if {"ts","price","volume","side"}.issubset(cols):
@@ -71,6 +122,7 @@ def _normalize_trades(df: pd.DataFrame) -> pd.DataFrame:
         out["order_id"] = df["order_id"] if "order_id" in df.columns else None
         out["meta_json"] = "{}"
         out["execution_profile"] = None
+        out["market_regime"] = None
         return out
 
     # Unknown schema -> attempt minimal
@@ -88,17 +140,59 @@ def _normalize_trades(df: pd.DataFrame) -> pd.DataFrame:
     df["symbol"] = "UNKNOWN"
     df["side"] = df.get("side", "BUY")
     df["order_type"] = df.get("order_type", "MARKET")
-    for c in ["fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","meta_json","execution_profile"]:
+    for c in [
+        "fee",
+        "fee_asset",
+        "pnl",
+        "exec_status",
+        "liquidity",
+        "client_order_id",
+        "order_id",
+        "meta_json",
+        "execution_profile",
+        "market_regime",
+    ]:
         if c not in df.columns:
             df[c] = None
-    return df[["ts","run_id","symbol","side","order_type","price","quantity","fee","fee_asset","pnl","exec_status","liquidity","client_order_id","order_id","execution_profile","meta_json"]]
+    return df[
+        [
+            "ts",
+            "run_id",
+            "symbol",
+            "side",
+            "order_type",
+            "price",
+            "quantity",
+            "fee",
+            "fee_asset",
+            "pnl",
+            "exec_status",
+            "liquidity",
+            "client_order_id",
+            "order_id",
+            "execution_profile",
+            "market_regime",
+            "meta_json",
+        ]
+    ]
 
 
 def _normalize_reports(df: pd.DataFrame) -> pd.DataFrame:
     """Normalize equity reports to at least ts_ms and equity columns."""
     if df is None or df.empty:
         return pd.DataFrame(
-            columns=["ts_ms", "symbol", "equity", "fee_total", "funding_cashflow", "execution_profile"]
+            columns=[
+                "ts_ms",
+                "symbol",
+                "equity",
+                "fee_total",
+                "funding_cashflow",
+                "bid",
+                "ask",
+                "mtm_price",
+                "execution_profile",
+                "market_regime",
+            ]
         )
 
     r = df.copy()
@@ -113,7 +207,16 @@ def _normalize_reports(df: pd.DataFrame) -> pd.DataFrame:
     if "symbol" not in r.columns:
         r["symbol"] = "UNKNOWN"
 
-    for c in ["equity", "fee_total", "funding_cashflow", "bid", "ask", "mtm_price", "execution_profile"]:
+    for c in [
+        "equity",
+        "fee_total",
+        "funding_cashflow",
+        "bid",
+        "ask",
+        "mtm_price",
+        "execution_profile",
+        "market_regime",
+    ]:
         if c not in r.columns:
             r[c] = pd.NA
 
@@ -125,7 +228,20 @@ def _normalize_reports(df: pd.DataFrame) -> pd.DataFrame:
     r["ask"] = pd.to_numeric(r["ask"], errors="coerce")
     r["mtm_price"] = pd.to_numeric(r["mtm_price"], errors="coerce")
 
-    return r[["ts_ms", "symbol", "equity", "fee_total", "funding_cashflow", "bid", "ask", "mtm_price", "execution_profile"]]
+    return r[
+        [
+            "ts_ms",
+            "symbol",
+            "equity",
+            "fee_total",
+            "funding_cashflow",
+            "bid",
+            "ask",
+            "mtm_price",
+            "execution_profile",
+            "market_regime",
+        ]
+    ]
 
 
 def _bucket_ts_ms(ts_ms: pd.Series, *, bar_seconds: int) -> pd.Series:

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -531,6 +531,7 @@ class SimStepReport:
     latency_p95_ms: float = 0.0
     execution_profile: str = ""
     latency_timeout_ratio: float = 0.0
+    market_regime: Any | None = None
     vol_raw: Optional[Dict[str, float]] = None
     cap_base_per_bar: float = 0.0
     used_base_before: float = 0.0
@@ -611,6 +612,7 @@ class SimStepReport:
             "latency_p95_ms": float(self.latency_p95_ms),
             "latency_timeout_ratio": float(self.latency_timeout_ratio),
             "execution_profile": str(self.execution_profile),
+            "market_regime": self.market_regime,
             "vol_raw": (
                 {str(k): float(v) for k, v in self.vol_raw.items()}
                 if isinstance(self.vol_raw, dict)
@@ -2828,6 +2830,7 @@ class ExecutionSimulator:
             latency_p95_ms=float(lat_stats.get("p95_ms", 0.0)),
             latency_timeout_ratio=float(lat_stats.get("timeout_rate", 0.0)),
             execution_profile=str(getattr(self, "execution_profile", "")),
+            market_regime=getattr(self, "_last_market_regime", None),
             vol_raw=self._last_vol_raw,
         )
         if trades:
@@ -9125,6 +9128,7 @@ class ExecutionSimulator:
             latency_p95_ms=float(lat_stats.get("p95_ms", 0.0)),
             latency_timeout_ratio=float(lat_stats.get("timeout_rate", 0.0)),
             execution_profile=str(getattr(self, "execution_profile", "")),
+            market_regime=getattr(self, "_last_market_regime", None),
             vol_raw=self._last_vol_raw,
         )
 

--- a/sandbox/sim_adapter.py
+++ b/sandbox/sim_adapter.py
@@ -593,6 +593,8 @@ class SimAdapter:
             actions=actions,
         )
         d = report.to_dict()
+        if "market_regime" not in d:
+            d["market_regime"] = getattr(report, "market_regime", None)
 
         # Пишем унифицированный лог построчно (без изменения возврата)
         try:

--- a/scripts/calibrate_live_slippage.py
+++ b/scripts/calibrate_live_slippage.py
@@ -127,6 +127,10 @@ def _prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     vol_series = _normalise_numeric(_resolve_column(df, DEFAULT_COLUMN_ALIASES["vol_factor"]))
     exec_profile_series = _resolve_column(df, DEFAULT_COLUMN_ALIASES["execution_profile"])
     regime_series = _resolve_column(df, DEFAULT_COLUMN_ALIASES["market_regime"])
+    if regime_series is not None:
+        regime_payload = regime_series
+    else:
+        regime_payload = pd.Series([None] * len(df), index=df.index, dtype=object)
 
     out = pd.DataFrame({
         "ts_ms": ts_series,
@@ -138,7 +142,7 @@ def _prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
         "liquidity": liquidity_series,
         "vol_factor": vol_series,
         "execution_profile": exec_profile_series,
-        "market_regime": regime_series,
+        "market_regime": regime_payload,
     })
 
     # Drop rows without symbols or slippage values

--- a/tests/test_execution_bar_capacity_base.py
+++ b/tests/test_execution_bar_capacity_base.py
@@ -51,6 +51,7 @@ class _CompatReport:
     latency_p95_ms: float = 0.0
     latency_timeout_ratio: float = 0.0
     execution_profile: str = ""
+    market_regime: Any | None = None
     vol_raw: Optional[Dict[str, float]] = None
     status: str = ""
     reason: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- extend `SimStepReport` to carry the last market regime and surface it via `to_dict`
- propagate market regime snapshots through log writing, adapters, and aggregation utilities
- update calibration tooling and tests to ensure the new column is preserved for downstream analytics

## Testing
- `pytest tests/test_execution_profile_logging_and_metrics.py tests/test_slippage_calibration_runtime.py`


------
https://chatgpt.com/codex/tasks/task_e_68d19a8b61ac832f94bf068a7863900d