### PR TITLE
Refine event batching API for execution engine

### DIFF
--- a/environment.pyx
+++ b/environment.pyx
@@ -20,334 +20,354 @@ import numpy as np
  
 
 cdef class TradingEnv:
-"""
-Торговое окружение с поддержкой режимов FULL_LOB (детальная симуляция стакана)
-и FAST (упрощенный режим). Реализует интерфейс Gym-подобного окружения (reset, step).
-"""
-cdef EnvConfig config
-cdef EnvState state
-cdef SimulationWorkspace workspace
-cdef ExecutionEngine engine
-cdef OrderBook lob
-cdef AgentOrderTracker order_tracker
-cdef MicrostructureGenerator micro_gen
-cdef bint use_full_lob
-cdef double prev_net_worth
-cdef double prev_units
-cdef double last_fill_ratio
-cdef double last_price # последний известный рыночный курс для оценки позиции (цена последней сделки или mid)
-cdef object pending_order # для FAST: незавершенный лимитный ордер
-
-def __init__(self, config: EnvConfig = None):
-    if config is None:
-        config = EnvConfig.default()
-    self.config = config
-    self.use_full_lob = (config.execution_mode.upper() == "FULL_LOB")
-    self._initialize_environment()
-
-def _initialize_environment(self):
-    """Инициализирует состояние и объекты симуляции."""
-    # State initialization
-    self.state = EnvState()
-    self.state.cash = self.config.market.initial_balance
-    self.state.units = 0.0
-    self.state.net_worth = self.config.market.initial_balance
-    self.state.prev_net_worth = self.config.market.initial_balance
-    self.state.peak_value = self.config.market.initial_balance
-    self.state._position_value = 0.0
-    self.state.step_idx = 0
-    self.state.is_bankrupt = False
-    self.state.next_order_id = 1
-    # Load config parameters into state
-    self.state.taker_fee = self.config.execution.taker_fee
-    self.state.maker_fee = self.config.execution.maker_fee
-    self.state.profit_close_bonus = self.config.reward.profit_close_bonus
-    self.state.loss_close_penalty = self.config.reward.loss_close_penalty
-    self.state.bankruptcy_threshold = self.config.risk.bankruptcy_threshold
-    self.state.max_drawdown = self.config.risk.max_drawdown
-    self.state.trade_frequency_penalty = self.config.reward.trade_frequency_penalty
-    self.state.turnover_penalty_coef = self.config.reward.turnover_penalty_coef
-    self.state.use_potential_shaping = self.config.reward.use_potential_shaping
-    self.state.use_legacy_log_reward = self.config.reward.use_legacy_log_reward
-    self.state.gamma = self.config.reward.gamma
-    self.state.last_potential = 0.0
-    self.state.potential_shaping_coef = self.config.reward.potential_shaping_coef
-    self.state.risk_aversion_variance = self.config.reward.risk_aversion_variance
-    self.state.risk_aversion_drawdown = self.config.reward.risk_aversion_drawdown
-    self.state.use_dynamic_risk = self.config.risk.use_dynamic_risk
-    self.state.risk_off_level = self.config.risk.risk_off_level
-    self.state.risk_on_level = self.config.risk.risk_on_level
-    self.state.max_position_risk_off = self.config.risk.max_position_risk_off
-    self.state.max_position_risk_on = self.config.risk.max_position_risk_on
-    self.state.price_scale = self.config.market.price_scale
-    # Internal tracking
-    self.prev_net_worth = self.state.net_worth
-    self.prev_units = self.state.units
-    self.last_fill_ratio = 1.0
-    self.last_price = self.config.market.initial_price
-    self.pending_order = None
-    if self.use_full_lob:
-        self.lob = OrderBook()
-        self.order_tracker = AgentOrderTracker()
-        self.micro_gen = MicrostructureGenerator(self.config.micro.events_per_step,
-                                                 self.config.micro.p_limit_order,
-                                                 self.config.micro.p_market_order,
-                                                 self.config.micro.p_cancel_order)
-        self.workspace = SimulationWorkspace(100)
-        self.engine = ExecutionEngine(self.state, self.lob, self.order_tracker, self.micro_gen, self.workspace)
-    else:
-        self.lob = None
-        self.order_tracker = None
-        self.micro_gen = None
-        self.workspace = None
-        self.engine = None
-
-def reset(self, seed: int = None):
     """
-    Сбрасывает состояние окружения. Если указан seed, задаёт зерно генератора случайностей.
-    Возвращает стартовое наблюдение и info.
+    Торговое окружение с поддержкой режимов FULL_LOB (детальная симуляция стакана)
+    и FAST (упрощенный режим). Реализует интерфейс Gym-подобного окружения (reset, step).
     """
-    if seed is not None:
-        np.random.seed(seed)
-    self._initialize_environment()
-    obs = self._get_observation()
-    info = {}
-    return obs, info
+    cdef EnvConfig config
+    cdef EnvState state
+    cdef SimulationWorkspace workspace
+    cdef ExecutionEngine engine
+    cdef OrderBook lob
+    cdef AgentOrderTracker order_tracker
+    cdef MicrostructureGenerator micro_gen
+    cdef bint use_full_lob
+    cdef double prev_net_worth
+    cdef double prev_units
+    cdef double last_fill_ratio
+    cdef double last_price # последний известный рыночный курс для оценки позиции (цена последней сделки или mid)
+    cdef object pending_order # для FAST: незавершенный лимитный ордер
 
-cpdef tuple step(self, object action):
-    """
-    Выполняет шаг среды с заданным действием агента.
-    Возвращает (обservation, reward, done, info).
-    """
-    self.state.step_idx += 1
-    self.prev_net_worth = self.state.net_worth
-    self.prev_units = self.state.units
-    cdef bint done = False
-    cdef dict info = {}
-    cdef double reward = 0.0
-    # Interpret action
-    cdef double target_fraction = 0.0
-    cdef bint is_limit_order = False
-    if isinstance(action, (list, tuple, np.ndarray)):
-        if len(action) >= 2:
-            target_fraction = <double> action[0]
-            is_limit_order = bool(int(action[1]) != 0)
-        elif len(action) == 1:
-            target_fraction = <double> action[0]
-            is_limit_order = False
-    elif isinstance(action, (int, float)):
-        target_fraction = <double> action
-        is_limit_order = False
-    else:
-        raise ValueError("Unsupported action type")
-    # Clamp fraction to [-1, 1]
-    if target_fraction > 1.0:
-        target_fraction = 1.0
-    if target_fraction < -1.0:
-        target_fraction = -1.0
-    # Dynamic risk limit
-    if self.config.risk.use_dynamic_risk:
-        cdef double max_frac
-        cdef double fg = self.config.risk.fear_greed_value
-        if fg <= self.config.risk.risk_off_level:
-            max_frac = self.config.risk.max_position_risk_off
-        elif fg >= self.config.risk.risk_on_level:
-            max_frac = self.config.risk.max_position_risk_on
+    def __init__(self, config: EnvConfig = None):
+        if config is None:
+            config = EnvConfig.default()
+        self.config = config
+        self.use_full_lob = (config.execution_mode.upper() == "FULL_LOB")
+        self._initialize_environment()
+
+    def _initialize_environment(self):
+        """Инициализирует состояние и объекты симуляции."""
+        # State initialization
+        self.state = EnvState()
+        self.state.cash = self.config.market.initial_balance
+        self.state.units = 0.0
+        self.state.net_worth = self.config.market.initial_balance
+        self.state.prev_net_worth = self.config.market.initial_balance
+        self.state.peak_value = self.config.market.initial_balance
+        self.state._position_value = 0.0
+        self.state.step_idx = 0
+        self.state.is_bankrupt = False
+        self.state.next_order_id = 1
+        # Load config parameters into state
+        self.state.taker_fee = self.config.execution.taker_fee
+        self.state.maker_fee = self.config.execution.maker_fee
+        self.state.profit_close_bonus = self.config.reward.profit_close_bonus
+        self.state.loss_close_penalty = self.config.reward.loss_close_penalty
+        self.state.bankruptcy_threshold = self.config.risk.bankruptcy_threshold
+        self.state.max_drawdown = self.config.risk.max_drawdown
+        self.state.trade_frequency_penalty = self.config.reward.trade_frequency_penalty
+        self.state.turnover_penalty_coef = self.config.reward.turnover_penalty_coef
+        self.state.use_potential_shaping = self.config.reward.use_potential_shaping
+        self.state.use_legacy_log_reward = self.config.reward.use_legacy_log_reward
+        self.state.gamma = self.config.reward.gamma
+        self.state.last_potential = 0.0
+        self.state.potential_shaping_coef = self.config.reward.potential_shaping_coef
+        self.state.risk_aversion_variance = self.config.reward.risk_aversion_variance
+        self.state.risk_aversion_drawdown = self.config.reward.risk_aversion_drawdown
+        self.state.use_dynamic_risk = self.config.risk.use_dynamic_risk
+        self.state.risk_off_level = self.config.risk.risk_off_level
+        self.state.risk_on_level = self.config.risk.risk_on_level
+        self.state.max_position_risk_off = self.config.risk.max_position_risk_off
+        self.state.max_position_risk_on = self.config.risk.max_position_risk_on
+        self.state.price_scale = self.config.market.price_scale
+        # Internal tracking
+        self.prev_net_worth = self.state.net_worth
+        self.prev_units = self.state.units
+        self.last_fill_ratio = 1.0
+        self.last_price = self.config.market.initial_price
+        self.pending_order = None
+        if self.use_full_lob:
+            self.lob = OrderBook()
+            self.order_tracker = AgentOrderTracker()
+            self.micro_gen = MicrostructureGenerator(self.config.micro.events_per_step,
+                                                     self.config.micro.p_limit_order,
+                                                     self.config.micro.p_market_order,
+                                                     self.config.micro.p_cancel_order)
+            self.workspace = SimulationWorkspace(100)
+            self.engine = ExecutionEngine(self.state, self.lob, self.order_tracker, self.micro_gen, self.workspace)
         else:
-            cdef double ratio = (fg - self.config.risk.risk_off_level) / (self.config.risk.risk_on_level - self.config.risk.risk_off_level + 1e-9)
-            if ratio < 0.0:
-                ratio = 0.0
-            if ratio > 1.0:
-                ratio = 1.0
-            max_frac = self.config.risk.max_position_risk_off + ratio * (self.config.risk.max_position_risk_on - self.config.risk.max_position_risk_off)
-        if abs(target_fraction) > max_frac:
-            target_fraction = (target_fraction / abs(target_fraction)) * max_frac
+            self.lob = None
+            self.order_tracker = None
+            self.micro_gen = None
+            self.workspace = None
+            self.engine = None
 
-    cdef double actual_fill_ratio = 1.0
-    cdef double prev_price = self.last_price
-    cdef double current_price = prev_price
-    cdef double vol_imbalance = 0.0
-    cdef int total_trades = 0
-    cdef int agent_trade_count = 0
-    cdef str closed_reason = ""
-    if self.use_full_lob:
-        # Execute via Engine
-        self.engine.step(target_fraction, not is_limit_order)  # True => market order, False => limit
-        total_trades = self.workspace.n_trades
-        vol_imbalance = 0.0
-        agent_trade_count = 0
-        for i in range(total_trades):
-            # We assume SimulationWorkspace provides trade details
-            if self.workspace.agent_taker[i] or self.workspace.agent_maker[i]:
-                agent_trade_count += 1
-                if self.workspace.agent_taker[i]:
-                    # Agent took liquidity in this trade
-                    # Determine side of agent in trade: assume trade_side positive = agent buy, negative = agent sell
-                    if self.workspace.trade_side[i] > 0:
-                        vol_imbalance += self.workspace.trade_volume[i]
-                    elif self.workspace.trade_side[i] < 0:
-                        vol_imbalance -= self.workspace.trade_volume[i]
-        # Determine fill ratio for agent's market order if any
-        if agent_trade_count > 0 and vol_imbalance != 0.0:
-            cdef double expected_vol = 0.0
-            if self.prev_net_worth > 1e-9:
-                expected_vol = abs(target_fraction * self.prev_net_worth / (prev_price if prev_price > 0 else 1.0) - self.prev_units)
-            cdef double filled_vol = abs(self.state.units - self.prev_units)
-            if expected_vol > 1e-9:
-                actual_fill_ratio = filled_vol / expected_vol
-        # Determine current price: use last trade price if any trade occurred, otherwise mid or previous price
-        if total_trades > 0:
-            # Assume last trade price stored
-            current_price = (self.workspace.trade_price[total_trades - 1]) / self.state.price_scale
-        elif self.lob.best_ask > 0 and self.lob.best_bid > 0:
-            current_price = (self.lob.best_ask + self.lob.best_bid) / (2.0 * self.state.price_scale)
+    def reset(self, seed: int = None):
+        """
+        Сбрасывает состояние окружения. Если указан seed, задаёт зерно генератора случайностей.
+        Возвращает стартовое наблюдение и info.
+        """
+        if seed is not None:
+            np.random.seed(seed)
+        self._initialize_environment()
+        obs = self._get_observation()
+        info = {}
+        return obs, info
+
+    cpdef tuple step(self, object action):
+        """
+        Выполняет шаг среды с заданным действием агента.
+        Возвращает (observation, reward, done, info).
+        """
+        self.state.step_idx += 1
+        self.prev_net_worth = self.state.net_worth
+        self.prev_units = self.state.units
+
+        cdef bint done = False
+        cdef dict info = {}
+        cdef double reward = 0.0
+        cdef double target_fraction = 0.0
+        cdef bint is_limit_order = False
+        cdef double max_frac = 0.0
+        cdef double fg = 0.0
+        cdef double ratio = 0.0
+        cdef double actual_fill_ratio = 1.0
+        cdef double prev_price = 0.0
+        cdef double current_price = 0.0
+        cdef double vol_imbalance = 0.0
+        cdef int total_trades = 0
+        cdef int agent_trade_count = 0
+        cdef int i = 0
+        cdef str closed_reason = ""
+        cdef double expected_vol = 0.0
+        cdef double filled_vol = 0.0
+        cdef double tick_size = 0.0
+        cdef double current_fraction = 0.0
+        cdef double target_units = 0.0
+        cdef double needed = 0.0
+        cdef double exec_price = 0.0
+        cdef double trade_value = 0.0
+        cdef double threshold_value = 0.0
+        cdef double drawdown_frac = 0.0
+        cdef double base_reward = 0.0
+        cdef double current_atr = 0.0
+        cdef double open_risk = 0.0
+        cdef double drawdown = 0.0
+        cdef double penalty_value = 0.0
+        cdef double potential = 0.0
+        cdef double shaping_reward = 0.0
+        cdef double realized_spread = 0.0
+        cdef double tick = 0.0
+
+        if isinstance(action, (list, tuple, np.ndarray)):
+            if len(action) >= 2:
+                target_fraction = <double> action[0]
+                is_limit_order = bool(int(action[1]) != 0)
+            elif len(action) == 1:
+                target_fraction = <double> action[0]
+        elif isinstance(action, (int, float)):
+            target_fraction = <double> action
         else:
-            current_price = prev_price
-        self.last_price = current_price
-    else:
-        if self.state.step_idx == 1:
-            current_price = self.config.market.initial_price
-            prev_price = current_price
+            raise ValueError("Unsupported action type")
+
+        if target_fraction > 1.0:
+            target_fraction = 1.0
+        if target_fraction < -1.0:
+            target_fraction = -1.0
+
+        if self.config.risk.use_dynamic_risk:
+            fg = self.config.risk.fear_greed_value
+            if fg <= self.config.risk.risk_off_level:
+                max_frac = self.config.risk.max_position_risk_off
+            elif fg >= self.config.risk.risk_on_level:
+                max_frac = self.config.risk.max_position_risk_on
+            else:
+                ratio = (fg - self.config.risk.risk_off_level) / (self.config.risk.risk_on_level - self.config.risk.risk_off_level + 1e-9)
+                if ratio < 0.0:
+                    ratio = 0.0
+                elif ratio > 1.0:
+                    ratio = 1.0
+                max_frac = self.config.risk.max_position_risk_off + ratio * (self.config.risk.max_position_risk_on - self.config.risk.max_position_risk_off)
+            if abs(target_fraction) > max_frac:
+                target_fraction = (target_fraction / abs(target_fraction)) * max_frac
+
+        prev_price = self.last_price
+        current_price = prev_price
+
+        if self.use_full_lob:
+            self.engine.step(target_fraction, not is_limit_order)
+            total_trades = self.workspace.n_trades
+            vol_imbalance = 0.0
+            agent_trade_count = 0
+
+            for i in range(total_trades):
+                if self.workspace.agent_taker[i] or self.workspace.agent_maker[i]:
+                    agent_trade_count += 1
+                    if self.workspace.agent_taker[i]:
+                        if self.workspace.trade_side[i] > 0:
+                            vol_imbalance += self.workspace.trade_volume[i]
+                        elif self.workspace.trade_side[i] < 0:
+                            vol_imbalance -= self.workspace.trade_volume[i]
+
+            if agent_trade_count > 0 and vol_imbalance != 0.0:
+                expected_vol = 0.0
+                if self.prev_net_worth > 1e-9:
+                    expected_vol = abs(target_fraction * self.prev_net_worth / (prev_price if prev_price > 0 else 1.0) - self.prev_units)
+                filled_vol = abs(self.state.units - self.prev_units)
+                if expected_vol > 1e-9:
+                    actual_fill_ratio = filled_vol / expected_vol
+
+            if total_trades > 0:
+                current_price = self.workspace.trade_price[total_trades - 1] / self.state.price_scale
+            elif self.lob.best_ask > 0 and self.lob.best_bid > 0:
+                current_price = (self.lob.best_ask + self.lob.best_bid) / (2.0 * self.state.price_scale)
+            else:
+                current_price = prev_price
             self.last_price = current_price
         else:
-            current_price = prev_price
-        if not is_limit_order:
-            cdef double tick_size = 1.0 / self.config.market.price_scale
-            # Determine target units corresponding to desired fraction
-            cdef double current_fraction = 0.0
-            if self.state.net_worth > 1e-9:
-                current_fraction = (self.state.units * current_price) / self.state.net_worth
-            if target_fraction > current_fraction:
-                # Buy
-                cdef double target_units = target_fraction * self.state.net_worth / (current_price if current_price > 0 else 1.0)
-                cdef double needed = target_units - self.state.units
-                if needed > 1e-9:
-                    cdef double exec_price = current_price + 0.5 * tick_size
-                    cdef double trade_value = needed * exec_price
-                    self.state.cash -= trade_value
-                    self.state.units += needed
-                    self.state.cash -= trade_value * self.config.execution.taker_fee
-                    agent_trade_count = 1
-            elif target_fraction < current_fraction:
-                # Sell
-                cdef double target_units = target_fraction * self.state.net_worth / (current_price if current_price > 0 else 1.0)
-                cdef double needed = self.state.units - target_units
-                if needed > 1e-9:
-                    cdef double exec_price = current_price - 0.5 * tick_size
-                    cdef double trade_value = needed * exec_price
-                    self.state.cash += trade_value
-                    self.state.units -= needed
-                    self.state.cash -= trade_value * self.config.execution.taker_fee
-                    agent_trade_count = 1
-        else:
-            # Place limit order (no immediate fill in FAST mode)
-            self.pending_order = {"fraction": target_fraction, "side": (1 if target_fraction > ((self.state.units * current_price) / self.state.net_worth if self.state.net_worth>0 else 0) else -1)}
-            agent_trade_count = 0
-        # Update net worth after trades
-        self.state.net_worth = self.state.cash + self.state.units * current_price
-        vol_imbalance = 0.0
-        total_trades = agent_trade_count
-        actual_fill_ratio = 1.0  # assume full fill for any executed trade in FAST
-        self.last_price = current_price
+            if self.state.step_idx == 1:
+                current_price = self.config.market.initial_price
+                prev_price = current_price
+                self.last_price = current_price
+            else:
+                current_price = prev_price
 
-    # Update position value and peak
-    self.state._position_value = self.state.units * current_price
-    if self.state.net_worth > self.state.peak_value:
-        self.state.peak_value = self.state.net_worth
+            if not is_limit_order:
+                tick_size = 1.0 / self.config.market.price_scale
+                current_fraction = 0.0
+                if self.state.net_worth > 1e-9:
+                    current_fraction = (self.state.units * current_price) / self.state.net_worth
+                if target_fraction > current_fraction:
+                    target_units = target_fraction * self.state.net_worth / (current_price if current_price > 0 else 1.0)
+                    needed = target_units - self.state.units
+                    if needed > 1e-9:
+                        exec_price = current_price + 0.5 * tick_size
+                        trade_value = needed * exec_price
+                        self.state.cash -= trade_value
+                        self.state.units += needed
+                        self.state.cash -= trade_value * self.config.execution.taker_fee
+                        agent_trade_count = 1
+                elif target_fraction < current_fraction:
+                    target_units = target_fraction * self.state.net_worth / (current_price if current_price > 0 else 1.0)
+                    needed = self.state.units - target_units
+                    if needed > 1e-9:
+                        exec_price = current_price - 0.5 * tick_size
+                        trade_value = needed * exec_price
+                        self.state.cash += trade_value
+                        self.state.units -= needed
+                        self.state.cash -= trade_value * self.config.execution.taker_fee
+                        agent_trade_count = 1
+            else:
+                self.pending_order = {
+                    "fraction": target_fraction,
+                    "side": (1 if target_fraction > ((self.state.units * current_price) / self.state.net_worth if self.state.net_worth > 0 else 0) else -1),
+                }
+                agent_trade_count = 0
 
-    # Risk management: stops
-    if self.config.risk.use_atr_stop or self.config.risk.use_trailing_stop or self.config.risk.tp_atr_mult > 0:
-        if self.prev_units != 0 and self.state.units == 0:
-            if self.config.risk.use_atr_stop:
-                closed_reason = "atr_sl_long" if self.prev_units > 0 else "atr_sl_short"
-            elif self.config.risk.use_trailing_stop:
-                closed_reason = "trailing_sl_long" if self.prev_units > 0 else "trailing_sl_short"
-            elif self.config.risk.tp_atr_mult > 0:
-                closed_reason = "static_tp_long" if self.prev_units > 0 else "static_tp_short"
-            if self.config.risk.terminate_on_sl_tp:
-                done = True
-    # Bankruptcy check
-    cdef double threshold_value = self.config.risk.bankruptcy_threshold * self.config.market.initial_balance
-    if self.state.net_worth <= threshold_value + 1e-9:
-        self.state.is_bankrupt = True
-        closed_reason = "bankrupt"
-        done = True
-        self.state.cash = 0.0
-        self.state.units = 0.0
-        self.state._position_value = 0.0
-    # Max drawdown check
-    if self.config.risk.max_drawdown < 1.0:
-        cdef double drawdown_frac = 0.0
-        if self.state.peak_value > 1e-9:
-            drawdown_frac = (self.state.peak_value - self.state.net_worth) / self.state.peak_value
-        if drawdown_frac >= self.config.risk.max_drawdown - 1e-9:
-            closed_reason = "max_drawdown"
+            self.state.net_worth = self.state.cash + self.state.units * current_price
+            vol_imbalance = 0.0
+            total_trades = agent_trade_count
+            actual_fill_ratio = 1.0
+            self.last_price = current_price
+
+        self.state._position_value = self.state.units * current_price
+        if self.state.net_worth > self.state.peak_value:
+            self.state.peak_value = self.state.net_worth
+
+        if self.config.risk.use_atr_stop or self.config.risk.use_trailing_stop or self.config.risk.tp_atr_mult > 0:
+            if self.prev_units != 0 and self.state.units == 0:
+                if self.config.risk.use_atr_stop:
+                    closed_reason = "atr_sl_long" if self.prev_units > 0 else "atr_sl_short"
+                elif self.config.risk.use_trailing_stop:
+                    closed_reason = "trailing_sl_long" if self.prev_units > 0 else "trailing_sl_short"
+                elif self.config.risk.tp_atr_mult > 0:
+                    closed_reason = "static_tp_long" if self.prev_units > 0 else "static_tp_short"
+                if self.config.risk.terminate_on_sl_tp:
+                    done = True
+
+        threshold_value = self.config.risk.bankruptcy_threshold * self.config.market.initial_balance
+        if self.state.net_worth <= threshold_value + 1e-9:
+            self.state.is_bankrupt = True
+            closed_reason = "bankrupt"
             done = True
+            self.state.cash = 0.0
+            self.state.units = 0.0
+            self.state._position_value = 0.0
 
-    # Calculate reward
-    cdef double ratio = 1.0
-    if self.prev_net_worth > 1e-9:
-        ratio = self.state.net_worth / self.prev_net_worth
-    if ratio < 1e-4:
-        ratio = 1e-4
-    if ratio > 10.0:
-        ratio = 10.0
-    cdef double base_reward = log(ratio)
-    reward = base_reward
-    if self.config.reward.use_potential_shaping:
-        cdef double current_atr = self.config.market.initial_atr
-        cdef double open_risk = 0.0
+        if self.config.risk.max_drawdown < 1.0:
+            drawdown_frac = 0.0
+            if self.state.peak_value > 1e-9:
+                drawdown_frac = (self.state.peak_value - self.state.net_worth) / self.state.peak_value
+            if drawdown_frac >= self.config.risk.max_drawdown - 1e-9:
+                closed_reason = "max_drawdown"
+                done = True
+
+        ratio = 1.0
+        if self.prev_net_worth > 1e-9:
+            ratio = self.state.net_worth / self.prev_net_worth
+        if ratio < 1e-4:
+            ratio = 1e-4
+        elif ratio > 10.0:
+            ratio = 10.0
+
+        base_reward = log(ratio)
+        reward = base_reward
+        if self.config.reward.use_potential_shaping:
+            current_atr = self.config.market.initial_atr
+            open_risk = 0.0
+            if self.state.net_worth > 1e-9:
+                open_risk = (abs(self.state.units) * current_atr) / self.state.net_worth
+            drawdown = 0.0
+            if self.state.peak_value > 1e-9:
+                drawdown = (self.state.peak_value - self.state.net_worth) / self.state.peak_value
+            penalty_value = self.config.reward.risk_aversion_variance * open_risk + self.config.reward.risk_aversion_drawdown * drawdown
+            potential = -tanh(penalty_value) * self.config.reward.potential_shaping_coef
+            shaping_reward = self.config.reward.gamma * potential - self.state.last_potential
+            reward += shaping_reward
+            self.state.last_potential = potential
+
+        if self.config.reward.trade_frequency_penalty > 1e-9:
+            reward -= self.config.reward.trade_frequency_penalty * agent_trade_count
+        if self.prev_units != 0 and self.state.units == 0:
+            if self.state.net_worth > self.prev_net_worth and self.config.reward.profit_close_bonus > 1e-9:
+                reward += self.config.reward.profit_close_bonus
+            elif self.state.net_worth < self.prev_net_worth and self.config.reward.loss_close_penalty > 1e-9:
+                reward -= self.config.reward.loss_close_penalty
+
+        info["vol_imbalance"] = float(vol_imbalance)
+        info["trade_intensity"] = int(total_trades)
+
+        realized_spread = 0.0
+        if self.use_full_lob:
+            if self.lob.best_ask > 0 and self.lob.best_bid > 0:
+                realized_spread = (self.lob.best_ask - self.lob.best_bid) / (2.0 * self.state.price_scale)
+        else:
+            tick = 1.0 / self.config.market.price_scale
+            realized_spread = tick / 2.0
+        info["realized_spread"] = float(realized_spread)
+
+        if agent_trade_count > 0:
+            self.last_fill_ratio = actual_fill_ratio if actual_fill_ratio <= 1.0 else 1.0
+        info["agent_fill_ratio"] = float(self.last_fill_ratio)
+        info["closed"] = closed_reason if closed_reason else None
+
+        return self._get_observation(), float(reward), bool(done), info
+
+    def _get_observation(self):
+        """
+        Формирует вектор наблюдения на основе текущего состояния.
+        (Упрощенная реализация; для полного набора признаков следует использовать модуль obs.)
+        """
+        cdef list obs_features = []
+        # Cash and position fractions (with tanh clipping)
+        cdef double cash_frac = 0.0
+        cdef double pos_frac = 0.0
         if self.state.net_worth > 1e-9:
-            open_risk = (abs(self.state.units) * current_atr) / self.state.net_worth
-        cdef double drawdown = 0.0
-        if self.state.peak_value > 1e-9:
-            drawdown = (self.state.peak_value - self.state.net_worth) / self.state.peak_value
-        cdef double penalty_value = self.config.reward.risk_aversion_variance * open_risk + self.config.reward.risk_aversion_drawdown * drawdown
-        cdef double potential = -tanh(penalty_value) * self.config.reward.potential_shaping_coef
-        cdef double shaping_reward = self.config.reward.gamma * potential - self.state.last_potential
-        reward += shaping_reward
-        self.state.last_potential = potential
-    if self.config.reward.trade_frequency_penalty > 1e-9:
-        reward -= self.config.reward.trade_frequency_penalty * agent_trade_count
-    if self.prev_units != 0 and self.state.units == 0:
-        if self.state.net_worth > self.prev_net_worth and self.config.reward.profit_close_bonus > 1e-9:
-            reward += self.config.reward.profit_close_bonus
-        elif self.state.net_worth < self.prev_net_worth and self.config.reward.loss_close_penalty > 1e-9:
-            reward -= self.config.reward.loss_close_penalty
-
-    # Info dictionary
-    info["vol_imbalance"] = float(vol_imbalance)
-    info["trade_intensity"] = int(total_trades)
-    cdef double realized_spread = 0.0
-    if self.use_full_lob:
-        if self.lob.best_ask > 0 and self.lob.best_bid > 0:
-            realized_spread = (self.lob.best_ask - self.lob.best_bid) / (2.0 * self.state.price_scale)
-    else:
-        cdef double tick = 1.0 / self.config.market.price_scale
-        realized_spread = tick / 2.0
-    info["realized_spread"] = float(realized_spread)
-    if agent_trade_count > 0:
-        self.last_fill_ratio = actual_fill_ratio if actual_fill_ratio <= 1.0 else 1.0
-    info["agent_fill_ratio"] = float(self.last_fill_ratio)
-    info["closed"] = closed_reason if closed_reason else None
-
-    return self._get_observation(), float(reward), bool(done), info
-
-def _get_observation(self):
-    """
-    Формирует вектор наблюдения на основе текущего состояния.
-    (Упрощенная реализация; для полного набора признаков следует использовать модуль obs.)
-    """
-    cdef list obs_features = []
-    # Cash and position fractions (with tanh clipping)
-    cdef double cash_frac = 0.0
-    cdef double pos_frac = 0.0
-    if self.state.net_worth > 1e-9:
-        cash_frac = self.state.cash / self.state.net_worth
-        pos_frac = self.state._position_value / self.state.net_worth
-    obs_features.append(float(tanh(cash_frac)))
-    obs_features.append(float(tanh(pos_frac)))
-    # Last agent fill ratio
-    obs_features.append(float(self.last_fill_ratio))
-    # (Additional features like indicators, microstructure proxies, etc., are omitted for brevity)
-    return np.array(obs_features, dtype=np.float32)
+            cash_frac = self.state.cash / self.state.net_worth
+            pos_frac = self.state._position_value / self.state.net_worth
+        obs_features.append(float(tanh(cash_frac)))
+        obs_features.append(float(tanh(pos_frac)))
+        # Last agent fill ratio
+        obs_features.append(float(self.last_fill_ratio))
+        # (Additional features like indicators, microstructure proxies, etc., are omitted for brevity)
+        return np.array(obs_features, dtype=np.float32)

--- a/execaction_interpreter.pyx
+++ b/execaction_interpreter.pyx
@@ -12,6 +12,10 @@ import core_constants as constants
 # For generating unique order IDs for agent orders (shim for environment's next_order_id)
 cdef int _next_order_id = 1  # NOTE: shim for integration; replace with state.next_order_id management later
 
+# Expose enum values as Python integers to avoid attribute lookups on the cdef enum.
+SIDE_BUY = <int> Side.BUY
+SIDE_SELL = <int> Side.SELL
+
 def build_agent_event_set(state, tracker, params, action):
     """
     Interpret the agent's action and generate a set of agent events for this step.
@@ -105,9 +109,9 @@ def build_agent_event_set(state, tracker, params, action):
     try:
         # Check buy side orders
         if tracker is not None:
-            existing_id = tracker.find_closest_order(price * constants.PRICE_SCALE, Side.BUY)
+            existing_id = tracker.find_closest_order(price * constants.PRICE_SCALE, SIDE_BUY)
             if existing_id == -1:
-                existing_id = tracker.find_closest_order(price * constants.PRICE_SCALE, Side.SELL)
+                existing_id = tracker.find_closest_order(price * constants.PRICE_SCALE, SIDE_SELL)
     except AttributeError:
         existing_id = -1
 

--- a/execevents.pyx
+++ b/execevents.pyx
@@ -1,12 +1,7 @@
 # cython: language_level=3
 import random
 
-cimport cython
-from libc.stdlib cimport malloc, free
-
-from execevents cimport EventType, Side, MarketEvent
-from execlob_book cimport CythonLOB
-from coreworkspace cimport SimulationWorkspace
+from execevents cimport EventType, Side
 
 def build_agent_limit_add(double mid_price, int side, int qty, int next_order_id):
     """
@@ -74,20 +69,5 @@ def apply_agent_events(state, tracker, microgen, lob, ws, events_list):
     cdef int n = len(all_events)
     if n == 0:
         return
-    # Allocate C array for events
-    cdef MarketEvent* events = <MarketEvent*> malloc(n * cython.sizeof(MarketEvent))
-    if events == NULL:
-        raise MemoryError("Failed to allocate events array")
-    cdef int i
-    cdef object evt
-    for i in range(n):
-        # Each event in list is expected as a tuple (type, side, price, qty, order_id)
-        evt = all_events[i]
-        events[i].type = <EventType> evt[0]
-        events[i].side = <Side> evt[1]
-        events[i].price = <int> evt[2]
-        events[i].qty = <int> evt[3]
-        events[i].order_id = <int> evt[4]
-    (<CythonLOB> lob).apply_events_batch_nogil(events, n, <SimulationWorkspace> ws)
-    # Free allocated events array
-    free(events)
+    # Dispatch events through the LOB helper
+    lob.apply_events_batch(all_events, ws)

--- a/execlob_book.pxd
+++ b/execlob_book.pxd
@@ -19,11 +19,17 @@ cdef class CythonLOB:
         # Best bid and ask indices (for quick access, updated as needed)
         int best_bid_index
         int best_ask_index
+    cdef bint _pending_market_is_agent
 
     cpdef CythonLOB clone(self)
     cdef void _ensure_capacity(self, bint is_bid, int min_capacity) nogil
+    cdef int _find_order_index_by_id(self, int order_id, bint is_bid) nogil
     cdef void add_limit(self, int side, int price, int qty, bint is_agent, int order_id) nogil
     cdef void cancel_order(self, int order_id) nogil
     cdef void match_market(self, int side, int qty, SimulationWorkspace ws) nogil
+    cdef void _record_trade(self, SimulationWorkspace ws, int price, int qty, int side,
+                            bint agent_maker, bint agent_taker, int maker_order_id) nogil
     cpdef double mid_price(self)
     cdef void apply_events_batch_nogil(self, MarketEvent* events, int num_events, SimulationWorkspace ws) nogil
+    cpdef void apply_events_batch(self, list events, SimulationWorkspace ws)
+    cpdef list iter_agent_orders(self)


### PR DESCRIPTION
## Summary
- add a Python-facing `apply_events_batch` on `CythonLOB` that marshals tuples into the existing nogil batch processor
- refactor `execevents.apply_agent_events` to call the helper directly, removing the manual struct management that required missing `.pxd` imports
- declare the internal workspace helpers in `execlob_book.pxd`, keeping the LOB definition consistent between interface and implementation files

## Testing
- `python -m cython --cplus -I . execevents.pyx`
- `python -m cython --cplus -I . execlob_book.pyx`


------
https://chatgpt.com/codex/tasks/task_e_68d44e3ab90c832fa99b4465fa9961ba