### PR TITLE
Adjust risk guard max position fallback

### DIFF
--- a/risk_guard.py
+++ b/risk_guard.py
@@ -81,8 +81,8 @@ class RiskGuard:
     def _get_max_position_from_state_or_cfg(state, cfg: RiskConfig) -> float:
         mp = float(getattr(state, "max_position", 0.0) or 0.0)
         if mp <= 0.0:
-            # если в стейте не задано — хеджируемся конфигом (не строже max_abs_position)
-            mp = min(1.0, cfg.max_abs_position)  # «1 контракт» как «минимум», но не выше hard-cap
+            # если в стейте не задано — используем положительный лимит из конфига либо fallback на 1 контракт
+            mp = float(cfg.max_abs_position) if cfg.max_abs_position > 0.0 else 1.0
         return float(mp)
 
     @staticmethod

--- a/tests/test_risk_guard_position_limit.py
+++ b/tests/test_risk_guard_position_limit.py
@@ -1,0 +1,33 @@
+import pathlib
+import sys
+
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+from action_proto import ActionProto, ActionType
+from risk_guard import RiskGuard, RiskConfig, RiskEvent
+
+
+class StateWithoutMax:
+    def __init__(self) -> None:
+        self.cash = 0.0
+        self.units = 0.0
+
+
+def test_missing_state_max_position_uses_config_limit():
+    cfg = RiskConfig(max_abs_position=10.0)
+    guard = RiskGuard(cfg)
+    state = StateWithoutMax()
+
+    max_pos = guard._get_max_position_from_state_or_cfg(state, cfg)
+    assert max_pos == 10.0
+
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=1.0)
+
+    event = guard.on_action_proposed(state, proto)
+    assert event == RiskEvent.NONE
+
+    # движение на полный объём (10 контрактов) допустимо, но превышение должно блокироваться
+    state.units = 9.0
+    event_limit = guard.on_action_proposed(state, proto)
+    assert event_limit == RiskEvent.POSITION_LIMIT


### PR DESCRIPTION
## Summary
- ensure the risk guard falls back to the configured `max_abs_position` when the state lacks its own max position and only uses 1 contract if no positive limit is configured
- add a regression test covering the config-based fallback and limit enforcement

## Testing
- pytest tests/test_risk_guard_reset.py tests/test_risk_guard_position_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be6cf348832f8da1703a8000a5f3