### PR TITLE
Add manual override support for Binance fee snapshots

### DIFF
--- a/configs/fees.yaml
+++ b/configs/fees.yaml
@@ -34,6 +34,13 @@ fees:
     per_symbol:
       ETHUSDT:
         enabled: false             # На уровне символа можно отключить альтернативное взыскание комиссий.
+  public_snapshot:                 # Опции для автоматического публичного снапшота (без приватных API).
+    vip_tier: null                 # Явный VIP-уровень аккаунта; null → используем конфиг/метаданные.
+    vip_label: null                # Текстовая метка VIP (override metadata.vip_tier).
+    use_bnb_discount: null         # true/false → принудительно считать скидку BNB активной/выключенной.
+    maker_discount_mult: null      # Множитель мейкера при BNB/VIP скидке (например 0.75).
+    taker_discount_mult: null      # Множитель тейкера при BNB/VIP скидке.
+    bnb_discount_rate: null        # Номинальная скидка Binance (по умолчанию 0.25 → множитель 0.75).
   symbol_fee_table:                # Inline-таблица ставок; может дополнять/override внешний файл.
     BTCUSDT:
       maker_bps: 1.8

--- a/scripts/refresh_fees.py
+++ b/scripts/refresh_fees.py
@@ -49,6 +49,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Label stored in metadata.vip_tier (default: %(default)s)",
     )
     parser.add_argument(
+        "--vip-tier-int",
+        type=int,
+        dest="vip_tier_int",
+        help="Explicit VIP tier integer stored in metadata.account_overrides.vip_tier",
+    )
+    parser.add_argument(
         "--csv",
         help="Optional CSV export with fee information to use instead of HTTP",
     )
@@ -57,6 +63,31 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=float,
         default=DEFAULT_BNB_DISCOUNT_RATE,
         help="Fractional taker discount when paying fees with BNB (default: 0.25)",
+    )
+    parser.add_argument(
+        "--use-bnb-discount",
+        dest="use_bnb_discount",
+        action="store_true",
+        help="Indicate that the account actively uses BNB fee discounts",
+    )
+    parser.add_argument(
+        "--no-bnb-discount",
+        dest="use_bnb_discount",
+        action="store_false",
+        help="Indicate that the account does not use BNB fee discounts",
+    )
+    parser.set_defaults(use_bnb_discount=None)
+    parser.add_argument(
+        "--maker-discount-mult",
+        type=float,
+        dest="maker_discount_mult",
+        help="Explicit maker fee multiplier to persist in metadata overrides",
+    )
+    parser.add_argument(
+        "--taker-discount-mult",
+        type=float,
+        dest="taker_discount_mult",
+        help="Explicit taker fee multiplier to persist in metadata overrides",
     )
     parser.add_argument(
         "--timeout",
@@ -160,6 +191,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     snapshot = load_public_fee_snapshot(
         vip_tier=args.vip_tier,
+        vip_tier_numeric=args.vip_tier_int,
+        use_bnb_discount=args.use_bnb_discount,
+        maker_discount_mult=args.maker_discount_mult,
+        taker_discount_mult=args.taker_discount_mult,
         timeout=args.timeout,
         public_url=args.public_url,
         csv_path=csv_path,

--- a/tests/test_fees_public_snapshot.py
+++ b/tests/test_fees_public_snapshot.py
@@ -1,0 +1,65 @@
+import json
+
+import pytest
+
+from impl_fees import FeesImpl
+
+
+def test_public_snapshot_overrides_applied_without_account_info(tmp_path):
+    snapshot_payload = {
+        "metadata": {
+            "built_at": "2024-01-01T00:00:00Z",
+            "source": "unit-test",
+            "vip_tier": "VIP 3",
+            "schema_version": 1,
+            "account_overrides": {
+                "vip_tier": 3,
+                "use_bnb_discount": True,
+                "maker_discount_mult": 0.75,
+                "taker_discount_mult": 0.75,
+            },
+        },
+        "fees": {
+            "BTCUSDT": {
+                "maker_bps": 1.0,
+                "taker_bps": 5.0,
+            }
+        },
+    }
+
+    snapshot_path = tmp_path / "fees.json"
+    snapshot_path.write_text(json.dumps(snapshot_payload), encoding="utf-8")
+
+    fees = FeesImpl.from_dict(
+        {
+            "path": str(snapshot_path),
+            "account_info": {"enabled": True},
+        }
+    )
+
+    assert fees.model_payload["vip_tier"] == 3
+    assert fees.model_payload["use_bnb_discount"] is True
+    assert fees.model_payload["maker_discount_mult"] == pytest.approx(0.75)
+    assert fees.model_payload["taker_discount_mult"] == pytest.approx(0.75)
+
+    expected = fees.expected_payload
+    assert expected["maker_fee_bps"] == pytest.approx(0.75)
+    assert expected["taker_fee_bps"] == pytest.approx(3.75)
+    assert expected["use_bnb_discount"] is True
+
+    account_meta = fees.metadata.get("account_fetch") or {}
+    assert account_meta.get("status") == "missing_credentials"
+    applied = account_meta.get("applied") or {}
+    assert applied.get("vip_tier") is False
+    assert applied.get("maker_bps") is False
+    assert applied.get("taker_bps") is False
+
+    table_meta = fees.metadata.get("table") or {}
+    overrides = table_meta.get("account_overrides") or {}
+    assert overrides.get("vip_tier") == 3
+    assert overrides.get("use_bnb_discount") is True
+    assert overrides.get("maker_discount_mult") == pytest.approx(0.75)
+    assert overrides.get("taker_discount_mult") == pytest.approx(0.75)
+
+    assert fees.metadata.get("maker_discount_mult") == pytest.approx(0.75)
+    assert fees.metadata.get("taker_discount_mult") == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
- allow the public fee refresh helper to accept explicit VIP tier and BNB discount overrides and persist them in snapshot metadata
- teach FeesConfig/FeesImpl to consume the override metadata or config when auto-refreshing so discount multipliers and VIP tier propagate without private APIs
- document the new knobs in the sample fees config and add a regression test that validates override handling

## Testing
- pytest TradingBot/tests/test_fees_*.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a6308bf8832fb5fb5d7cee32f314