### PR TITLE
Fix daily interpolation for hourly multipliers

### DIFF
--- a/tests/test_utils_time_multipliers.py
+++ b/tests/test_utils_time_multipliers.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from utils_time import get_hourly_multiplier
+
+
+def _ts_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+def test_daily_interpolation_progresses_over_entire_day():
+    multipliers = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    monday = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    early = monday + timedelta(hours=1, minutes=30)
+    early_frac = (1.5) / 24.0
+    assert get_hourly_multiplier(_ts_ms(early), multipliers, interpolate=True) == pytest.approx(
+        multipliers[0] + (multipliers[1] - multipliers[0]) * early_frac
+    )
+
+    late = monday + timedelta(hours=23, minutes=30)
+    late_frac = (23.5) / 24.0
+    assert get_hourly_multiplier(_ts_ms(late), multipliers, interpolate=True) == pytest.approx(
+        multipliers[0] + (multipliers[1] - multipliers[0]) * late_frac
+    )
+
+
+def test_daily_interpolation_matches_base_without_interpolation():
+    multipliers = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    monday = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    ts = _ts_ms(monday + timedelta(hours=12))
+
+    assert get_hourly_multiplier(ts, multipliers, interpolate=False) == multipliers[0]

--- a/utils_time.py
+++ b/utils_time.py
@@ -16,7 +16,7 @@ import time
 from pathlib import Path
 import numpy as np
 import clock
-from utils.time import hour_of_week, HOUR_MS, HOURS_IN_WEEK
+from utils.time import hour_of_week, HOUR_MS, HOURS_IN_WEEK, DAY_MS
 
 __all__ = [
     "bar_start_ms",
@@ -394,7 +394,9 @@ def get_hourly_multiplier(
     If ``interpolate`` is ``False`` (default) the multiplier of the nearest
     hour is returned.  When ``True``, the result is linearly interpolated
     between the current hour and the next using the minute offset within the
-    hour.  Missing or short arrays gracefully default to ``1.0``.
+    hour.  When ``multipliers`` contains one value per day (length ``7``), the
+    interpolation spans the whole day instead of just the current hour. Missing
+    or short arrays gracefully default to ``1.0``.
     """
 
     if multipliers is None:
@@ -411,7 +413,11 @@ def get_hourly_multiplier(
         if not interpolate:
             return base
         nxt = float(multipliers[(idx + 1) % length])
-        frac = (ts_ms % HOUR_MS) / float(HOUR_MS)
+        ts_val = int(ts_ms)
+        if length == 7:
+            frac = (ts_val % DAY_MS) / float(DAY_MS)
+        else:
+            frac = (ts_val % HOUR_MS) / float(HOUR_MS)
         return base + (nxt - base) * frac
     except Exception:
         return 1.0


### PR DESCRIPTION
## Summary
- ensure get_hourly_multiplier interpolates daily seasonality over the full day
- cover the daily interpolation behaviour with new unit tests

## Testing
- pytest tests/test_utils_time_multipliers.py

------
https://chatgpt.com/codex/tasks/task_e_68d3bd194404832f91ff7cb59814a1cc