### PR TITLE
Add turnover-aware reward and expose configuration toggles

### DIFF
--- a/config.py
+++ b/config.py
@@ -105,11 +105,13 @@ class RewardParams:
     """Настройки функции вознаграждения."""
 
     use_potential_shaping: bool = False  # Использовать potential-based shaping
+    use_legacy_log_reward: bool = False  # Добавлять логарифмический доход к ΔPnL
     gamma: float = 0.99  # Коэффициент дисконтирования
     potential_shaping_coef: float = 1.0  # Масштаб коэффициента потенциала
     risk_aversion_variance: float = 1.0  # Штраф за открытый риск
     risk_aversion_drawdown: float = 1.0  # Штраф за просадку
     trade_frequency_penalty: float = 0.0  # Штраф за каждую сделку
+    turnover_penalty_coef: float = 0.0  # Штраф за оборот (ноционал)
     event_reward: bool = False  # Включить бонусы/штрафы за события закрытия позиций
     profit_close_bonus: float = 0.0  # Бонус за закрытие позиции с прибылью
     loss_close_penalty: float = 0.0  # Штраф за закрытие позиции с убытком
@@ -135,11 +137,13 @@ class RewardParams:
         """Возвращает словарь с параметрами RewardParams."""
         return {
             "use_potential_shaping": self.use_potential_shaping,
+            "use_legacy_log_reward": self.use_legacy_log_reward,
             "gamma": self.gamma,
             "potential_shaping_coef": self.potential_shaping_coef,
             "risk_aversion_variance": self.risk_aversion_variance,
             "risk_aversion_drawdown": self.risk_aversion_drawdown,
             "trade_frequency_penalty": self.trade_frequency_penalty,
+            "turnover_penalty_coef": self.turnover_penalty_coef,
             "event_reward": self.event_reward,
             "profit_close_bonus": self.profit_close_bonus,
             "loss_close_penalty": self.loss_close_penalty,

--- a/environment.pyx
+++ b/environment.pyx
@@ -66,7 +66,9 @@ def _initialize_environment(self):
     self.state.bankruptcy_threshold = self.config.risk.bankruptcy_threshold
     self.state.max_drawdown = self.config.risk.max_drawdown
     self.state.trade_frequency_penalty = self.config.reward.trade_frequency_penalty
+    self.state.turnover_penalty_coef = self.config.reward.turnover_penalty_coef
     self.state.use_potential_shaping = self.config.reward.use_potential_shaping
+    self.state.use_legacy_log_reward = self.config.reward.use_legacy_log_reward
     self.state.gamma = self.config.reward.gamma
     self.state.last_potential = 0.0
     self.state.potential_shaping_coef = self.config.reward.potential_shaping_coef


### PR DESCRIPTION
## Summary
- switch the Cython reward to use delta net worth as the primary signal, optionally layering the legacy log-return shaping behind a flag and subtracting a turnover penalty
- accumulate executed notional each step, log step PnL/turnover, and roll `prev_net_worth` forward after committing state updates
- surface `use_legacy_log_reward` and `turnover_penalty_coef` on the config/env state so callers can control the new behaviour

## Testing
- pytest tests/test_read_only_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68d1bfb39b28832f93587ec41e306351