### PR TITLE
Adjust risk guard max position fallback

### DIFF
--- a/risk_guard.py
+++ b/risk_guard.py
@@ -80,10 +80,13 @@ class RiskGuard:
     @staticmethod
     def _get_max_position_from_state_or_cfg(state, cfg: RiskConfig) -> float:
         mp = float(getattr(state, "max_position", 0.0) or 0.0)
-        if mp <= 0.0:
-            # если в стейте не задано — хеджируемся конфигом (не строже max_abs_position)
-            mp = min(1.0, cfg.max_abs_position)  # «1 контракт» как «минимум», но не выше hard-cap
-        return float(mp)
+        if mp > 0.0 and math.isfinite(mp):
+            return mp
+
+        cfg_mp = float(cfg.max_abs_position)
+        if not math.isfinite(cfg_mp) or cfg_mp <= 0.0:
+            cfg_mp = 1.0
+        return float(cfg_mp)
 
     @staticmethod
     def _notional(state, mid_price: float) -> float:


### PR DESCRIPTION
## Summary
- update the max-position fallback so state values fall back to the configured absolute limit while ensuring it remains positive and finite
- extend risk guard tests to cover deriving the proposed position from the configuration limit when state max position is missing

## Testing
- pytest tests/test_risk_guard_reset.py


------
https://chatgpt.com/codex/tasks/task_e_68d2be66fbdc832fb06866cdff7d1834