### PR TITLE
Fix custom policy import path

### DIFF
--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -137,7 +137,7 @@ torch.backends.cudnn.benchmark = True
 
 
 from trading_patchnew import TradingEnv, DecisionTiming
-from custom_policy_patch import CustomActorCriticPolicy
+from custom_policy_patch1 import CustomActorCriticPolicy
 from fetch_all_data_patch import load_all_data
 # --- ИЗМЕНЕНИЕ: Импортируем быструю Cython-функцию оценки ---
 from evaluation_utils import evaluate_policy_custom_cython


### PR DESCRIPTION
## Summary
- update `train_model_multi_patch.py` to import `CustomActorCriticPolicy` from the existing `custom_policy_patch1` module

## Testing
- python - <<'PY'
from custom_policy_patch1 import CustomActorCriticPolicy
print('Custom policy imported successfully')
PY


------
https://chatgpt.com/codex/tasks/task_e_68d3f0450a34832fb46df43d5d0ebddf