### PR TITLE
Fix RiskGuard notional exposure calculation

### DIFF
--- a/risk_guard.py
+++ b/risk_guard.py
@@ -90,9 +90,11 @@ class RiskGuard:
 
     @staticmethod
     def _notional(state, mid_price: float) -> float:
-        # Абсолютная величина net exposure (в денежных единицах)
-        # NW = cash + units * mid_price
-        return abs(float(state.cash) + float(state.units) * float(mid_price))
+        # Абсолютная экспозиция позиции (в денежных единицах)
+        price = float(mid_price)
+        if not math.isfinite(price) or price <= 0.0:
+            return 0.0
+        return abs(float(state.units)) * price
 
     def _update_equity_windows(self, ts: int, state, mid_price: float) -> Tuple[float, float, float]:
         # Возвращает (nw, peak, dd_pct)


### PR DESCRIPTION
## Summary
- adjust `RiskGuard._notional` to compute absolute position exposure and ignore invalid mid prices
- add a regression test ensuring cash-only accounts do not trigger the notional limit while positions still do

## Testing
- pytest tests/test_risk_guard_reset.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d45ad348832fbddfdfffa2beccb8