### PR TITLE
feat: route offline dataset splits into training and sims

### DIFF
--- a/script_eval.py
+++ b/script_eval.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from core_config import load_config
 from service_eval import from_config
+from scripts.offline_utils import resolve_split_bundle
 
 
 def main() -> None:
@@ -44,9 +45,83 @@ def main() -> None:
         default="benchmarks/sim_kpi_thresholds.json",
         help="JSON с допустимыми диапазонами KPI",
     )
+    p.add_argument(
+        "--offline-config",
+        default="configs/offline.yaml",
+        help="Path to offline dataset configuration",
+    )
+    p.add_argument(
+        "--dataset-split",
+        default="test",
+        help="Dataset split identifier (use 'none' to disable offline bundle integration)",
+    )
     args = p.parse_args()
 
     cfg = load_config(args.config)
+    split_key = (args.dataset_split or "").strip()
+    seasonality_path: str | None = None
+    fees_path: str | None = None
+    adv_path: str | None = None
+    seasonality_hash: str | None = None
+    if split_key and split_key.lower() not in {"none", "null"}:
+        try:
+            offline_bundle = resolve_split_bundle(args.offline_config, split_key)
+        except FileNotFoundError as exc:
+            raise SystemExit(f"Offline config not found: {args.offline_config}") from exc
+        except KeyError as exc:
+            raise SystemExit(
+                f"Dataset split '{split_key}' not found in offline config {args.offline_config}"
+            ) from exc
+        except ValueError as exc:
+            raise SystemExit(f"Failed to resolve offline split '{split_key}': {exc}") from exc
+        if offline_bundle.version:
+            print(
+                f"Resolved offline dataset split '{offline_bundle.name}' version {offline_bundle.version}"
+            )
+        else:
+            print(f"Resolved offline dataset split '{offline_bundle.name}'")
+        seasonality_art = offline_bundle.artifacts.get("seasonality")
+        if seasonality_art:
+            seasonality_path = seasonality_art.path.as_posix()
+            raw_hash = seasonality_art.info.artifact.get("verification_hash")
+            if raw_hash:
+                seasonality_hash = str(raw_hash)
+        fees_art = offline_bundle.artifacts.get("fees")
+        if fees_art:
+            fees_path = fees_art.path.as_posix()
+        adv_art = offline_bundle.artifacts.get("adv")
+        if adv_art:
+            adv_path = adv_art.path.as_posix()
+
+    cfg_dict = cfg.dict()
+    if seasonality_path:
+        cfg_dict["liquidity_seasonality_path"] = seasonality_path
+        cfg_dict["latency_seasonality_path"] = seasonality_path
+        latency_block = cfg_dict.setdefault("latency", {})
+        if not latency_block.get("latency_seasonality_path"):
+            latency_block["latency_seasonality_path"] = seasonality_path
+        if seasonality_hash:
+            cfg_dict["liquidity_seasonality_hash"] = seasonality_hash
+    if fees_path:
+        fees_block = cfg_dict.setdefault("fees", {})
+        if not fees_block.get("path"):
+            fees_block["path"] = fees_path
+    if adv_path:
+        adv_block = cfg_dict.setdefault("adv", {})
+        if not adv_block.get("path"):
+            adv_block["path"] = adv_path
+        execution_block = cfg_dict.setdefault("execution", {})
+        if isinstance(execution_block, dict):
+            bar_block = execution_block.setdefault("bar_capacity_base", {})
+            if not bar_block.get("adv_base_path"):
+                bar_block["adv_base_path"] = adv_path
+    cfg = cfg.__class__.parse_obj(cfg_dict)
+
+    if seasonality_path and not Path(seasonality_path).exists():
+        raise FileNotFoundError(
+            f"Liquidity seasonality file not found: {seasonality_path}. Run offline builders first."
+        )
+
     metrics = from_config(
         cfg,
         snapshot_config_path=args.config,

--- a/scripts/offline_utils.py
+++ b/scripts/offline_utils.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import json
 import math
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, MutableMapping
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
 
 import yaml
 
@@ -157,3 +158,193 @@ def resolve_split_artifact(
         config_end_ms=config_end_ms,
         output_path=output_path,
     )
+
+
+def _extract_metadata_block(payload: Any) -> Mapping[str, Any] | None:
+    if isinstance(payload, Mapping):
+        for key in ("metadata", "meta"):
+            value = payload.get(key)
+            if isinstance(value, Mapping):
+                return value
+        for value in payload.values():
+            nested = _extract_metadata_block(value)
+            if isinstance(nested, Mapping):
+                return nested
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        for item in payload:
+            nested = _extract_metadata_block(item)
+            if isinstance(nested, Mapping):
+                return nested
+    return None
+
+
+def load_artifact_metadata(path: Path) -> Mapping[str, Any] | None:
+    with Path(path).open("r", encoding="utf-8") as fh:
+        try:
+            payload = json.load(fh)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"failed to parse metadata from {path}: {exc}") from exc
+    metadata = _extract_metadata_block(payload)
+    return metadata if isinstance(metadata, Mapping) else None
+
+
+def _extract_window_bounds(entry: Mapping[str, Any] | None) -> tuple[int | None, int | None]:
+    if not isinstance(entry, Mapping):
+        return (None, None)
+    start_ms = None
+    end_ms = None
+    for key in ("start_ms", "start_ts", "start", "from", "begin"):
+        if key in entry and entry[key] is not None:
+            try:
+                start_ms = _parse_time_ms(entry[key])
+            except Exception:  # pragma: no cover - defensive
+                continue
+            break
+    for key in ("end_ms", "end_ts", "end", "to", "stop"):
+        if key in entry and entry[key] is not None:
+            try:
+                end_ms = _parse_time_ms(entry[key])
+            except Exception:  # pragma: no cover - defensive
+                continue
+            break
+    return start_ms, end_ms
+
+
+def validate_artifact_window(
+    split_info: SplitArtifact,
+    metadata: Mapping[str, Any],
+    *,
+    artifact_name: str,
+) -> None:
+    window_block = metadata.get("data_window")
+    if not isinstance(window_block, Mapping):
+        return
+    actual_block = window_block.get("actual")
+    actual_start, actual_end = _extract_window_bounds(actual_block if isinstance(actual_block, Mapping) else {})
+    issues: list[str] = []
+    split_start = split_info.split_start_ms
+    split_end = split_info.split_end_ms
+    if actual_start is not None and split_start is not None and actual_start < split_start:
+        issues.append(
+            f"start {ms_to_iso(actual_start)} precedes split start {ms_to_iso(split_start)}"
+        )
+    if actual_end is not None and split_end is not None and actual_end > split_end:
+        issues.append(
+            f"end {ms_to_iso(actual_end)} exceeds split end {ms_to_iso(split_end)}"
+        )
+    if issues:
+        message = "; ".join(issues)
+        raise ValueError(f"{artifact_name} window out of range: {message}")
+
+
+@dataclass(frozen=True)
+class ResolvedArtifact:
+    name: str
+    info: SplitArtifact
+    path: Path
+    metadata: Mapping[str, Any] | None
+
+
+@dataclass(frozen=True)
+class ResolvedSplitBundle:
+    name: str
+    version: str | None
+    artifacts: Dict[str, ResolvedArtifact]
+
+
+def resolve_artifact_path(
+    split_info: SplitArtifact,
+    *,
+    artifact_name: str,
+    require_metadata: bool = True,
+    validate: bool = True,
+) -> tuple[Path, Mapping[str, Any] | None]:
+    base_path = split_info.output_path
+    if base_path is None:
+        raise ValueError(
+            f"offline config for split {split_info.split_name!r} "
+            f"is missing {artifact_name}.output_path"
+        )
+    resolved_path = apply_split_tag(base_path, split_info.tag)
+    if not resolved_path.exists():
+        raise FileNotFoundError(
+            f"resolved {artifact_name} artifact not found: {resolved_path}"
+        )
+    metadata: Mapping[str, Any] | None = None
+    if require_metadata or validate:
+        metadata = load_artifact_metadata(resolved_path)
+        if metadata is None and require_metadata:
+            raise ValueError(
+                f"{artifact_name} artifact {resolved_path} does not contain metadata"
+            )
+    if validate and metadata is not None:
+        try:
+            validate_artifact_window(split_info, metadata, artifact_name=artifact_name)
+        except ValueError as exc:
+            raise ValueError(f"{artifact_name} artifact {resolved_path}: {exc}") from exc
+    elif validate and metadata is None:
+        raise ValueError(
+            f"{artifact_name} artifact {resolved_path} is missing metadata for validation"
+        )
+    return resolved_path, metadata
+
+
+def resolve_split_bundle(
+    payload_or_path: Mapping[str, Any] | str | Path,
+    split_name: str,
+    *,
+    artifact_keys: Sequence[str] = ("seasonality", "adv", "fees"),
+    require_metadata: bool = True,
+    validate: bool = True,
+) -> ResolvedSplitBundle:
+    if isinstance(payload_or_path, (str, Path)):
+        payload = load_offline_payload(payload_or_path)
+    else:
+        payload = payload_or_path
+    datasets = payload.get("datasets")
+    if not isinstance(datasets, Mapping):
+        raise KeyError("offline config does not define dataset splits")
+    split_cfg = datasets.get(split_name)
+    split_mapping = _coerce_mapping(split_cfg)
+    version = split_mapping.get("version")
+    artifacts: Dict[str, ResolvedArtifact] = {}
+    for key in artifact_keys:
+        artifact_cfg = split_mapping.get(key)
+        if artifact_cfg is None:
+            continue
+        try:
+            split_info = resolve_split_artifact(payload, split_name, key)
+        except KeyError:
+            continue
+        path, metadata = resolve_artifact_path(
+            split_info,
+            artifact_name=key,
+            require_metadata=require_metadata,
+            validate=validate,
+        )
+        artifacts[key] = ResolvedArtifact(
+            name=key,
+            info=split_info,
+            path=path,
+            metadata=metadata,
+        )
+        if version is None:
+            version = split_info.version
+    resolved_version = str(version) if version is not None else None
+    return ResolvedSplitBundle(name=split_name, version=resolved_version, artifacts=artifacts)
+
+
+__all__ = [
+    "SplitArtifact",
+    "ResolvedArtifact",
+    "ResolvedSplitBundle",
+    "apply_split_tag",
+    "window_days",
+    "load_offline_payload",
+    "load_artifact_metadata",
+    "resolve_artifact_path",
+    "resolve_split_artifact",
+    "resolve_split_bundle",
+    "sanitize_tag",
+    "validate_artifact_window",
+]


### PR DESCRIPTION
## Summary
- add dataset bundle resolution helpers and metadata validation in `scripts/offline_utils`
- allow training, backtesting and evaluation entrypoints to select offline artefact splits via CLI
- default seasonality, fees and ADV paths from the chosen split while validating resolved files

## Testing
- pytest tests/test_offline_artifact_generators.py

------
https://chatgpt.com/codex/tasks/task_e_68d28068b8a8832fa4b4f08b28bae3d8