### PR TITLE
Update training imports to top-level modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -3109,7 +3109,7 @@ with tabs[14]:
     import os
     import pandas as pd
     import yaml
-    from training.tcost import effective_return_series
+    from trainingtcost import effective_return_series
 
     def _read_table(path: str) -> pd.DataFrame:
         ext = os.path.splitext(path)[1].lower()
@@ -3199,7 +3199,7 @@ with tabs[15]:
 
     import os
     import pandas as pd
-    from training.no_trade import compute_no_trade_mask
+    from no_trade import compute_no_trade_mask
 
     def _read_table_mask(path: str) -> pd.DataFrame:
         ext = os.path.splitext(path)[1].lower()
@@ -3279,7 +3279,7 @@ with tabs[16]:
     import json
     import pandas as pd
     import yaml
-    from training.splits import make_walkforward_splits
+    from splits import make_walkforward_splits
 
     def _read_table_wf(path: str) -> pd.DataFrame:
         ext = os.path.splitext(path)[1].lower()
@@ -3397,7 +3397,7 @@ with tabs[17]:
 
     import os
     import pandas as pd
-    from training.threshold_tuner import (
+    from threshold_tuner import (
         TuneConfig,
         tune_threshold,
         load_min_signal_gap_s_from_yaml,
@@ -3686,7 +3686,7 @@ with tabs[19]:
     import os
     import numpy as np
     import pandas as pd
-    from training.drift import (
+    from drift import (
         make_baseline,
         save_baseline_json,
         load_baseline_json,

--- a/check_drift.py
+++ b/check_drift.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import numpy as np
 import pandas as pd
 
-from training.drift import compute_psi, load_baseline_json, default_feature_list
+from drift import compute_psi, load_baseline_json, default_feature_list
 
 
 def _read_table(path: str) -> pd.DataFrame:

--- a/make_costaware_targets.py
+++ b/make_costaware_targets.py
@@ -9,7 +9,7 @@ import pandas as pd
 import yaml
 from pydantic import BaseModel, Field
 
-from training.tcost import effective_return_series
+from trainingtcost import effective_return_series
 
 
 class SimFeesConfig(BaseModel):

--- a/make_drift_baseline.py
+++ b/make_drift_baseline.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import numpy as np
 import pandas as pd
 
-from training.drift import make_baseline, save_baseline_json, default_feature_list
+from drift import make_baseline, save_baseline_json, default_feature_list
 
 
 def _read_table(path: str) -> pd.DataFrame:

--- a/make_walkforward_splits.py
+++ b/make_walkforward_splits.py
@@ -8,7 +8,7 @@ import os
 import pandas as pd
 import yaml
 
-from training.splits import make_walkforward_splits
+from splits import make_walkforward_splits
 
 
 def _read_table(path: str) -> pd.DataFrame:

--- a/tune_threshold.py
+++ b/tune_threshold.py
@@ -3,7 +3,7 @@ import os
 
 import pandas as pd
 
-from training.threshold_tuner import (
+from threshold_tuner import (
     TuneConfig,
     tune_threshold,
     load_min_signal_gap_s_from_yaml,


### PR DESCRIPTION
## Summary
- update CLI scripts to import helper functions from their new top-level modules
- align Streamlit tabs with the same module paths for cost-aware targets, walk-forward splits, drift monitoring, threshold tuning, and no-trade masks

## Testing
- `python - <<'PY'
import importlib
import runpy
import sys

std_logging = importlib.import_module('logging')
sys.modules['logging'] = std_logging

try:
    runpy.run_path('/workspace/TradingBot/make_costaware_targets.py', run_name='__main__')
except SystemExit:
    pass
PY`
- `python - <<'PY'
import importlib
import runpy
import sys

scripts = [
    ('make_walkforward_splits.py', ['--help']),
    ('check_drift.py', ['--help']),
    ('make_drift_baseline.py', ['--help']),
    ('tune_threshold.py', ['--help']),
]

std_logging = importlib.import_module('logging')
sys.modules['logging'] = std_logging

for script, args in scripts:
    print(f"Running {script} {' '.join(args)}")
    sys.argv = [script, *args]
    sys.path = [p for p in sys.path if p and not p.endswith('TradingBot')]
    sys.path.append('/workspace/TradingBot')
    try:
        runpy.run_path(f'/workspace/TradingBot/{script}', run_name='__main__')
    except SystemExit:
        pass
    print()
PY`
- `python - <<'PY'
import importlib
import runpy
import sys

std_logging = importlib.import_module('logging')
sys.modules['logging'] = std_logging

sys.argv = ['check_drift.py', '--help']
sys.path = [p for p in sys.path if p and not p.endswith('TradingBot')]
sys.path.append('/workspace/TradingBot')
try:
    runpy.run_path('/workspace/TradingBot/check_drift.py', run_name='__main__')
except SystemExit as exc:
    print(f'Exited with code {exc.code}')
print('Done running check_drift help')
PY`
- `python - <<'PY'
import importlib
import sys

std_logging = importlib.import_module('logging')
sys.modules['logging'] = std_logging

sys.path = [p for p in sys.path if p and not p.endswith('TradingBot')]
sys.path.append('/workspace/TradingBot')

try:
    import app  # noqa: F401
    print('Imported app successfully')
except Exception as exc:
    print(f'Failed to import app: {exc}')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d2a07f9aec832fb3c9807d92fea247