### PR TITLE
Handle BNB fee conversion via fees model

### DIFF
--- a/tests/test_execution_sim_bnb_fee_conversion.py
+++ b/tests/test_execution_sim_bnb_fee_conversion.py
@@ -75,11 +75,14 @@ def test_bnb_fee_conversion_updates_equity(volume_frac):
     trade = report.trades[0]
 
     discount_mult = 0.75
-    expected_fee = trade.price * trade.qty * (taker_bps * discount_mult) / 1e4
+    expected_fee_quote = trade.price * trade.qty * (taker_bps * discount_mult) / 1e4
+    expected_fee_bnb = expected_fee_quote / conversion_rate
 
     fees_delta = sim.fees_cum - fees_before
-    assert math.isclose(fees_delta, expected_fee, rel_tol=1e-9)
-    assert math.isclose(report.fee_total, expected_fee, rel_tol=1e-9)
+    assert math.isclose(fees_delta, expected_fee_quote, rel_tol=1e-9)
+    assert math.isclose(report.fee_total, expected_fee_bnb, rel_tol=1e-9)
+    assert math.isclose(trade.fee, expected_fee_bnb, rel_tol=1e-9)
+    assert math.isclose(report.fee_total * conversion_rate, expected_fee_quote, rel_tol=1e-9)
 
     eq_delta = report.equity - baseline.equity
     realized_delta = report.realized_pnl - baseline.realized_pnl
@@ -88,7 +91,7 @@ def test_bnb_fee_conversion_updates_equity(volume_frac):
 
     assert math.isclose(
         eq_delta - realized_delta - unrealized_delta - funding_delta,
-        -expected_fee,
+        -expected_fee_quote,
         rel_tol=1e-9,
     )
 


### PR DESCRIPTION
## Summary
- fall back to the local fees module when the simulator-only version is unavailable
- route trade fee computation through the fees model so settlement metadata and BNB conversion are respected, including tracking conversion differences against equity
- propagate conversion-rate data from the simulator config and extend the BNB conversion test to cover the converted amounts

## Testing
- pytest tests/test_execution_sim_bnb_fee_conversion.py


------
https://chatgpt.com/codex/tasks/task_e_68d2df736d90832f836ba149cec576a3