### PR TITLE
Add split-aware offline artifact workflows and tests

### DIFF
--- a/scripts/offline_utils.py
+++ b/scripts/offline_utils.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping
+
+import yaml
+
+from offline_config import normalize_dataset_splits
+from utils_time import parse_time_to_ms
+
+
+_TAG_SAFE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_DAY_MS = 86_400_000
+
+
+def _coerce_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    raise KeyError("expected mapping")
+
+
+def _parse_time_ms(raw: Any) -> int | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    try:
+        return int(parse_time_to_ms(text))
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError(f"failed to parse timestamp '{raw}'") from exc
+
+
+def ms_to_iso(ms: int | None) -> str | None:
+    if ms is None:
+        return None
+    return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sanitize_tag(tag: str | None, *, fallback: str) -> str:
+    base = (tag or "").strip() or fallback
+    sanitized = _TAG_SAFE_RE.sub("-", base).strip("-_.")
+    return sanitized or fallback
+
+
+def apply_split_tag(path: Path, tag: str) -> Path:
+    sanitized = sanitize_tag(tag, fallback="split")
+    suffix = "".join(path.suffixes)
+    if suffix:
+        stem = path.name[: -len(suffix)]
+    else:
+        stem = path.name
+    if stem.endswith(f"_{sanitized}") or stem.endswith(f"-{sanitized}"):
+        return path
+    new_name = f"{stem}_{sanitized}{suffix}" if stem else f"{sanitized}{suffix}"
+    return path.with_name(new_name)
+
+
+def window_days(start_ms: int | None, end_ms: int | None) -> int | None:
+    if start_ms is None or end_ms is None:
+        return None
+    if end_ms <= start_ms:
+        return 0
+    span = end_ms - start_ms
+    return max(1, math.ceil(span / _DAY_MS))
+
+
+def load_offline_payload(path: Path | str) -> dict[str, Any]:
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as fh:
+        payload = yaml.safe_load(fh) or {}
+    if not isinstance(payload, MutableMapping):
+        raise ValueError(f"offline config {config_path} must be a mapping")
+    data = dict(payload)
+    datasets_raw = data.get("datasets")
+    if not isinstance(datasets_raw, Mapping):
+        datasets_raw = data.get("dataset_splits")
+    data["datasets"] = normalize_dataset_splits(datasets_raw)
+    return data
+
+
+@dataclass(frozen=True)
+class SplitArtifact:
+    split_name: str
+    version: str | None
+    split_start_ms: int | None
+    split_end_ms: int | None
+    artifact: Mapping[str, Any]
+    config_start_ms: int | None
+    config_end_ms: int | None
+    output_path: Path | None
+
+    @property
+    def tag(self) -> str:
+        return sanitize_tag(self.version, fallback=self.split_name)
+
+    @property
+    def split_metadata(self) -> dict[str, str]:
+        meta = {"name": self.split_name}
+        if self.version:
+            meta["version"] = self.version
+        return meta
+
+    @property
+    def configured_window(self) -> dict[str, str | int | None]:
+        return {
+            "start": ms_to_iso(self.config_start_ms),
+            "end": ms_to_iso(self.config_end_ms),
+            "start_ms": self.config_start_ms,
+            "end_ms": self.config_end_ms,
+        }
+
+
+def resolve_split_artifact(
+    payload: Mapping[str, Any],
+    split_name: str,
+    artifact_key: str,
+) -> SplitArtifact:
+    datasets = payload.get("datasets")
+    if not isinstance(datasets, Mapping):
+        raise KeyError("offline config does not define dataset splits")
+    split_cfg = datasets.get(split_name)
+    split_mapping = _coerce_mapping(split_cfg)
+    version = split_mapping.get("version")
+    split_start_ms = _parse_time_ms(split_mapping.get("start"))
+    split_end_ms = _parse_time_ms(split_mapping.get("end"))
+
+    artifact_cfg = split_mapping.get(artifact_key)
+    artifact_mapping = _coerce_mapping(artifact_cfg)
+
+    input_cfg = artifact_mapping.get("input") if isinstance(artifact_mapping.get("input"), Mapping) else None
+    if isinstance(input_cfg, Mapping):
+        config_start_ms = _parse_time_ms(input_cfg.get("start"))
+        config_end_ms = _parse_time_ms(input_cfg.get("end"))
+    else:
+        config_start_ms = None
+        config_end_ms = None
+    if config_start_ms is None:
+        config_start_ms = split_start_ms
+    if config_end_ms is None:
+        config_end_ms = split_end_ms
+
+    output_path_raw = artifact_mapping.get("output_path")
+    output_path = Path(str(output_path_raw)) if output_path_raw else None
+
+    return SplitArtifact(
+        split_name=split_mapping.get("name", split_name) or split_name,
+        version=str(version) if version is not None else None,
+        split_start_ms=split_start_ms,
+        split_end_ms=split_end_ms,
+        artifact=artifact_mapping,
+        config_start_ms=config_start_ms,
+        config_end_ms=config_end_ms,
+        output_path=output_path,
+    )

--- a/tests/test_offline_artifact_generators.py
+++ b/tests/test_offline_artifact_generators.py
@@ -1,0 +1,262 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+from scripts import build_adv as build_adv_cli
+from scripts import build_hourly_seasonality as hourly_cli
+from scripts import build_spread_seasonality as spread_cli
+from scripts import refresh_fees as refresh_fees_cli
+from scripts.offline_utils import apply_split_tag
+from utils_time import parse_time_to_ms
+
+
+@pytest.mark.parametrize("symbol", ["BTCUSDT"])
+def test_build_adv_split_uses_config(tmp_path, monkeypatch, symbol):
+    adv_base = tmp_path / "adv" / "adv.json"
+    config_path = tmp_path / "offline.yaml"
+    config_payload = {
+        "datasets": {
+            "sample": {
+                "version": "v99-train",
+                "start": "2020-01-01T00:00:00Z",
+                "end": "2020-01-31T00:00:00Z",
+                "adv": {
+                    "input": {
+                        "start": "2020-01-01T00:00:00Z",
+                        "end": "2020-01-21T00:00:00Z",
+                    },
+                    "output_path": str(adv_base),
+                },
+            }
+        }
+    }
+    config_path.write_text(yaml.safe_dump(config_payload))
+    rest_cfg = tmp_path / "rest.yaml"
+    rest_cfg.write_text("{}\n")
+
+    start_ms = parse_time_to_ms("2020-01-01T00:00:00Z")
+    end_ms = parse_time_to_ms("2020-01-21T00:00:00Z")
+
+    fetch_kwargs: dict = {}
+
+    def fake_fetch(session, symbols, **kwargs):
+        fetch_kwargs.update(kwargs)
+        ts_values = [start_ms + i * 86_400_000 for i in range(5)]
+        df = pd.DataFrame(
+            {
+                "ts_ms": ts_values,
+                "quote_asset_volume": np.linspace(1_000.0, 1_500.0, num=5),
+            }
+        )
+        return {symbols[0]: df}
+
+    class DummySession:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def write_stats(self, path):
+            self.stats_path = path
+
+    monkeypatch.setattr(build_adv_cli, "fetch_klines_for_symbols", fake_fetch)
+    monkeypatch.setattr(build_adv_cli, "RestBudgetSession", DummySession)
+    monkeypatch.setattr(build_adv_cli, "_load_universe", lambda _: ({}, []))
+
+    args = [
+        "--split",
+        "sample",
+        "--config",
+        str(config_path),
+        "--symbols",
+        symbol,
+        "--rest-budget-config",
+        str(rest_cfg),
+    ]
+    build_adv_cli.main(args)
+
+    assert fetch_kwargs["start_ms"] == start_ms
+    assert fetch_kwargs["end_ms"] == end_ms
+
+    out_path = apply_split_tag(adv_base, "v99-train")
+    assert out_path.exists()
+
+    payload = json.loads(out_path.read_text())
+    meta = payload["meta"]
+    assert meta["split"] == {"name": "sample", "version": "v99-train"}
+    assert meta["data_window"]["actual"]["start_ms"] == start_ms
+    assert meta["data_window"]["actual"]["end_ms"] == end_ms
+    assert meta["data_window"]["config"]["end_ms"] == end_ms
+
+
+def test_refresh_fees_split_output(tmp_path, monkeypatch):
+    fees_base = tmp_path / "fees" / "fees.json"
+    config_path = tmp_path / "offline.yaml"
+    config_payload = {
+        "datasets": {
+            "sample": {
+                "version": "v2",
+                "start": "2019-01-01T00:00:00Z",
+                "end": "2019-06-30T00:00:00Z",
+                "fees": {
+                    "input": {
+                        "start": "2019-01-01T00:00:00Z",
+                        "end": "2019-04-01T00:00:00Z",
+                    },
+                    "output_path": str(fees_base),
+                },
+            }
+        }
+    }
+    config_path.write_text(yaml.safe_dump(config_payload))
+
+    monkeypatch.setattr(refresh_fees_cli, "fetch_exchange_symbols", lambda timeout: ["BTCUSDT"])
+
+    snapshot_payload = {
+        "metadata": {"built_at": "2019-04-01T00:00:00Z"},
+        "fees": {"BTCUSDT": {"maker_bps": 10, "taker_bps": 10}},
+    }
+    dummy_snapshot = SimpleNamespace(
+        payload=snapshot_payload,
+        records={"BTCUSDT": object()},
+        symbols={"BTCUSDT"},
+        maker_bps_default=None,
+        taker_bps_default=None,
+        taker_discount_mult=None,
+        maker_discount_mult=None,
+    )
+    monkeypatch.setattr(refresh_fees_cli, "load_public_fee_snapshot", lambda **_: dummy_snapshot)
+
+    refresh_fees_cli.main(["--split", "sample", "--config", str(config_path)])
+
+    out_path = apply_split_tag(fees_base, "v2")
+    assert out_path.exists()
+    payload = json.loads(out_path.read_text())
+    meta = payload["metadata"]
+    assert meta["split"] == {"name": "sample", "version": "v2"}
+    assert meta["data_window"]["actual"]["end"] == "2019-04-01T00:00:00Z"
+    assert meta["data_window"]["config"]["end"] == "2019-04-01T00:00:00Z"
+    assert meta["output_path"].endswith("_v2.json")
+
+
+def test_build_hourly_seasonality_split(tmp_path, monkeypatch):
+    data_path = tmp_path / "seasonality.csv"
+    start_ms = parse_time_to_ms("2021-04-01T00:00:00Z")
+    end_ms = parse_time_to_ms("2021-05-01T00:00:00Z")
+    extra_ms = parse_time_to_ms("2021-06-01T00:00:00Z")
+    ts_values = [start_ms + i * 3_600_000 for i in range(10)] + [end_ms, extra_ms]
+    df = pd.DataFrame(
+        {
+            "ts_ms": ts_values,
+            "liquidity": np.linspace(1.0, 2.0, num=len(ts_values)),
+            "latency_ms": np.linspace(10, 20, num=len(ts_values)),
+            "spread": np.linspace(0.1, 0.2, num=len(ts_values)),
+        }
+    )
+    df.to_csv(data_path, index=False)
+
+    config_path = tmp_path / "offline.yaml"
+    output_base = tmp_path / "seasonality" / "profile.json"
+    config_payload = {
+        "datasets": {
+            "sample": {
+                "version": "v-season",
+                "start": "2021-03-01T00:00:00Z",
+                "end": "2021-06-30T00:00:00Z",
+                "seasonality": {
+                    "input": {
+                        "start": "2021-04-01T00:00:00Z",
+                        "end": "2021-05-01T00:00:00Z",
+                    },
+                    "output_path": str(output_base),
+                },
+            }
+        }
+    }
+    config_path.write_text(yaml.safe_dump(config_payload))
+
+    args = [
+        "prog",
+        "--data",
+        str(data_path),
+        "--split",
+        "sample",
+        "--config",
+        str(config_path),
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    hourly_cli.main()
+
+    out_path = apply_split_tag(output_base, "v-season")
+    assert out_path.exists()
+    payload = json.loads(out_path.read_text())
+    meta = payload["metadata"]
+    assert meta["split"] == {"name": "sample", "version": "v-season"}
+    assert meta["data_window"]["config"]["end"] == "2021-05-01T00:00:00Z"
+    assert meta["data_window"]["actual"]["end"] == "2021-05-01T00:00:00Z"
+    assert meta["data_window"]["actual"]["start"] == "2021-04-01T00:00:00Z"
+
+
+def test_build_spread_seasonality_split(tmp_path, monkeypatch):
+    data_path = tmp_path / "spread.csv"
+    start_ms = parse_time_to_ms("2022-07-01T00:00:00Z")
+    end_ms = parse_time_to_ms("2022-07-10T00:00:00Z")
+    rows = []
+    for i in range(15):
+        ts = start_ms + i * 3_600_000
+        rows.append({"timestamp": ts, "high": 102.0 + i, "low": 100.0 + i})
+    rows.append({"timestamp": end_ms, "high": 200.0, "low": 199.0})
+    rows.append({"timestamp": parse_time_to_ms("2022-08-01T00:00:00Z"), "high": 150.0, "low": 149.0})
+    pd.DataFrame(rows).to_csv(data_path, index=False)
+
+    config_path = tmp_path / "offline.yaml"
+    output_base = tmp_path / "spread" / "profile.json"
+    config_payload = {
+        "datasets": {
+            "sample": {
+                "version": "v-spread",
+                "start": "2022-06-01T00:00:00Z",
+                "end": "2022-08-31T00:00:00Z",
+                "seasonality": {
+                    "input": {
+                        "start": "2022-07-01T00:00:00Z",
+                        "end": "2022-07-10T00:00:00Z",
+                    },
+                    "output_path": str(output_base),
+                },
+            }
+        }
+    }
+    config_path.write_text(yaml.safe_dump(config_payload))
+
+    args = [
+        "prog",
+        "--data",
+        str(data_path),
+        "--split",
+        "sample",
+        "--config",
+        str(config_path),
+        "--ts-col",
+        "timestamp",
+    ]
+    monkeypatch.setattr(sys, "argv", args)
+    spread_cli.main()
+
+    out_path = apply_split_tag(output_base, "v-spread")
+    assert out_path.exists()
+    payload = json.loads(out_path.read_text())
+    meta = payload["metadata"]
+    assert meta["split"] == {"name": "sample", "version": "v-spread"}
+    assert meta["data_window"]["config"]["start"] == "2022-07-01T00:00:00Z"
+    assert meta["data_window"]["actual"]["end"].startswith("2022-07-10")


### PR DESCRIPTION
## Summary
- add a shared helper to resolve dataset split metadata, compute versioned output paths, and format data-window timestamps
- update the ADV, fee refresh, hourly seasonality, and spread seasonality scripts to accept --split/--config, clamp to split windows, and embed split metadata and data-window details in outputs
- add smoke-style pytest coverage that builds fixtures for a sample split and asserts path and date handling match the offline config

## Testing
- pytest tests/test_offline_artifact_generators.py

------
https://chatgpt.com/codex/tasks/task_e_68d2798eeb18832fa8e966c03ec6d00d