### PR TITLE
Fix no-trade block duration calculation and tests

### DIFF
--- a/tests/test_apply_no_trade_mask.py
+++ b/tests/test_apply_no_trade_mask.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from apply_no_trade_mask import _blocked_durations
+
+
+def test_blocked_durations_respect_timeframe_for_final_bar():
+    tf_ms = 60_000
+    ts = np.array([0, 60_000, 120_000, 180_000, 240_000], dtype=np.int64)
+    mask = np.array([False, True, True, False, True])
+
+    durations = _blocked_durations(ts, mask, tf_ms=tf_ms)
+
+    assert durations.tolist() == pytest.approx([2.0, 1.0])
+    assert durations.sum() == pytest.approx(3.0)
+
+
+def test_blocked_durations_single_bar_uses_timeframe():
+    tf_ms = 60_000
+    ts = np.array([1_000_000], dtype=np.int64)
+    mask = np.array([True])
+
+    durations = _blocked_durations(ts, mask, tf_ms=tf_ms)
+
+    assert durations.tolist() == [pytest.approx(tf_ms / 60_000.0)]


### PR DESCRIPTION
## Summary
- ensure `_blocked_durations` accounts for trailing blocked bars by using the provided timeframe or inferred spacing
- pass the CLI timeframe into `_blocked_durations` so histogram output reflects full bar durations
- add regression tests covering single-bar blocks and multi-bar duration aggregation

## Testing
- pytest tests/test_apply_no_trade_mask.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be634740832f9fc74c9f2d49cdb9