### PR TITLE
Fix ADV store path resolution and add tests

### DIFF
--- a/adv_store.py
+++ b/adv_store.py
@@ -144,7 +144,8 @@ class ADVStore:
                 candidate = os.path.join(base, dataset_name)
                 if os.path.exists(candidate):
                     return candidate
-            return base
+            if os.path.exists(base) and (not dataset_name or not os.path.isdir(base)):
+                return base
         return None
 
     def _ensure_loaded_locked(self) -> None:

--- a/tests/test_adv_store.py
+++ b/tests/test_adv_store.py
@@ -1,0 +1,40 @@
+import os
+
+from adv_store import ADVStore
+
+
+def test_adv_store_resolves_dataset_from_later_candidate(tmp_path):
+    dataset_name = "adv.json"
+
+    missing_dir = tmp_path / "missing"
+    missing_dir.mkdir()
+
+    valid_dir = tmp_path / "valid"
+    valid_dir.mkdir()
+    dataset_path = valid_dir / dataset_name
+    dataset_path.write_text("{}", encoding="utf-8")
+
+    cfg = {
+        "path": os.fspath(missing_dir),
+        "extra": {"adv_path": os.fspath(valid_dir)},
+        "dataset": dataset_name,
+    }
+
+    store = ADVStore(cfg)
+
+    assert store.path == os.fspath(dataset_path)
+
+
+def test_adv_store_skips_missing_file_candidate(tmp_path):
+    missing_file = tmp_path / "missing.json"
+    valid_file = tmp_path / "valid.json"
+    valid_file.write_text("{}", encoding="utf-8")
+
+    cfg = {
+        "path": os.fspath(missing_file),
+        "extra": {"adv_path": os.fspath(valid_file)},
+    }
+
+    store = ADVStore(cfg)
+
+    assert store.path == os.fspath(valid_file)


### PR DESCRIPTION
## Summary
- prevent `_resolve_path` from returning non-existent dataset locations by verifying the candidate paths
- add ADV store tests covering fallback to later valid candidates for both directory and file configurations

## Testing
- pytest tests/test_adv_store.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be668424832f896869121526bb52