### PR TITLE
Fix build_training_table direct imports

### DIFF
--- a/build_training_table.py
+++ b/build_training_table.py
@@ -8,9 +8,9 @@ from typing import List, Optional
 
 import pandas as pd
 
-from data.asof_join import AsofMerger, AsofSpec
-from data.leakguard import LeakConfig, LeakGuard
-from data.labels import LabelConfig, LabelBuilder
+from asof_join import AsofMerger, AsofSpec
+from leakguard import LeakConfig, LeakGuard
+from labels import LabelConfig, LabelBuilder
 
 
 def _read_df(path: str) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- update `build_training_table.py` to import helper classes from the top-level modules instead of the deprecated `data` package path

## Testing
- python build_training_table.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d2a4ba02e4832f830fc7569c99828e