### PR TITLE
Allow zero fee discount multiplier

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -4271,11 +4271,11 @@ class ExecutionSimulator:
                     exc_info=True,
                 )
                 multiplier = None
-        if multiplier is None or not math.isfinite(multiplier) or multiplier <= 0.0:
+        if multiplier is None or not math.isfinite(multiplier) or multiplier < 0.0:
             fallback = self._fallback_discount_multiplier(symbol, is_maker)
             if fallback is not None:
                 multiplier = fallback
-        if multiplier is None or not math.isfinite(multiplier) or multiplier <= 0.0:
+        if multiplier is None or not math.isfinite(multiplier) or multiplier < 0.0:
             multiplier = 1.0
         return float(multiplier)
 
@@ -4302,7 +4302,7 @@ class ExecutionSimulator:
                 sources.append(account_overrides.get(key))
         for candidate in sources:
             value = ExecutionSimulator._trade_cost_float(candidate)
-            if value is None or value <= 0.0:
+            if value is None or value < 0.0:
                 continue
             return float(value)
         return None

--- a/tests/test_execution_sim_fee_discount.py
+++ b/tests/test_execution_sim_fee_discount.py
@@ -1,0 +1,71 @@
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+
+base = pathlib.Path(__file__).resolve().parents[1]
+
+spec_exec = importlib.util.spec_from_file_location("execution_sim", base / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec_exec)
+sys.modules["execution_sim"] = exec_mod
+spec_exec.loader.exec_module(exec_mod)
+
+ActionProto = exec_mod.ActionProto
+ActionType = exec_mod.ActionType
+ExecutionSimulator = exec_mod.ExecutionSimulator
+
+
+class DummyQuantizer:
+    def quantize_qty(self, symbol, qty):
+        return float(qty)
+
+    def quantize_price(self, symbol, price):
+        return float(price)
+
+    def clamp_notional(self, symbol, ref_price, qty):
+        return float(qty)
+
+    def check_percent_price_by_side(self, symbol, side, price, ref_price):
+        return True
+
+
+def test_zero_fee_discount_multiplier_maintains_zero_fees():
+    fees_config = {
+        "maker_bps": 12.0,
+        "taker_bps": 12.0,
+        "maker_discount_mult": 0.0,
+        "taker_discount_mult": 0.0,
+    }
+
+    sim = ExecutionSimulator(filters_path=None, fees_config=fees_config)
+    sim.set_quantizer(DummyQuantizer())
+
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=1.0)
+
+    sim.run_step(
+        ts=500_000,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[],
+    )
+    fees_before = sim.fees_cum
+
+    report = sim.run_step(
+        ts=1_000_000,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[(ActionType.MARKET, proto)],
+    )
+
+    assert report.trades, "Expected at least one trade to be executed"
+    trade = report.trades[0]
+
+    assert report.fee_total == pytest.approx(0.0)
+    assert trade.fee == pytest.approx(0.0)
+    assert sim.fees_cum == pytest.approx(fees_before)


### PR DESCRIPTION
## Summary
- allow zero discount multipliers to propagate without being replaced with unity
- accept zero-valued discount overrides from configuration sources
- add a regression test ensuring zero discount multipliers keep simulated fees at zero

## Testing
- pytest tests/test_execution_sim_fee_discount.py

------
https://chatgpt.com/codex/tasks/task_e_68d3168c94e0832f9b8a295a194809ff