### PR TITLE
Adjust partial window trimming in agg_klines

### DIFF
--- a/agg_klines.py
+++ b/agg_klines.py
@@ -59,8 +59,8 @@ def _agg(df: pd.DataFrame, interval: str, drop_partial: bool = False) -> pd.Data
             cleaned.append(g)
             continue
         # drop_partial=True: отбрасываем неполные окна
-        start_bound = _floor_ts(min_ts, step) + step
-        end_bound = _floor_ts(max_ts, step)
+        start_bound = _floor_ts(min_ts, step) + (0 if start_ok else step)
+        end_bound = _floor_ts(max_ts, step) + (step if end_ok else 0)
         g2 = g[(g["ts_ms"] >= start_bound) & (g["ts_ms"] < end_bound)]
         cleaned.append(g2)
     if problems:

--- a/tests/test_agg_klines_validation.py
+++ b/tests/test_agg_klines_validation.py
@@ -57,6 +57,12 @@ def test_drop_partial():
     assert out["ts_ms"].tolist() == [180_000]
 
 
+def test_drop_partial_keeps_aligned_head():
+    df = _mk([0, 60_000, 120_000, 180_000, 240_000])
+    out = _agg(df, "3m", drop_partial=True)
+    assert out["ts_ms"].tolist() == [0]
+
+
 def test_hourly_aggregation_alignment():
     df = _mk(list(range(0, 2 * 3_600_000, 60_000)))
     out = _agg(df, "1h")


### PR DESCRIPTION
## Summary
- keep the first aligned bucket when dropping partial windows by adjusting start and end bounds
- add a regression test to ensure drop_partial preserves an aligned head while trimming a partial tail

## Testing
- pytest tests/test_agg_klines_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be6a31b4832f949204ce142b45ff