### PR TITLE
Fix quantizer handling of missing percent price multipliers

### DIFF
--- a/quantizer.py
+++ b/quantizer.py
@@ -129,8 +129,8 @@ class SymbolFilters:
             qty_min=_to_float(ls.get("minQty"), 0.0),
             qty_max=_to_float(ls.get("maxQty"), float("inf")),
             min_notional=_to_float(mn.get("minNotional"), 0.0),
-            multiplier_up=_to_float(ppbs.get("multiplierUp"), None) if ppbs else None,
-            multiplier_down=_to_float(ppbs.get("multiplierDown"), None) if ppbs else None,
+            multiplier_up=_to_optional_float(ppbs.get("multiplierUp")) if ppbs else None,
+            multiplier_down=_to_optional_float(ppbs.get("multiplierDown")) if ppbs else None,
             quote_precision=quote_precision,
             commission_step=commission_step,
         )

--- a/tests/test_quantizer_entrypoints.py
+++ b/tests/test_quantizer_entrypoints.py
@@ -41,6 +41,7 @@ from core_config import Components, load_config
 from core_config import RetryConfig
 import di_registry
 from impl_quantizer import QuantizerImpl, QuantizerConfig
+from quantizer import Quantizer
 
 
 def _components_stub() -> Components:
@@ -162,3 +163,23 @@ def test_quantizer_refresh_is_debounced(monkeypatch, tmp_path):
     QuantizerImpl(cfg)
 
     assert len(run_calls) == 1
+
+
+def test_quantizer_accepts_percent_price_without_multipliers():
+    filters = {
+        "BTCUSDT": {
+            "PRICE_FILTER": {"tickSize": "0.01"},
+            "LOT_SIZE": {"stepSize": "0.001"},
+            "MIN_NOTIONAL": {"minNotional": "10"},
+            # Missing multiplierUp/multiplierDown should not raise
+            "PERCENT_PRICE_BY_SIDE": {
+                "bidMultiplierUp": "1.1",
+                "bidMultiplierDown": "0.9",
+            },
+        }
+    }
+
+    quantizer = Quantizer(filters)
+    symbol_filters = quantizer._filters["BTCUSDT"]
+    assert symbol_filters.multiplier_up is None
+    assert symbol_filters.multiplier_down is None


### PR DESCRIPTION
## Summary
- treat missing percent price multipliers as optional floats to avoid exceptions
- add regression test ensuring Quantizer handles missing multipliers

## Testing
- pytest tests/test_quantizer_entrypoints.py

------
https://chatgpt.com/codex/tasks/task_e_68d28f2d4dc4832fb456e5cbcd44b2ce