### PR TITLE
Fix SimulationWorkspace nogil allocation issues

### DIFF
--- a/coreworkspace.pxd
+++ b/coreworkspace.pxd
@@ -19,9 +19,11 @@ cdef class SimulationWorkspace:
 
     cdef int trade_count    # Number of trades recorded in the current step
     cdef int filled_count   # Number of order IDs recorded as fully filled in the current step
+    cdef int _capacity      # Allocated slots for each buffer
 
     # Methods for managing the workspace buffers.
     cdef void ensure_capacity(self, int min_capacity) nogil
+    cdef void _resize_buffers(self, int new_capacity)
     cdef void clear_step(self) nogil
     cdef void push_trade(self, double price, double qty, char side, char is_agent_maker, long long ts) nogil
     cdef void push_filled_order_id(self, long long order_id) nogil


### PR DESCRIPTION
## Summary
- declare the SimulationWorkspace capacity field and resize helper in the pxd so the implementation can rely on them
- move buffer reallocation into a GIL-held helper to avoid `cdef` declarations inside `with gil` blocks and keep nogil callers safe

## Testing
- cython -I. --cplus coreworkspace.pyx

------
https://chatgpt.com/codex/tasks/task_e_68d418ea11d0832fb93e7fe7b17aed95