### PR TITLE
Import Decimal in mediator

### DIFF
--- a/mediator.py
+++ b/mediator.py
@@ -13,6 +13,7 @@ Mediator — координатор между средой, LOB/симулят�
 """
 
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any, Dict, List, Tuple, Optional, TYPE_CHECKING, Mapping
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Summary
- import Decimal from the standard library in mediator so ExecReport creation uses the proper symbol

## Testing
- pytest tests/test_mediator_quantization.py

------
https://chatgpt.com/codex/tasks/task_e_68d293cb9240832fbeae4be4d120ed2f