### PR TITLE
Fix pyproject configuration for setuptools build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,55 +23,5 @@ extra = [
     "uvicorn>=0.27.0",
 ]
 
-[tool.setuptools.extension-modules."core.core"]
-sources = ["core/core.pyx"]
-extra-compile-args = ["-O3", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
-[tool.setuptools.extension-modules."exec.lob_book"]
-sources = ["exec/lob_book.pyx"]
-language = "c++"
-extra-compile-args = ["-O3", "-std=c++17", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
-[tool.setuptools.extension-modules."exec.engine"]
-sources = ["exec/engine.pyx"]
-language = "c++"
-extra-compile-args = ["-O3", "-std=c++17", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
-[tool.setuptools.extension-modules."micro.generator"]
-sources = ["micro/generator.pyx"]
-extra-compile-args = ["-O3", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
-[tool.setuptools.extension-modules."market.market_simulator_wrapper"]
-sources = ["market/market_simulator_wrapper.pyx"]
-language = "c++"
-extra-compile-args = ["-O3", "-std=c++17", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
-[tool.setuptools.extension-modules."risk.risk"]
-sources = ["risk/risk.pyx"]
-extra-compile-args = ["-O3", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
- [tool.setuptools.extension-modules."obs.builder"]
- sources = ["obs/builder.pyx"]
- extra-compile-args = ["-O3", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
- # Include NumPy headers for this module
- include-dirs = ["numpy.get_include()"]
-
-[tool.setuptools.extension-modules."reward.reward"]
-sources = ["reward/reward.pyx"]
-extra-compile-args = ["-O3", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
-[tool.setuptools.extension-modules."metrics.metrics"]
-sources = ["metrics/metrics.pyx"]
-extra-compile-args = ["-O3", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
-
- [tool.setuptools.extension-modules."api.environment"]
- sources = ["api/environment.pyx"]
- language = "c++"
- extra-compile-args = ["-O3", "-std=c++17", "-DCYTHON_BOUND_CHECK=0", "-DCYTHON_WRAPAROUND=0"]
- # Include NumPy headers for this module
- include-dirs = ["numpy.get_include()"]
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-
-[DONE]


### PR DESCRIPTION
## Summary
- remove the invalid [tool.setuptools.extension-modules] tables from pyproject.toml to avoid setuptools rejecting the configuration
- leave the build metadata (build-system, dependencies, scripts and pytest settings) intact so setup.py can drive the extension build

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d426f383f4832f898018373fb3146e