### PR TITLE
Fix blocked durations to include final bar

### DIFF
--- a/tests/test_apply_no_trade_mask.py
+++ b/tests/test_apply_no_trade_mask.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from apply_no_trade_mask import _blocked_durations
+
+
+def test_blocked_durations_single_bar_counts_full_minute():
+    ts = np.array([0, 60_000, 120_000], dtype=np.int64)
+    mask = [False, True, False]
+
+    durations = _blocked_durations(ts, mask, bar_length_ms=60_000)
+
+    np.testing.assert_allclose(durations, [1.0])
+
+
+def test_blocked_durations_two_bars_counts_full_minutes():
+    ts = np.array([0, 60_000, 120_000, 180_000], dtype=np.int64)
+    mask = [False, True, True, False]
+
+    durations = _blocked_durations(ts, mask)
+
+    np.testing.assert_allclose(durations, [2.0])


### PR DESCRIPTION
## Summary
- update the blocked duration helper to accept an explicit bar length or infer one and include the trailing bar in interval durations
- pass the timeframe width from the CLI histogram helper so reported minutes match the true bar counts
- add unit tests that verify one- and two-bar blocked masks report the expected durations

## Testing
- pytest tests/test_apply_no_trade_mask.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be6de380832fb3b796b3ec85cdaf