### PR TITLE
Fix zero maximum fee handling in FeesImpl

### DIFF
--- a/fees.py
+++ b/fees.py
@@ -313,19 +313,19 @@ def _sanitize_rounding_config(data: Any) -> Dict[str, Any]:
             if decimals_int >= 0:
                 normalized["decimals"] = decimals_int
 
-    minimum_fee = (
-        _sanitize_optional_non_negative(mapping.get("minimum_fee"))
-        or _sanitize_optional_non_negative(mapping.get("min_fee"))
-        or _sanitize_optional_non_negative(mapping.get("minimum"))
-    )
+    minimum_fee = _sanitize_optional_non_negative(mapping.get("minimum_fee"))
+    if minimum_fee is None:
+        minimum_fee = _sanitize_optional_non_negative(mapping.get("min_fee"))
+    if minimum_fee is None:
+        minimum_fee = _sanitize_optional_non_negative(mapping.get("minimum"))
     if minimum_fee is not None:
         normalized["minimum_fee"] = float(minimum_fee)
 
-    maximum_fee = (
-        _sanitize_optional_non_negative(mapping.get("maximum_fee"))
-        or _sanitize_optional_non_negative(mapping.get("max_fee"))
-        or _sanitize_optional_non_negative(mapping.get("maximum"))
-    )
+    maximum_fee = _sanitize_optional_non_negative(mapping.get("maximum_fee"))
+    if maximum_fee is None:
+        maximum_fee = _sanitize_optional_non_negative(mapping.get("max_fee"))
+    if maximum_fee is None:
+        maximum_fee = _sanitize_optional_non_negative(mapping.get("maximum"))
     if maximum_fee is not None:
         normalized["maximum_fee"] = float(maximum_fee)
 

--- a/impl_fees.py
+++ b/impl_fees.py
@@ -150,19 +150,19 @@ def _normalise_rounding_options(
     if decimals is not None:
         normalized["decimals"] = decimals
 
-    minimum = _safe_non_negative_float(
-        mapping.get("minimum")
-        or mapping.get("min_fee")
-        or mapping.get("minimum_fee")
-    )
+    minimum = _safe_non_negative_float(mapping.get("minimum"))
+    if minimum is None:
+        minimum = _safe_non_negative_float(mapping.get("min_fee"))
+    if minimum is None:
+        minimum = _safe_non_negative_float(mapping.get("minimum_fee"))
     if minimum is not None:
         normalized["minimum_fee"] = float(minimum)
 
-    maximum = _safe_non_negative_float(
-        mapping.get("maximum")
-        or mapping.get("max_fee")
-        or mapping.get("maximum_fee")
-    )
+    maximum = _safe_non_negative_float(mapping.get("maximum"))
+    if maximum is None:
+        maximum = _safe_non_negative_float(mapping.get("max_fee"))
+    if maximum is None:
+        maximum = _safe_non_negative_float(mapping.get("maximum_fee"))
     if maximum is not None:
         normalized["maximum_fee"] = float(maximum)
 

--- a/tests/test_fees_rounding.py
+++ b/tests/test_fees_rounding.py
@@ -1,7 +1,49 @@
 import pytest
 
 from impl_fees import FeesImpl
-from fees import FeeComputation, FeesModel
+from fees import FeeComputation, FeesModel, _sanitize_rounding_config
+
+
+def test_rounding_config_allows_zero_minimum_and_maximum_fee():
+    config = _sanitize_rounding_config({"minimum_fee": 0.0, "maximum_fee": 0.0})
+
+    assert config.get("minimum_fee") == pytest.approx(0.0)
+    assert config.get("maximum_fee") == pytest.approx(0.0)
+
+
+def test_rounding_config_preserves_zero_fee_from_aliases():
+    config = _sanitize_rounding_config(
+        {
+            "minimum_fee": None,
+            "min_fee": 0.0,
+            "maximum_fee": None,
+            "max_fee": 0.0,
+        }
+    )
+
+    assert config.get("minimum_fee") == pytest.approx(0.0)
+    assert config.get("maximum_fee") == pytest.approx(0.0)
+
+
+def test_fees_impl_rounding_preserves_zero_fee_aliases():
+    fees = FeesImpl.from_dict(
+        {
+            "rounding": {
+                "minimum_fee": None,
+                "min_fee": 0.0,
+                "maximum_fee": None,
+                "max_fee": 0.0,
+            }
+        }
+    )
+
+    rounding_payload = fees.model_payload.get("rounding") or {}
+    assert rounding_payload.get("minimum_fee") == pytest.approx(0.0)
+    assert rounding_payload.get("maximum_fee") == pytest.approx(0.0)
+
+    rounding_meta = fees.metadata.get("rounding") or {}
+    assert rounding_meta.get("minimum_fee") == pytest.approx(0.0)
+    assert rounding_meta.get("maximum_fee") == pytest.approx(0.0)
 
 
 def test_rounding_nested_options_normalized():


### PR DESCRIPTION
## Summary
- ensure `_normalise_rounding_options` checks rounding fee aliases sequentially so zero minimum/maximum values are preserved when building FeesImpl payloads
- add regression coverage asserting FeesImpl keeps zero-valued fee bounds sourced from alias keys in metadata and payloads

## Testing
- pytest tests/test_fees_rounding.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ae737d20832fbca5c0c2b0653a67