### PR TITLE
Fix calibration imports for calibration utilities

### DIFF
--- a/app.py
+++ b/app.py
@@ -3550,7 +3550,7 @@ with tabs[18]:
     import json
     import numpy as np
     import pandas as pd
-    from training.calibration import (
+    from calibration import (
         fit_calibrator,
         BaseCalibrator,
         evaluate_before_after,

--- a/apply_calibrator.py
+++ b/apply_calibrator.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import pandas as pd
 
-from training.calibration import BaseCalibrator
+from calibration import BaseCalibrator
 
 
 def _read_table(path: str) -> pd.DataFrame:

--- a/train_calibrator.py
+++ b/train_calibrator.py
@@ -9,7 +9,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-from training.calibration import (
+from calibration import (
     BaseCalibrator,
     calibration_table,
     evaluate_before_after,


### PR DESCRIPTION
## Summary
- update calibration CLI scripts to import from the root-level calibration module
- align Streamlit probability calibration tab to use the same module so the UI loads

## Testing
- python apply_calibrator.py --help
- python train_calibrator.py --help
- python - <<'PY'
from calibration import (
    fit_calibrator,
    BaseCalibrator,
    evaluate_before_after,
    calibration_table,
)
print('calibration imports ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d2987a3bb8832fac0d1c97e5001eee