### PR TITLE
Fix fee decimal rounding to use half-up

### DIFF
--- a/fees.py
+++ b/fees.py
@@ -140,13 +140,27 @@ def _round_value_to_decimals(value: float, decimals: int) -> float:
         return float(value)
     try:
         quant = Decimal(1).scaleb(-decimals)
-        rounded = Decimal(str(value)).quantize(quant)
+        rounded = Decimal(str(value)).quantize(quant, rounding=ROUND_HALF_UP)
         result = float(rounded)
         if math.isfinite(result):
             return result
     except (InvalidOperation, ValueError):
         pass
-    return float(round(value, decimals))
+
+    try:
+        factor = 10 ** decimals
+        scaled = float(value) * factor
+        if scaled >= 0.0:
+            adjusted = math.floor(scaled + 0.5)
+        else:
+            adjusted = math.ceil(scaled - 0.5)
+        result = adjusted / factor
+        if math.isfinite(result):
+            return float(result)
+    except Exception:
+        pass
+
+    return float(value)
 
 
 def _round_value_to_step(value: float, step: float, mode: str) -> float:

--- a/tests/test_fees_rounding.py
+++ b/tests/test_fees_rounding.py
@@ -242,3 +242,22 @@ def test_bnb_rounding_scales_with_conversion():
     assert details.rounding_step == pytest.approx(0.00005)
     assert details.commission_step == pytest.approx(0.00005)
 
+
+def test_decimal_rounding_uses_half_up():
+    model = FeesModel.from_dict(
+        {
+            "maker_bps": 0,
+            "taker_bps": 250,
+            "rounding": {"decimals": 2},
+        }
+    )
+
+    fee = model.compute(
+        side="SELL",
+        price=1.0,
+        qty=1.0,
+        liquidity="taker",
+    )
+
+    assert fee == pytest.approx(0.03)
+


### PR DESCRIPTION
## Summary
- ensure decimal rounding for fee calculations uses half-up semantics instead of the default bankers rounding
- add a regression test covering the half-up behaviour when only decimal rounding is configured

## Testing
- pytest tests/test_fees_rounding.py

------
https://chatgpt.com/codex/tasks/task_e_68d3a22698dc832f97251dd7332c59c6