### PR TITLE
Fix next_bar_open_ms returning incorrect timestamp

### DIFF
--- a/utils_time.py
+++ b/utils_time.py
@@ -134,7 +134,7 @@ def now_ms() -> int:
 def next_bar_open_ms(close_ms: int, timeframe_ms: int) -> int:
     """Return the open timestamp of the bar following ``close_ms``."""
 
-    return bar_close_ms(close_ms, timeframe_ms)
+    return bar_start_ms(close_ms, timeframe_ms)
 
 
 def interpolate_daily_multipliers(days: Sequence[float]) -> np.ndarray:


### PR DESCRIPTION
## Summary
- correct `next_bar_open_ms` to use the start of the bar containing the provided close timestamp

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3d7340810832fb60d31916343a8b5