### PR TITLE
Fix Cython agent state declarations

### DIFF
--- a/lob_state_cython.pxd
+++ b/lob_state_cython.pxd
@@ -82,7 +82,7 @@ cdef class EnvState:
     cdef public double _position_value
     cdef public int step_idx
     cdef public bint is_bankrupt
-    cdef public AgentOrderTracker* agent_orders_ptr
+    cdef AgentOrderTracker* agent_orders_ptr
     cdef public unsigned long long next_order_id
 
     cdef public bint use_atr_stop


### PR DESCRIPTION
## Summary
- enable C++ mode for the lob_state Cython module and expand the AgentOrderTracker declarations so Cython sees every C++ method signature
- keep the EnvState agent order tracker pointer internal to C while ensuring it is allocated and freed safely during lifecycle hooks
- clean up the runtime helpers (MarketSimulatorWrapper, agent order updates, reward function) so their C variables are declared up-front and no longer trigger Cython syntax errors

## Testing
- `cython --cplus lob_state_cython.pyx` *(fails: repository lacks required .pxd headers such as fast_lob.pxd and coreworkspace.pxd)*

------
https://chatgpt.com/codex/tasks/task_e_68d461c640cc832f8d23b4115485f950