### PR TITLE
Preserve configured close lag in signal runner

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -5415,7 +5415,13 @@ def from_config(
         timeframe_ms = 60_000
 
     cfg.timing.timeframe_ms = int(timeframe_ms)
-    cfg.timing.close_lag_ms = int(resolved_timing.decision_delay_ms)
+    timing_fields_set = getattr(cfg.timing, "model_fields_set", None)
+    if timing_fields_set is None:
+        timing_fields_set = getattr(cfg.timing, "__fields_set__", set())
+    if "close_lag_ms" not in timing_fields_set:
+        cfg.timing.close_lag_ms = int(resolved_timing.decision_delay_ms)
+    else:
+        cfg.timing.close_lag_ms = max(0, int(cfg.timing.close_lag_ms))
     cfg.execution.timeframe_ms = int(timeframe_ms)
     cfg.execution.latency_constant_ms = int(resolved_timing.decision_delay_ms)
     cfg.execution.latency_steps = int(resolved_timing.latency_steps)


### PR DESCRIPTION
## Summary
- keep user-provided timing.close_lag_ms when building the service signal runner
- fall back to the timing profile delay only when the config did not set a close lag

## Testing
- pytest tests/test_service_signal_runner_close_lag.py

------
https://chatgpt.com/codex/tasks/task_e_68d3c73d9c54832fb63b80a4a27272a1