### PR TITLE
Ensure calendar maintenance reason remains isolated

### DIFF
--- a/no_trade.py
+++ b/no_trade.py
@@ -165,9 +165,6 @@ def _window_reasons(
     m_custom = _in_custom_window(ts_ms, cfg.custom_ms or [])
     m_calendar = _apply_calendar_windows(ts_ms, calendar, symbols)
 
-    m_daily = np.logical_or(m_daily, m_calendar)
-    m_custom = np.logical_or(m_custom, m_calendar)
-
     data = {
         "maintenance_daily": m_daily,
         "maintenance_funding": m_funding,

--- a/tests/test_no_trade_ratio.py
+++ b/tests/test_no_trade_ratio.py
@@ -273,8 +273,8 @@ def test_maintenance_calendar_blocks_rows(tmp_path):
     reasons = mask.attrs.get("reasons")
     assert isinstance(reasons, pd.DataFrame)
     actual_calendar = reasons["maintenance_calendar"].tolist()
-    assert reasons["maintenance_daily"].tolist() == actual_calendar
-    assert reasons["maintenance_custom"].tolist() == actual_calendar
+    assert reasons["maintenance_daily"].tolist() == [False] * len(df)
+    assert reasons["maintenance_custom"].tolist() == [False] * len(df)
 
     state_payload = mask.attrs.get("state")
     assert isinstance(state_payload, dict)
@@ -427,8 +427,8 @@ def test_calendar_format_override_and_merge(tmp_path):
     expected = [False, True, True, True, True]
     assert mask.tolist() == expected
     assert reasons["maintenance_calendar"].tolist() == expected
-    assert reasons["maintenance_daily"].tolist() == expected
-    assert reasons["maintenance_custom"].tolist() == expected
+    assert reasons["maintenance_daily"].tolist() == [False] * len(df)
+    assert reasons["maintenance_custom"].tolist() == [False] * len(df)
 
     state_payload = mask.attrs.get("state") or {}
     calendar_state = (state_payload.get("maintenance") or {}).get("calendar") or {}


### PR DESCRIPTION
## Summary
- keep daily and custom no-trade reasons independent from maintenance calendar windows
- update calendar-related no-trade tests to confirm only the calendar column is populated

## Testing
- pytest tests/test_no_trade_ratio.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2be66a00c832faa59ca68ab73516d