### PR TITLE
Fix rounding fee sanitization for zero values

### DIFF
--- a/fees.py
+++ b/fees.py
@@ -313,19 +313,19 @@ def _sanitize_rounding_config(data: Any) -> Dict[str, Any]:
             if decimals_int >= 0:
                 normalized["decimals"] = decimals_int
 
-    minimum_fee = (
-        _sanitize_optional_non_negative(mapping.get("minimum_fee"))
-        or _sanitize_optional_non_negative(mapping.get("min_fee"))
-        or _sanitize_optional_non_negative(mapping.get("minimum"))
-    )
+    minimum_fee = _sanitize_optional_non_negative(mapping.get("minimum_fee"))
+    if minimum_fee is None:
+        minimum_fee = _sanitize_optional_non_negative(mapping.get("min_fee"))
+    if minimum_fee is None:
+        minimum_fee = _sanitize_optional_non_negative(mapping.get("minimum"))
     if minimum_fee is not None:
         normalized["minimum_fee"] = float(minimum_fee)
 
-    maximum_fee = (
-        _sanitize_optional_non_negative(mapping.get("maximum_fee"))
-        or _sanitize_optional_non_negative(mapping.get("max_fee"))
-        or _sanitize_optional_non_negative(mapping.get("maximum"))
-    )
+    maximum_fee = _sanitize_optional_non_negative(mapping.get("maximum_fee"))
+    if maximum_fee is None:
+        maximum_fee = _sanitize_optional_non_negative(mapping.get("max_fee"))
+    if maximum_fee is None:
+        maximum_fee = _sanitize_optional_non_negative(mapping.get("maximum"))
     if maximum_fee is not None:
         normalized["maximum_fee"] = float(maximum_fee)
 

--- a/tests/test_fees_rounding.py
+++ b/tests/test_fees_rounding.py
@@ -1,7 +1,28 @@
 import pytest
 
 from impl_fees import FeesImpl
-from fees import FeeComputation, FeesModel
+from fees import FeeComputation, FeesModel, _sanitize_rounding_config
+
+
+def test_rounding_config_allows_zero_minimum_and_maximum_fee():
+    config = _sanitize_rounding_config({"minimum_fee": 0.0, "maximum_fee": 0.0})
+
+    assert config.get("minimum_fee") == pytest.approx(0.0)
+    assert config.get("maximum_fee") == pytest.approx(0.0)
+
+
+def test_rounding_config_preserves_zero_fee_from_aliases():
+    config = _sanitize_rounding_config(
+        {
+            "minimum_fee": None,
+            "min_fee": 0.0,
+            "maximum_fee": None,
+            "max_fee": 0.0,
+        }
+    )
+
+    assert config.get("minimum_fee") == pytest.approx(0.0)
+    assert config.get("maximum_fee") == pytest.approx(0.0)
 
 
 def test_rounding_nested_options_normalized():


### PR DESCRIPTION
## Summary
- prevent `_sanitize_rounding_config` from discarding zero-valued minimum/maximum fees by removing truthy fallbacks
- add regression coverage to ensure zero fees and alias keys are retained during rounding config sanitization

## Testing
- pytest tests/test_fees_rounding.py


------
https://chatgpt.com/codex/tasks/task_e_68d3ae737d20832fbca5c0c2b0653a67