### PR TITLE
Fix funding buffer wraparound and rename logging module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -233,7 +233,7 @@ from_config(cfg_run, trainer=trainer, train_cfg=cfg)
 ## Логи и отчёты
 
 Сервисы автоматически пишут журналы сделок и отчёты по эквити через
-класс `LogWriter` из модуля [`logging.py`](logging.py). По умолчанию
+класс `LogWriter` из модуля [`sim_logging.py`](sim_logging.py). По умолчанию
 создаются два файла.
 
 ### `logs/log_trades_<runid>.csv`

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ from .execution_algos import (
 from .latency import LatencyModel
 from .risk import RiskManager, RiskConfig, RiskEvent
 try:
-    from .logging import LogWriter, LogConfig
+    from .sim_logging import LogWriter, LogConfig
 except Exception:  # pragma: no cover - optional dependency
     LogWriter = None  # type: ignore
     LogConfig = None  # type: ignore

--- a/execution_sim.py
+++ b/execution_sim.py
@@ -376,7 +376,7 @@ except Exception:
 
 # --- Импорт логгера ---
 try:
-    from sim.logging import LogWriter, LogConfig
+    from sim.sim_logging import LogWriter, LogConfig
 except Exception:
     LogWriter = None  # type: ignore
     LogConfig = None  # type: ignore

--- a/no_trade.py
+++ b/no_trade.py
@@ -59,7 +59,9 @@ def _in_funding_buffer(ts_ms: np.ndarray, buf_min: int) -> np.ndarray:
     # |sec_day - mark| <= buf*60
     mask = np.zeros_like(sec_day, dtype=bool)
     for m in marks:
-        mask |= (np.abs(sec_day - m) <= buf_min * 60)
+        diff = np.abs(sec_day - m)
+        wrapped = 86400 - diff
+        mask |= np.minimum(diff, wrapped) <= buf_min * 60
     return mask
 
 

--- a/scripts/calibrate_live_slippage.py
+++ b/scripts/calibrate_live_slippage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Calibrate live slippage curves from execution logs.
 
-This utility scans trade fills produced by :class:`logging.LogWriter`,
+This utility scans trade fills produced by :class:`sim_logging.LogWriter`,
 aggregates empirical impact-vs-notional curves and derives seasonal
 adjustments that can be consumed by the runtime slippage model.  The
 workflow is fully offline – it only depends on historical log files and

--- a/service_backtest.py
+++ b/service_backtest.py
@@ -877,7 +877,7 @@ class ServiceBacktest:
             "reports_path": os.path.join(logs_dir, f"report_equity_{run_id}.csv"),
         }
         try:  # переподключаем логгер симулятора с нужными путями
-            from logging import LogWriter, LogConfig  # type: ignore
+            from sim_logging import LogWriter, LogConfig  # type: ignore
 
             self.sim._logger = LogWriter(
                 LogConfig.from_dict(logging_config), run_id=run_id

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -3321,7 +3321,7 @@ class ServiceSignalRunner:
                 "reports_path": os.path.join(logs_dir, f"report_equity_{run_id}.csv"),
             }
             try:
-                from logging import LogWriter, LogConfig  # type: ignore
+                from sim_logging import LogWriter, LogConfig  # type: ignore
 
                 sim._logger = LogWriter(
                     LogConfig.from_dict(logging_config), run_id=run_id

--- a/sim_logging.py
+++ b/sim_logging.py
@@ -1,4 +1,4 @@
-# sim/logging.py
+# sim/sim_logging.py
 from __future__ import annotations
 
 import os

--- a/tests/test_execution_profile_logging_and_metrics.py
+++ b/tests/test_execution_profile_logging_and_metrics.py
@@ -14,7 +14,7 @@ exec_mod = importlib.util.module_from_spec(spec_exec)
 sys.modules["execution_sim"] = exec_mod
 spec_exec.loader.exec_module(exec_mod)
 
-spec_log = importlib.util.spec_from_file_location("sim_logging", BASE / "logging.py")
+spec_log = importlib.util.spec_from_file_location("sim_logging", BASE / "sim_logging.py")
 log_mod = importlib.util.module_from_spec(spec_log)
 sys.modules["sim_logging"] = log_mod
 spec_log.loader.exec_module(log_mod)

--- a/tests/test_no_trade_helpers.py
+++ b/tests/test_no_trade_helpers.py
@@ -25,7 +25,7 @@ def test_in_funding_buffer_with_midnight_and_day_marks():
     ], dtype=np.int64)
     ts_ms = ts_minutes * 60_000
     mask = _in_funding_buffer(ts_ms, 10)
-    expected = np.array([True, True, True, False, True, False, False])
+    expected = np.array([True, True, True, False, True, False, True])
     np.testing.assert_array_equal(mask, expected)
 
 


### PR DESCRIPTION
## Summary
- fix `_in_funding_buffer` so the funding window correctly wraps around midnight
- rename the custom simulation logger module to `sim_logging.py` and update all references so the stdlib `logging` module can be imported again
- adjust logging-related tests and docs to use the new module path and provide explicit trade payloads for column assertions

## Testing
- pytest tests/test_no_trade_helpers.py tests/test_logging_columns.py tests/test_execution_profile_logging_and_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b5567658832f9d3eec9df6f5b8d3