### PR TITLE
Fix default BNB fee discount multiplier

### DIFF
--- a/impl_fees.py
+++ b/impl_fees.py
@@ -7,6 +7,7 @@ import copy
 import datetime as _dt
 import json
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass, field
@@ -417,15 +418,22 @@ class FeesConfig:
         maker_mult_input = self.maker_discount_mult
         self.maker_discount_overridden = maker_mult_input is not None
         maker_mult = _safe_float(maker_mult_input)
+        try:
+            default_discount_mult = 1.0 - float(DEFAULT_BNB_DISCOUNT_RATE)
+        except (TypeError, ValueError):
+            default_discount_mult = 1.0
+        if not math.isfinite(default_discount_mult):
+            default_discount_mult = 1.0
+        default_discount_mult = max(0.0, min(default_discount_mult, 1.0))
         if maker_mult is None:
-            maker_mult = 0.75 if self.use_bnb_discount else 1.0
+            maker_mult = default_discount_mult if self.use_bnb_discount else 1.0
         self.maker_discount_mult = maker_mult
 
         taker_mult_input = self.taker_discount_mult
         self.taker_discount_overridden = taker_mult_input is not None
         taker_mult = _safe_float(taker_mult_input)
         if taker_mult is None:
-            taker_mult = 0.75 if self.use_bnb_discount else 1.0
+            taker_mult = default_discount_mult if self.use_bnb_discount else 1.0
         self.taker_discount_mult = taker_mult
 
         vip_input = self.vip_tier

--- a/tests/test_fees_discount.py
+++ b/tests/test_fees_discount.py
@@ -1,5 +1,6 @@
 import pytest
 
+from binance_fee_refresh import DEFAULT_BNB_DISCOUNT_RATE
 from impl_fees import FeesConfig, FeesImpl
 
 
@@ -17,10 +18,11 @@ def test_bnb_discount_applied_by_default():
     fee_disc_maker = disc.model.compute(side="BUY", price=price, qty=qty, liquidity="maker")
     fee_disc_taker = disc.model.compute(side="BUY", price=price, qty=qty, liquidity="taker")
 
-    assert disc.cfg.maker_discount_mult == 0.75
-    assert disc.cfg.taker_discount_mult == 0.75
-    assert fee_disc_maker == pytest.approx(fee_base_maker * 0.75)
-    assert fee_disc_taker == pytest.approx(fee_base_taker * 0.75)
+    expected_mult = 1.0 - float(DEFAULT_BNB_DISCOUNT_RATE)
+    assert disc.cfg.maker_discount_mult == pytest.approx(expected_mult)
+    assert disc.cfg.taker_discount_mult == pytest.approx(expected_mult)
+    assert fee_disc_maker == pytest.approx(fee_base_maker * expected_mult)
+    assert fee_disc_taker == pytest.approx(fee_base_taker * expected_mult)
 
 
 def test_bnb_discount_auto_data_ignored_when_disabled():


### PR DESCRIPTION
## Summary
- derive the default BNB fee discount multiplier from the configured discount rate constant
- adjust the fee discount test to expect the computed multiplier value instead of a hard-coded number

## Testing
- pytest tests/test_fees_discount.py

------
https://chatgpt.com/codex/tasks/task_e_68d39dcadf5c832fadd530b72864dd07