### PR TITLE
Fix discount multipliers when BNB discount disabled

### DIFF
--- a/impl_fees.py
+++ b/impl_fees.py
@@ -747,15 +747,22 @@ class FeesImpl:
                 self.account_fee_info = info
                 self.account_fee_overrides = info.to_fee_overrides()
 
-        maker_discount_mult = cfg.maker_discount_mult
-        if not cfg.maker_discount_overridden and cfg.auto_maker_discount_mult is not None:
-            maker_discount_mult = float(cfg.auto_maker_discount_mult)
-        taker_discount_mult = cfg.taker_discount_mult
-        if not cfg.taker_discount_overridden and cfg.auto_taker_discount_mult is not None:
-            taker_discount_mult = float(cfg.auto_taker_discount_mult)
         use_bnb_discount = cfg.use_bnb_discount
         if not cfg.use_bnb_discount_overridden and cfg.auto_use_bnb_discount is not None:
             use_bnb_discount = bool(cfg.auto_use_bnb_discount)
+
+        maker_discount_mult = cfg.maker_discount_mult
+        taker_discount_mult = cfg.taker_discount_mult
+        if use_bnb_discount:
+            if not cfg.maker_discount_overridden and cfg.auto_maker_discount_mult is not None:
+                maker_discount_mult = float(cfg.auto_maker_discount_mult)
+            if not cfg.taker_discount_overridden and cfg.auto_taker_discount_mult is not None:
+                taker_discount_mult = float(cfg.auto_taker_discount_mult)
+        else:
+            if not cfg.maker_discount_overridden:
+                maker_discount_mult = 1.0
+            if not cfg.taker_discount_overridden:
+                taker_discount_mult = 1.0
 
         self._maker_discount_mult = float(maker_discount_mult)
         self._taker_discount_mult = float(taker_discount_mult)

--- a/tests/test_fees_discount.py
+++ b/tests/test_fees_discount.py
@@ -1,6 +1,6 @@
 import pytest
 
-from impl_fees import FeesImpl
+from impl_fees import FeesConfig, FeesImpl
 
 
 def test_bnb_discount_applied_by_default():
@@ -21,4 +21,36 @@ def test_bnb_discount_applied_by_default():
     assert disc.cfg.taker_discount_mult == 0.75
     assert fee_disc_maker == pytest.approx(fee_base_maker * 0.75)
     assert fee_disc_taker == pytest.approx(fee_base_taker * 0.75)
+
+
+def test_bnb_discount_auto_data_ignored_when_disabled():
+    price = 100.0
+    qty = 1.0
+
+    baseline = FeesImpl(FeesConfig(use_bnb_discount=False))
+    fee_base_maker = baseline.model.compute(
+        side="BUY", price=price, qty=qty, liquidity="maker"
+    )
+    fee_base_taker = baseline.model.compute(
+        side="BUY", price=price, qty=qty, liquidity="taker"
+    )
+
+    cfg = FeesConfig(use_bnb_discount=False)
+    cfg.auto_maker_discount_mult = 0.25
+    cfg.auto_taker_discount_mult = 0.5
+    cfg.auto_use_bnb_discount = True
+
+    auto = FeesImpl(cfg)
+    fee_auto_maker = auto.model.compute(
+        side="BUY", price=price, qty=qty, liquidity="maker"
+    )
+    fee_auto_taker = auto.model.compute(
+        side="BUY", price=price, qty=qty, liquidity="taker"
+    )
+
+    assert auto.model_payload["use_bnb_discount"] is False
+    assert auto.model_payload["maker_discount_mult"] == pytest.approx(1.0)
+    assert auto.model_payload["taker_discount_mult"] == pytest.approx(1.0)
+    assert fee_auto_maker == pytest.approx(fee_base_maker)
+    assert fee_auto_taker == pytest.approx(fee_base_taker)
 


### PR DESCRIPTION
## Summary
- prevent auto discount multipliers from applying when BNB discounts are disabled so effective multipliers remain at 1.0
- extend the fees discount test suite to cover the disabled-discount scenario with auto multiplier data

## Testing
- pytest tests/test_fees_discount.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d8b83714832f97a62b5b2ea50448