### PR TITLE
Align live timing with execution profiles

### DIFF
--- a/tests/test_timing_profiles.py
+++ b/tests/test_timing_profiles.py
@@ -1,3 +1,6 @@
+import logging
+from decimal import Decimal
+
 import pandas as pd
 import pytest
 
@@ -9,6 +12,9 @@ from core_config import (
     ExecutionProfile,
 )
 from leakguard import LeakGuard, LeakConfig
+from pipeline import PipelineConfig, PipelineResult, Stage
+from core_models import Bar
+import service_signal_runner
 from trading_patchnew import TradingEnv, DecisionTiming
 
 
@@ -73,3 +79,169 @@ def test_execution_profile_switch_changes_env_behavior():
     finally:
         env_mkt.close()
         env_vwap.close()
+
+
+def test_mkt_open_profile_alignment(monkeypatch: pytest.MonkeyPatch) -> None:
+    timing_defaults, timing_profiles = load_timing_profiles()
+    resolved = resolve_execution_timing(
+        ExecutionProfile.MKT_OPEN_NEXT_H1, timing_defaults, timing_profiles
+    )
+    timeframe_ms = timing_defaults.timeframe_ms or 60_000
+
+    df = _make_minimal_df(rows=3, timeframe_ms=timeframe_ms)
+    env = TradingEnv(
+        df,
+        decision_mode=DecisionTiming[resolved.decision_mode],
+        decision_delay_ms=resolved.decision_delay_ms,
+        latency_steps=resolved.latency_steps,
+        leak_guard=LeakGuard(
+            LeakConfig(
+                decision_delay_ms=resolved.decision_delay_ms,
+                min_lookback_ms=resolved.min_lookback_ms,
+            )
+        ),
+    )
+    try:
+        env.reset()
+        decision_ts = int(env.df.loc[0, "decision_ts"])
+    finally:
+        env.close()
+
+    class _DummyMetric:
+        def labels(self, *args, **kwargs):
+            return self
+
+        def inc(self, *args, **kwargs) -> None:
+            return None
+
+        def set(self, *args, **kwargs) -> None:
+            return None
+
+        def observe(self, *args, **kwargs) -> None:
+            return None
+
+    class DummyFeaturePipe:
+        def __init__(self) -> None:
+            self.signal_quality = {}
+
+        def update(self, bar, skip_metrics: bool = False):
+            return {}
+
+    class DummyPolicy:
+        def __init__(self, symbol: str) -> None:
+            self._symbol = symbol
+
+        def decide(self, features, ctx):
+            return [DummyOrder(self._symbol)]
+
+        def consume_signal_transitions(self):
+            return []
+
+    class DummyOrder:
+        def __init__(self, symbol: str, quantity: float = 1.0, side: str = "BUY") -> None:
+            self.symbol = symbol
+            self.quantity = quantity
+            self.side = side
+            self.meta = {}
+
+    class DummyExecutor:
+        def submit(self, order) -> None:
+            return None
+
+    dummy_metric = _DummyMetric()
+    for attr in (
+        "skipped_incomplete_bars",
+        "pipeline_stage_drop_count",
+    ):
+        monkeypatch.setattr(service_signal_runner, attr, dummy_metric)
+    monkeypatch.setattr(
+        service_signal_runner.monitoring, "inc_stage", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        service_signal_runner.monitoring, "inc_reason", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        service_signal_runner.monitoring, "record_signals", lambda *args, **kwargs: None
+    )
+    for attr in (
+        "signal_error_rate",
+        "throttle_enqueued_count",
+        "throttle_dropped_count",
+        "ws_dup_skipped_count",
+        "ttl_expired_boundary_count",
+        "signal_boundary_count",
+        "queue_len",
+        "age_at_publish_ms",
+        "signal_published_count",
+        "signal_absolute_count",
+        "throttle_queue_expired_count",
+    ):
+        monkeypatch.setattr(service_signal_runner.monitoring, attr, dummy_metric)
+    monkeypatch.setattr(
+        service_signal_runner.monitoring, "kill_switch_triggered", lambda: False
+    )
+    monkeypatch.setattr(
+        service_signal_runner.monitoring, "alert_zero_signals", lambda *a, **k: None
+    )
+
+    guard_call: dict[str, int] = {}
+
+    def _guard(bar, now_ms, enforce, lag_ms, *, stage_cfg=None):
+        guard_call["now_ms"] = int(now_ms)
+        guard_call["lag_ms"] = int(lag_ms)
+        return PipelineResult(action="pass", stage=Stage.CLOSED_BAR)
+
+    monkeypatch.setattr(service_signal_runner, "closed_bar_guard", _guard)
+    monkeypatch.setattr(service_signal_runner.clock, "now_ms", lambda: decision_ts)
+
+    recorded_dedup: list[int] = []
+    monkeypatch.setattr(
+        service_signal_runner.signal_bus, "should_skip", lambda symbol, close_ms: False
+    )
+    monkeypatch.setattr(
+        service_signal_runner.signal_bus,
+        "update",
+        lambda symbol, close_ms: recorded_dedup.append(int(close_ms)),
+    )
+
+    captured_publish: list[int] = []
+
+    def _publish(self, order, symbol: str, bar_close_ms: int, *, stage_cfg=None):
+        captured_publish.append(int(bar_close_ms))
+        return PipelineResult(action="pass", stage=Stage.PUBLISH, decision=order)
+
+    monkeypatch.setattr(service_signal_runner._Worker, "publish_decision", _publish)
+
+    worker = service_signal_runner._Worker(
+        fp=DummyFeaturePipe(),
+        policy=DummyPolicy("BTCUSDT"),
+        logger=logging.getLogger("timing-test"),
+        executor=DummyExecutor(),
+        guards=None,
+        enforce_closed_bars=True,
+        close_lag_ms=resolved.decision_delay_ms,
+        ws_dedup_enabled=True,
+        ws_dedup_timeframe_ms=timeframe_ms,
+        throttle_cfg=None,
+        pipeline_cfg=PipelineConfig(),
+    )
+
+    bar = Bar(
+        ts=int(df.loc[0, "ts_ms"]),
+        symbol="BTCUSDT",
+        open=Decimal(str(df.loc[0, "open"])),
+        high=Decimal(str(df.loc[0, "high"])),
+        low=Decimal(str(df.loc[0, "low"])),
+        close=Decimal(str(df.loc[0, "close"])),
+        volume_base=None,
+        volume_quote=Decimal("0"),
+        is_final=True,
+    )
+
+    worker.process(bar)
+
+    assert guard_call["lag_ms"] == resolved.decision_delay_ms
+    assert guard_call["now_ms"] == decision_ts
+    assert captured_publish == [int(bar.ts)]
+    assert recorded_dedup == [int(bar.ts) + timeframe_ms]
+    assert int(bar.ts) + resolved.decision_delay_ms == decision_ts


### PR DESCRIPTION
## Summary
- load timing profiles in `service_signal_runner.from_config` and resolve the selected execution profile before constructing the runner
- propagate the resolved decision delay, latency metadata, and timeframe back onto the run config so websocket dedupe and downstream components share the training timing profile
- add a regression test that drives a stubbed live worker alongside the training env to assert close/decision timestamps stay aligned for `MKT_OPEN_NEXT_H1`

## Testing
- `pytest tests/test_timing_profiles.py` *(skipped: gymnasium not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1dd497874832f820f32b16b081deb