### PR TITLE
Fix ensure_dir helpers to avoid misclassifying extensionless files

### DIFF
--- a/app.py
+++ b/app.py
@@ -446,7 +446,8 @@ with st.sidebar:
     )
 
     logs_dir = st.text_input("Каталог логов", value="logs")
-    _ensure_dir(logs_dir)
+    if logs_dir:
+        os.makedirs(logs_dir, exist_ok=True)
 
     trades_path = st.text_input(
         "Путь к трейдам (для evaluate)",

--- a/ingest_orchestrator.py
+++ b/ingest_orchestrator.py
@@ -27,9 +27,8 @@ _INTERVAL_MS = {
 
 
 def _ensure_dir(path: str) -> None:
-    d = os.path.dirname(path) if os.path.splitext(path)[1] else path
-    if d:
-        os.makedirs(d, exist_ok=True)
+    directory = os.path.dirname(os.fspath(path)) or "."
+    os.makedirs(directory, exist_ok=True)
 
 
 def _pick_base_interval(intervals: List[str]) -> str:
@@ -87,7 +86,7 @@ def main():
     # 1) Ingest klines для всех символов и всех указанных интервалов
     for sym in symbols:
         for interval in intervals:
-            _ensure_dir(klines_dir)
+            os.makedirs(klines_dir, exist_ok=True)
             cmd = [
                 sys.executable,
                 "scripts/ingest_klines.py",
@@ -124,7 +123,7 @@ def main():
     # 3) Для фьючей: funding + mark-price
     if market == "futures":
         for sym in symbols:
-            _ensure_dir(futures_dir)
+            os.makedirs(futures_dir, exist_ok=True)
             cmd = [
                 sys.executable,
                 "scripts/ingest_funding_mark.py",

--- a/service_calibrate_tcost.py
+++ b/service_calibrate_tcost.py
@@ -34,9 +34,8 @@ from legacy_sandbox_config import load_config as load_sandbox_config
 
 
 def _ensure_dir(path: str) -> None:
-    d = os.path.dirname(path) if os.path.splitext(path)[1] else path
-    if d:
-        os.makedirs(d, exist_ok=True)
+    directory = os.path.dirname(os.fspath(path)) or "."
+    os.makedirs(directory, exist_ok=True)
 
 
 def _safe_abs_log_ret(df: pd.DataFrame, sym_col: str, ts_col: str, price_col: str) -> pd.Series:

--- a/service_fetch_exchange_specs.py
+++ b/service_fetch_exchange_specs.py
@@ -60,9 +60,8 @@ def _estimate_kline_tokens(limit: int) -> float:
 
 
 def _ensure_dir(path: str) -> None:
-    d = os.path.dirname(path) if os.path.splitext(path)[1] else path
-    if d:
-        os.makedirs(d, exist_ok=True)
+    directory = os.path.dirname(os.fspath(path)) or "."
+    os.makedirs(directory, exist_ok=True)
 
 
 def _write_json_atomic(path: str, payload: Mapping[str, Any] | Sequence[Any]) -> None:

--- a/services/universe.py
+++ b/services/universe.py
@@ -51,9 +51,8 @@ def _throttled_get(
 
 
 def _ensure_dir(path: str) -> None:
-    d = os.path.dirname(path) if os.path.splitext(path)[1] else path
-    if d:
-        os.makedirs(d, exist_ok=True)
+    directory = os.path.dirname(os.fspath(path)) or "."
+    os.makedirs(directory, exist_ok=True)
 
 
 def run(

--- a/services/utils_app.py
+++ b/services/utils_app.py
@@ -15,9 +15,8 @@ import pandas as pd
 
 
 def ensure_dir(path: str) -> None:
-    d = os.path.dirname(path) if os.path.splitext(path)[1] else path
-    if d:
-        os.makedirs(d, exist_ok=True)
+    directory = os.path.dirname(os.fspath(path)) or "."
+    os.makedirs(directory, exist_ok=True)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update directory helper functions to rely on parent paths instead of filename extensions
- ensure the ingest orchestrator explicitly creates output directories before invoking scripts
- create the Streamlit logs directory immediately when the path input is provided

## Testing
- python -m compileall app.py ingest_orchestrator.py service_calibrate_tcost.py service_fetch_exchange_specs.py services/universe.py services/utils_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c0356cc0832fbe96d7e88f13a3d4