### PR TITLE
Handle missing sandbox config in TradingEnv

### DIFF
--- a/trading_patchnew.py
+++ b/trading_patchnew.py
@@ -332,7 +332,14 @@ class TradingEnv(gym.Env):
         elif override:
             cfg_nt = NoTradeConfig(**override)
         else:
-            cfg_nt = get_no_trade_config(kwargs.get("sandbox_config", "configs/legacy_sandbox.yaml"))
+            sandbox_path = kwargs.get("sandbox_config", "configs/legacy_sandbox.yaml")
+            try:
+                cfg_nt = get_no_trade_config(sandbox_path)
+            except FileNotFoundError:
+                logger.warning(
+                    "Sandbox config %s not found; using default no-trade settings", sandbox_path
+                )
+                cfg_nt = NoTradeConfig()
         self._no_trade_cfg = cfg_nt
         if "ts_ms" in self.df.columns:
             ts = (


### PR DESCRIPTION
## Summary
- fall back to an empty NoTradeConfig when the default sandbox config file is absent
- log a warning instead of crashing so TradingEnv can be initialised without legacy configs

## Testing
- pytest TradingBot/tests/test_close_shift.py
- pytest TradingBot/tests/test_no_trade_mask.py

------
https://chatgpt.com/codex/tasks/task_e_68d3abc695d0832fb593ee3a40fd2881