### PR TITLE
Fix signal_runner compatibility export

### DIFF
--- a/signal_runner.py
+++ b/signal_runner.py
@@ -1,11 +1,20 @@
-"""Thin compatibility wrapper for ServiceSignalRunner.
+"""Thin compatibility wrapper for :class:`service_signal_runner.ServiceSignalRunner`.
 
-This module previously contained the business logic for running
-realtime signalers. The logic has been moved to
-:mod:`service_signal_runner`. Importing :class:`SignalRunner` from this
-module now simply re-exports :class:`ServiceSignalRunner`.
+Historically the trading services imported ``SignalRunner`` from this module.
+After the refactor in which the implementation moved to
+``service_signal_runner.ServiceSignalRunner`` the intent was to keep this
+module as a compatibility shim that re-exports the new class.  The previous
+implementation only defined the alias ``SignalRunner`` and forgot to export
+``ServiceSignalRunner`` itself, meaning ``from signal_runner import
+ServiceSignalRunner`` raised :class:`ImportError`.  Some callers – including
+tests – still import the class directly under its original name, so we need to
+expose both symbols.
 """
 
-from service_signal_runner import ServiceSignalRunner as SignalRunner
+from service_signal_runner import ServiceSignalRunner
+
+# Re-export both the legacy name (SignalRunner) and the new explicit class
+# name to preserve backwards compatibility.
+SignalRunner = ServiceSignalRunner
 
 __all__ = ["SignalRunner", "ServiceSignalRunner"]


### PR DESCRIPTION
## Summary
- ensure the compatibility shim in `signal_runner` re-exports both `SignalRunner` and `ServiceSignalRunner`
- document the compatibility behaviour directly in the module

## Testing
- `python - <<'PY'
import importlib
m = importlib.import_module('signal_runner')
print(hasattr(m, 'SignalRunner'))
print(hasattr(m, 'ServiceSignalRunner'))
from signal_runner import SignalRunner, ServiceSignalRunner
print(SignalRunner is ServiceSignalRunner)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d3cc258888832fabbb2bb1fd9c6c3c