### PR TITLE
Fix ADV store path fallback logic

### DIFF
--- a/adv_store.py
+++ b/adv_store.py
@@ -136,15 +136,22 @@ class ADVStore:
             if dataset_name == "":
                 dataset_name = None
         for base in candidates:
-            if dataset_name and os.path.isdir(base):
-                candidate = os.path.join(base, dataset_name)
-                if os.path.exists(candidate):
-                    return candidate
-            if dataset_name and dataset_name not in os.path.basename(base):
-                candidate = os.path.join(base, dataset_name)
-                if os.path.exists(candidate):
-                    return candidate
-            return base
+            if dataset_name:
+                if os.path.isdir(base):
+                    candidate = os.path.join(base, dataset_name)
+                    if os.path.exists(candidate):
+                        return candidate
+                if dataset_name not in os.path.basename(base):
+                    candidate = os.path.join(base, dataset_name)
+                    if os.path.exists(candidate):
+                        return candidate
+                if os.path.exists(base) and (
+                    dataset_name in os.path.basename(base) or not os.path.isdir(base)
+                ):
+                    return base
+                continue
+            if os.path.exists(base):
+                return base
         return None
 
     def _ensure_loaded_locked(self) -> None:

--- a/tests/test_adv_store.py
+++ b/tests/test_adv_store.py
@@ -1,0 +1,26 @@
+import os
+
+from adv_store import ADVStore
+
+
+def test_resolve_path_skips_missing_dataset(tmp_path):
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    secondary = tmp_path / "secondary"
+    secondary.mkdir()
+
+    dataset_name = "foo"
+    expected = secondary / dataset_name
+    expected.touch()
+
+    cfg = {
+        "path": os.fspath(primary),
+        "dataset": dataset_name,
+        "extra": {
+            "data_path": os.fspath(secondary),
+        },
+    }
+
+    store = ADVStore(cfg)
+
+    assert store.path == os.fspath(expected)


### PR DESCRIPTION
## Summary
- update ADVStore path resolution to skip returning a base directory when the dataset-specific entry is missing
- add a regression test ensuring a later candidate is chosen when the first dataset path is absent

## Testing
- pytest tests/test_adv_store.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be6a01e0832f9c16fa174f0b7e1b