### PR TITLE
Fix indentation spaces in custom policy

### DIFF
--- a/custom_policy_patch1.py
+++ b/custom_policy_patch1.py
@@ -199,10 +199,10 @@ class CustomActorCriticPolicy(RecurrentActorCriticPolicy):
     def _get_action_dist_from_latent(self, latent_pi: torch.Tensor):
         if isinstance(self.action_space, spaces.Box):
             mean_actions = self.action_net(latent_pi)
-            # Гладкое отображение неурезанного параметра в диапазон [-5, 0]
-            # torch.tanh дает [-1, 1], мы масштабируем и сдвигаем его.
-            log_std = -2.5 + 2.5 * torch.tanh(self.unconstrained_log_std)
-            return self.action_dist.proba_distribution(mean_actions, log_std)
+            # Гладкое отображение неурезанного параметра в диапазон [-5, 0]
+            # torch.tanh дает [-1, 1], мы масштабируем и сдвигаем его.
+            log_std = -2.5 + 2.5 * torch.tanh(self.unconstrained_log_std)
+            return self.action_dist.proba_distribution(mean_actions, log_std)
         elif isinstance(self.action_space, spaces.Discrete):
             action_logits = self.action_net(latent_pi)
             return self.action_dist.proba_distribution(action_logits)


### PR DESCRIPTION
## Summary
- replace non-breaking space indentation in the Box branch of `_get_action_dist_from_latent` so the file parses correctly

## Testing
- python -m compileall custom_policy_patch1.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b37b9ba8832f878a6938fd7a7848