### PR TITLE
Preserve calendar maintenance mask

### DIFF
--- a/no_trade.py
+++ b/no_trade.py
@@ -165,9 +165,6 @@ def _window_reasons(
     m_custom = _in_custom_window(ts_ms, cfg.custom_ms or [])
     m_calendar = _apply_calendar_windows(ts_ms, calendar, symbols)
 
-    m_daily = np.logical_or(m_daily, m_calendar)
-    m_custom = np.logical_or(m_custom, m_calendar)
-
     data = {
         "maintenance_daily": m_daily,
         "maintenance_funding": m_funding,

--- a/tests/test_no_trade_ratio.py
+++ b/tests/test_no_trade_ratio.py
@@ -273,8 +273,10 @@ def test_maintenance_calendar_blocks_rows(tmp_path):
     reasons = mask.attrs.get("reasons")
     assert isinstance(reasons, pd.DataFrame)
     actual_calendar = reasons["maintenance_calendar"].tolist()
-    assert reasons["maintenance_daily"].tolist() == actual_calendar
-    assert reasons["maintenance_custom"].tolist() == actual_calendar
+    expected_false = [False] * len(df)
+    assert reasons["maintenance_daily"].tolist() == expected_false
+    assert reasons["maintenance_custom"].tolist() == expected_false
+    assert reasons["window"].tolist() == actual_calendar
 
     state_payload = mask.attrs.get("state")
     assert isinstance(state_payload, dict)
@@ -427,8 +429,10 @@ def test_calendar_format_override_and_merge(tmp_path):
     expected = [False, True, True, True, True]
     assert mask.tolist() == expected
     assert reasons["maintenance_calendar"].tolist() == expected
-    assert reasons["maintenance_daily"].tolist() == expected
-    assert reasons["maintenance_custom"].tolist() == expected
+    expected_false = [False] * len(df)
+    assert reasons["maintenance_daily"].tolist() == expected_false
+    assert reasons["maintenance_custom"].tolist() == expected_false
+    assert reasons["window"].tolist() == expected
 
     state_payload = mask.attrs.get("state") or {}
     calendar_state = (state_payload.get("maintenance") or {}).get("calendar") or {}


### PR DESCRIPTION
## Summary
- keep maintenance calendar masking isolated from daily and custom windows
- ensure calendar-only schedules populate only the maintenance_calendar reason and still set the aggregate window flag
- update regression tests to cover the separated calendar masking behavior

## Testing
- pytest tests/test_no_trade_ratio.py

------
https://chatgpt.com/codex/tasks/task_e_68d2be6e9e50832f9473e5f2a4b19cd1