### PR TITLE
Fix evaluate_policy import in multi patch training

### DIFF
--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -140,7 +140,7 @@ from trading_patchnew import TradingEnv, DecisionTiming
 from custom_policy_patch1 import CustomActorCriticPolicy
 from fetch_all_data_patch import load_all_data
 # --- ИЗМЕНЕНИЕ: Импортируем быструю Cython-функцию оценки ---
-from evaluation_utils import evaluate_policy_custom_cython
+from evaluate_policy_custom_cython import evaluate_policy_custom_cython
 from scripts.validate_regime_distributions import compare_regime_distributions
 from data_validation import DataValidator
 from utils.model_io import save_sidecar_metadata, check_model_compat


### PR DESCRIPTION
## Summary
- update train_model_multi_patch to import evaluate_policy_custom_cython from the correct module

## Testing
- python - <<'PY'
import importlib
module = importlib.import_module('evaluate_policy_custom_cython')
print('Loaded module:', module.__name__)
print('Has attribute evaluate_policy_custom_cython:', hasattr(module, 'evaluate_policy_custom_cython'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d3f2c9ad0c832fb5389d4147e02d19