### PR TITLE
Fix double-discount of account fee overrides

### DIFF
--- a/impl_fees.py
+++ b/impl_fees.py
@@ -850,13 +850,20 @@ class FeesImpl:
         if not cfg.taker_bps_overridden and cfg.auto_taker_bps is not None:
             taker_bps = float(cfg.auto_taker_bps)
         account_maker_bps = _safe_float(self.account_fee_overrides.get("maker_bps"))
-        if account_maker_bps is not None:
+        account_maker_override = account_maker_bps is not None
+        if account_maker_override:
             maker_bps = account_maker_bps
             self._account_fee_applied["maker_bps"] = True
         account_taker_bps = _safe_float(self.account_fee_overrides.get("taker_bps"))
-        if account_taker_bps is not None:
+        account_taker_override = account_taker_bps is not None
+        if account_taker_override:
             taker_bps = account_taker_bps
             self._account_fee_applied["taker_bps"] = True
+
+        if account_maker_override:
+            self._maker_discount_mult = 1.0
+        if account_taker_override:
+            self._taker_discount_mult = 1.0
 
         self.base_fee_bps: Dict[str, float] = {
             "maker_fee_bps": maker_bps * self._maker_discount_mult,


### PR DESCRIPTION
## Summary
- prevent the fees model from multiplying account-provided maker/taker rates by the BNB discount again
- add a regression test ensuring account fee overrides yield the expected maker and taker fees when BNB discounts are enabled

## Testing
- pytest tests/test_fees_account_info.py

------
https://chatgpt.com/codex/tasks/task_e_68d39fd0c2cc832fa698a0c6e0e51b91