### PR TITLE
Handle BNB fee conversion and add regression test

### DIFF
--- a/tests/test_execution_sim_bnb_fee_conversion.py
+++ b/tests/test_execution_sim_bnb_fee_conversion.py
@@ -1,0 +1,94 @@
+import importlib.util
+import math
+import pathlib
+import sys
+
+import pytest
+
+
+base = pathlib.Path(__file__).resolve().parents[1]
+
+spec_exec = importlib.util.spec_from_file_location("execution_sim", base / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec_exec)
+sys.modules["execution_sim"] = exec_mod
+spec_exec.loader.exec_module(exec_mod)
+
+ActionProto = exec_mod.ActionProto
+ActionType = exec_mod.ActionType
+ExecutionSimulator = exec_mod.ExecutionSimulator
+
+
+class DummyQuantizer:
+    def quantize_qty(self, symbol, qty):
+        return float(qty)
+
+    def quantize_price(self, symbol, price):
+        return float(price)
+
+    def clamp_notional(self, symbol, ref_price, qty):
+        return float(qty)
+
+    def check_percent_price_by_side(self, symbol, side, price, ref_price):
+        return True
+
+
+@pytest.mark.parametrize("volume_frac", [1.0, -1.0])
+def test_bnb_fee_conversion_updates_equity(volume_frac):
+    conversion_rate = 200.0
+    taker_bps = 12.0
+    fees_config = {
+        "maker_bps": taker_bps,
+        "taker_bps": taker_bps,
+        "use_bnb_discount": True,
+        "maker_discount_mult": 0.75,
+        "taker_discount_mult": 0.75,
+        "settlement": {"mode": "bnb", "currency": "BNB"},
+        "bnb_conversion_rate": conversion_rate,
+    }
+
+    sim = ExecutionSimulator(filters_path=None, fees_config=fees_config)
+    sim.set_quantizer(DummyQuantizer())
+
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=volume_frac)
+
+    baseline = sim.run_step(
+        ts=500_000,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[],
+    )
+    fees_before = sim.fees_cum
+    funding_before = sim.funding_cum
+
+    report = sim.run_step(
+        ts=1_000_000,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[(ActionType.MARKET, proto)],
+    )
+
+    assert report.trades, "Expected at least one trade to be executed"
+    trade = report.trades[0]
+
+    discount_mult = 0.75
+    expected_fee = trade.price * trade.qty * (taker_bps * discount_mult) / 1e4
+
+    fees_delta = sim.fees_cum - fees_before
+    assert math.isclose(fees_delta, expected_fee, rel_tol=1e-9)
+    assert math.isclose(report.fee_total, expected_fee, rel_tol=1e-9)
+
+    eq_delta = report.equity - baseline.equity
+    realized_delta = report.realized_pnl - baseline.realized_pnl
+    unrealized_delta = report.unrealized_pnl - baseline.unrealized_pnl
+    funding_delta = sim.funding_cum - funding_before
+
+    assert math.isclose(
+        eq_delta - realized_delta - unrealized_delta - funding_delta,
+        -expected_fee,
+        rel_tol=1e-9,
+    )
+


### PR DESCRIPTION
## Summary
- detect quote currencies from fee metadata, configs, or known suffixes and cache the result
- convert BNB-settled fee amounts to quote currency totals when a conversion rate is available and log settlement details
- add a regression test covering BNB discounted fees to ensure equity and cumulative fees track the quote currency cost

## Testing
- pytest tests/test_execution_sim_bnb_fee_conversion.py
- pytest tests/test_execution_sim_maker_fee.py

------
https://chatgpt.com/codex/tasks/task_e_68d2cc55d1d0832fb4272f54f66aaf68