### PR TITLE
Fix next bar open time calculation

### DIFF
--- a/utils_time.py
+++ b/utils_time.py
@@ -134,7 +134,7 @@ def now_ms() -> int:
 def next_bar_open_ms(close_ms: int, timeframe_ms: int) -> int:
     """Return the open timestamp of the bar following ``close_ms``."""
 
-    return bar_start_ms(close_ms, timeframe_ms)
+    return bar_close_ms(close_ms, timeframe_ms)
 
 
 def interpolate_daily_multipliers(days: Sequence[float]) -> np.ndarray:


### PR DESCRIPTION
## Summary
- fix next_bar_open_ms to compute the following bar open using bar_close_ms

## Testing
- pytest tests/test_utils_time_bars.py -q
- pytest tests/test_market_open_h1.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d40e66f0bc832fbedeaee979b13d80