### PR TITLE
Implement gap-aware ffill validation for LeakGuard

### DIFF
--- a/leakguard.py
+++ b/leakguard.py
@@ -1,11 +1,12 @@
 # data/leakguard.py
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Optional
 
+import numpy as np
 import pandas as pd
+from pandas.api import types as pdt
 
 
 @dataclass
@@ -38,33 +39,133 @@ class LeakGuard:
         d["decision_ts"] = d[ts_col].astype("int64") + int(self.cfg.decision_delay_ms)
         return d
 
-    def validate_ffill_gaps(self, df: pd.DataFrame, *, ts_col: str, group_keys: list[str], value_cols: list[str], max_gap_ms: int) -> pd.DataFrame:
+    def validate_ffill_gaps(
+        self,
+        df: pd.DataFrame,
+        *,
+        ts_col: str,
+        group_keys: list[str],
+        value_cols: list[str],
+        max_gap_ms: int,
+    ) -> pd.DataFrame:
         """
         Выставляет NaN, если «держание» значения длится дольше max_gap_ms (защита от чрезмерного ffill).
         """
+        if ts_col not in df.columns:
+            raise ValueError(f"'{ts_col}' не найден в датафрейме")
+        missing_group = [col for col in group_keys if col not in df.columns]
+        if missing_group:
+            raise ValueError(f"Отсутствуют ключи группировки: {missing_group}")
+        missing_value_cols = [col for col in value_cols if col not in df.columns]
+        if missing_value_cols:
+            raise ValueError(f"Отсутствуют колонки для проверки: {missing_value_cols}")
+
+        if not value_cols:
+            return df.copy()
+
+        try:
+            max_gap = int(max_gap_ms)
+        except (TypeError, ValueError) as err:
+            raise ValueError("max_gap_ms должен быть целым числом") from err
+        if max_gap < 0:
+            raise ValueError("max_gap_ms должен быть неотрицательным")
+
         d = df.copy()
-        max_gap = int(max_gap_ms)
-        d = d.sort_values(group_keys + [ts_col])
-        for col in value_cols:
-            # вычислим длительность с момента последнего ненулевого значения
-            last_ts = None
-            last_val = None
-            bad_idx = []
-            for idx, row in d.iterrows():
-                ts = int(row[ts_col])
-                val = row[col]
-                if (val is None) or (isinstance(val, float) and math.isnan(val)):
-                    # пусто — продолжаем держать gap
+        d["__orig_order__"] = np.arange(len(d), dtype="int64")
+
+        ts_numeric = pd.to_numeric(d[ts_col], errors="raise")
+        if ts_numeric.isna().any():
+            raise ValueError("Обнаружены пропущенные значения в столбце с таймштампами")
+        d[ts_col] = ts_numeric.astype("int64")
+
+        sort_columns = list(group_keys) + [ts_col, "__orig_order__"]
+        d = d.sort_values(sort_columns, kind="mergesort").copy()
+
+        if group_keys:
+            grouped = d.groupby(group_keys, sort=False, dropna=False)
+        else:
+            grouped = d.groupby(lambda _: 0, sort=False)
+        masks: dict[str, pd.Series] = {
+            col: pd.Series(False, index=d.index) for col in value_cols
+        }
+
+        for _, idx in grouped.groups.items():
+            group_df = d.loc[idx]
+            ts_values = group_df[ts_col].to_numpy(dtype="int64")
+
+            for col in value_cols:
+                values = group_df[col]
+                invalid_positions: list[int] = []
+
+                last_value = None
+                has_last_value = False
+                run_start_ts: Optional[int] = None
+                invalid_run = False
+
+                for row_idx, ts_val, cell in zip(values.index, ts_values, values.to_numpy()):
+                    if pd.isna(cell):
+                        last_value = None
+                        has_last_value = False
+                        run_start_ts = None
+                        invalid_run = False
+                        continue
+
+                    if (not has_last_value) or (cell != last_value):
+                        last_value = cell
+                        has_last_value = True
+                        run_start_ts = int(ts_val)
+                        invalid_run = False
+
+                    if invalid_run:
+                        invalid_positions.append(row_idx)
+                        continue
+
+                    if run_start_ts is None:
+                        continue
+
+                    if int(ts_val) - run_start_ts > max_gap:
+                        invalid_positions.append(row_idx)
+                        invalid_run = True
+
+                if invalid_positions:
+                    masks[col].loc[invalid_positions] = True
+
+        for col, mask in masks.items():
+            if mask.any():
+                if pdt.is_numeric_dtype(d[col].dtype):
+                    d[col] = d[col].where(~mask, other=np.nan)
+                else:
+                    d[col] = d[col].where(~mask, other=pd.NA)
+
+        min_lookback = int(getattr(self.cfg, "min_lookback_ms", 0) or 0)
+        if min_lookback > 0:
+            if group_keys:
+                grouped_after = d.groupby(group_keys, sort=False, dropna=False)
+            else:
+                grouped_after = d.groupby(lambda _: 0, sort=False)
+            for _, idx in grouped_after.groups.items():
+                group_df = d.loc[idx]
+                if group_df.empty:
                     continue
-                if last_ts is not None and (ts - last_ts) > max_gap:
-                    # заполнившееся значение после слишком большого разрыва — оставляем как есть,
-                    # а вот все «протянутые» интервалы должны стать NaN. Проще — обнулим значение здесь.
-                    pass
-                last_ts = ts
-                last_val = val
-            # Упростим: заменим слишком длинные растяжки на NaN через rolling last-observed-gap
-            # (без сложной индексации — производимая эвристика)
-            # Для гарантии корректности — пользователь может вместо этого использовать строгий tolerance в asof.
-            # Здесь оставим «no-op», чтобы не разрушать данные.
-            _ = last_val
+                first_ts = int(group_df[ts_col].iloc[0])
+                for col in value_cols:
+                    valid_idx = group_df.index[~group_df[col].isna()]
+                    if valid_idx.empty:
+                        raise ValueError(
+                            f"Недостаточно данных для '{col}' внутри группы {group_keys}: всё NaN"
+                        )
+                    first_valid_ts = int(group_df.loc[valid_idx[0], ts_col])
+                    if first_valid_ts - first_ts > min_lookback:
+                        if group_keys:
+                            group_info = group_df[group_keys].iloc[0].to_dict()
+                        else:
+                            group_info = {"group": "__all__"}
+                        raise ValueError(
+                            "Нарушено требование min_lookback_ms: колонка "
+                            f"'{col}' для группы {group_info} имеет первую доступную точку "
+                            f"только через {first_valid_ts - first_ts} мс"
+                        )
+
+        d = d.sort_values("__orig_order__", kind="mergesort")
+        d = d.drop(columns="__orig_order__")
         return d

--- a/tests/test_leakguard_ffill.py
+++ b/tests/test_leakguard_ffill.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from leakguard import LeakConfig, LeakGuard
+
+
+def test_validate_ffill_gaps_enforces_span_limits_and_preserves_decision_delay():
+    guard = LeakGuard(LeakConfig(decision_delay_ms=500))
+    df = pd.DataFrame(
+        {
+            "symbol": [
+                "ETH",
+                "ETH",
+                "ETH",
+                "ETH",
+                "ETH",
+                "ETH",
+                "BTC",
+                "BTC",
+                "BTC",
+            ],
+            "ts_ms": [3200, 0, 1500, 4000, 2200, 1000, 0, 500, 4000],
+            "feature": [1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 5.0, 5.0, 5.0],
+            "other": [20.0, 10.0, 10.0, 30.0, 10.0, 10.0, 1.0, 1.0, 1.0],
+        }
+    )
+
+    df_with_decision = guard.attach_decision_time(df, ts_col="ts_ms")
+    validated = guard.validate_ffill_gaps(
+        df_with_decision,
+        ts_col="ts_ms",
+        group_keys=["symbol"],
+        value_cols=["feature", "other"],
+        max_gap_ms=1_500,
+    )
+
+    # Decision timestamps should remain consistent with the configured delay.
+    expected_decision = df_with_decision["ts_ms"].astype("int64") + 500
+    pd.testing.assert_series_equal(
+        validated["decision_ts"].astype("int64"), expected_decision.astype("int64"), check_names=False
+    )
+
+    # Original ordering must be preserved to avoid altering downstream expectations.
+    assert list(validated.index) == list(df_with_decision.index)
+
+    expected_feature = [np.nan, 1.0, 1.0, 2.0, np.nan, 1.0, 5.0, 5.0, np.nan]
+    expected_other = [20.0, 10.0, 10.0, 30.0, np.nan, 10.0, 1.0, 1.0, np.nan]
+
+    np.testing.assert_allclose(
+        validated["feature"].to_numpy(),
+        np.array(expected_feature, dtype=float),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        validated["other"].to_numpy(),
+        np.array(expected_other, dtype=float),
+        equal_nan=True,
+    )
+
+
+def test_validate_ffill_gaps_detects_min_lookback_violations():
+    guard = LeakGuard(LeakConfig(min_lookback_ms=1_500))
+    df = pd.DataFrame(
+        {
+            "symbol": ["ETH", "ETH", "ETH", "ETH"],
+            "ts_ms": [0, 500, 1_000, 3_500],
+            "feature": [np.nan, np.nan, np.nan, 1.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="min_lookback_ms"):
+        guard.validate_ffill_gaps(
+            df,
+            ts_col="ts_ms",
+            group_keys=["symbol"],
+            value_cols=["feature"],
+            max_gap_ms=10_000,
+        )
+
+
+def test_validate_ffill_gaps_requires_timestamp_values():
+    guard = LeakGuard()
+    df = pd.DataFrame(
+        {
+            "symbol": ["ETH", "ETH"],
+            "ts_ms": [0, np.nan],
+            "feature": [1.0, 1.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="таймштампами"):
+        guard.validate_ffill_gaps(
+            df,
+            ts_col="ts_ms",
+            group_keys=["symbol"],
+            value_cols=["feature"],
+            max_gap_ms=1_000,
+        )


### PR DESCRIPTION
## Summary
- implement proper gap tracking, sorting, and min-lookback enforcement in `LeakGuard.validate_ffill_gaps`
- add focused tests covering acceptable/excessive gaps, decision-delay integration, and input validation

## Testing
- pytest tests/test_leakguard_ffill.py

------
https://chatgpt.com/codex/tasks/task_e_68d289a47f68832fb631c25ab4541a83