### PR TITLE
Implement full MarketSimulator wrapper bindings

### DIFF
--- a/marketmarket_simulator_wrapper.pxd
+++ b/marketmarket_simulator_wrapper.pxd
@@ -1,15 +1,61 @@
-cimport libc.stdint
+from libc.stddef cimport size_t
+from libc.stdint cimport uint64_t
+from libcpp.array cimport array
 
-# Cython interface for the MarketSimulatorWrapper
+from core_constants cimport MarketRegime
+
+cdef extern from "MarketSimulator.h" nogil:
+    cdef cppclass MarketSimulator:
+        MarketSimulator(
+            double* price,
+            double* open,
+            double* high,
+            double* low,
+            double* volume_usd,
+            size_t n_steps,
+            uint64_t seed=0
+        ) except +
+        double step(size_t i, double black_swan_probability, bint is_training_mode)
+        void set_seed(uint64_t seed)
+        void set_regime_distribution(const array[double, 4]& probs)
+        void enable_random_shocks(bint enable, double probability_per_step)
+        void force_market_regime(MarketRegime regime, size_t start, size_t duration)
+        void set_liquidity_seasonality(const array[double, 168]& multipliers)
+        int shock_triggered(size_t i) const
+        double get_ma5(size_t i) const
+        double get_ma20(size_t i) const
+        double get_atr(size_t i) const
+        double get_rsi(size_t i) const
+        double get_macd(size_t i) const
+        double get_macd_signal(size_t i) const
+        double get_momentum(size_t i) const
+        double get_cci(size_t i) const
+        double get_obv(size_t i) const
+        double get_bb_lower(size_t i) const
+        double get_bb_upper(size_t i) const
+
+
 cdef class MarketSimulatorWrapper:
     """Cython wrapper for the C++ MarketSimulator (safe interface)."""
+    cdef MarketSimulator* _sim
     cdef public bint _random_shocks_enabled
     cdef public bint _last_shock
     cdef double _last_price
-    cpdef void set_seed(self, libc.stdint.uint64_t seed)
-    cpdef void enable_random_shocks(self, bint enable)
-    cpdef void step(self, int step_index, double black_swan_probability, bint is_training_mode)
-    cpdef bint shock_triggered(self)
+    cdef size_t _last_step
+    cdef double _flash_probability
+    cdef array[double, 4] _regime_probs
+    cdef array[double, 168] _liquidity_multipliers
+    cdef object _price_ref
+    cdef object _open_ref
+    cdef object _high_ref
+    cdef object _low_ref
+    cdef object _volume_ref
+    cdef size_t _n_steps
+
+    cpdef void set_seed(self, uint64_t seed)
+    cpdef void enable_random_shocks(self, bint enable, double probability=0.01)
+    cpdef double step(self, int step_index, double black_swan_probability, bint is_training_mode)
+    cpdef int shock_triggered(self, long step_idx=-1)
     cpdef double get_last_price(self)
     cpdef double get_ma5(self)
     cpdef double get_ma20(self)
@@ -22,4 +68,8 @@ cdef class MarketSimulatorWrapper:
     cpdef double get_obv(self)
     cpdef double get_bb_lower(self)
     cpdef double get_bb_upper(self)
-    cpdef void force_market_regime(self, object name, int start, int duration)
+    cpdef void set_regime_distribution(self, object probabilities)
+    cpdef object get_regime_distribution(self)
+    cpdef void set_liquidity_seasonality(self, object multipliers)
+    cpdef object get_liquidity_seasonality(self)
+    cpdef void force_market_regime(self, object regime, int start=0, int duration=0)

--- a/marketmarket_simulator_wrapper.pyx
+++ b/marketmarket_simulator_wrapper.pyx
@@ -1,127 +1,198 @@
-import math
+# cython: language_level=3
+# distutils: language = c++
 
+import numpy as np
+
+cimport numpy as np
+
+from libc.stddef cimport size_t
 from libc.stdint cimport uint64_t
+
+from core_constants cimport MarketRegime
+
+np.import_array()
+
+
+cdef inline double _clamp_non_negative(double value) nogil:
+    if value < 0.0:
+        return 0.0
+    return value
+
 
 cdef class MarketSimulatorWrapper:
     """Cython wrapper for MarketSimulator, providing safe access to simulation and indicators."""
-    cdef public bint _random_shocks_enabled
-    cdef public bint _last_shock       # whether last step had a shock
-    cdef double _last_price
 
-    def __cinit__(self):
-        # Initialize default state
+    def __cinit__(self,
+                  object price_arr not None,
+                  object open_arr not None,
+                  object high_arr not None,
+                  object low_arr not None,
+                  object volume_usd_arr not None,
+                  uint64_t seed=0):
+        cdef np.ndarray[np.float64_t, ndim=1] price = np.ascontiguousarray(price_arr, dtype=np.float64)
+        cdef np.ndarray[np.float64_t, ndim=1] open_ = np.ascontiguousarray(open_arr, dtype=np.float64)
+        cdef np.ndarray[np.float64_t, ndim=1] high = np.ascontiguousarray(high_arr, dtype=np.float64)
+        cdef np.ndarray[np.float64_t, ndim=1] low = np.ascontiguousarray(low_arr, dtype=np.float64)
+        cdef np.ndarray[np.float64_t, ndim=1] volume = np.ascontiguousarray(volume_usd_arr, dtype=np.float64)
+
+        if price.shape[0] != open_.shape[0] or price.shape[0] != high.shape[0] or \
+           price.shape[0] != low.shape[0] or price.shape[0] != volume.shape[0]:
+            raise ValueError("All OHLCV arrays must have the same length")
+        if price.shape[0] == 0:
+            raise ValueError("Market simulator requires at least one timestep")
+
+        self._price_ref = price
+        self._open_ref = open_
+        self._high_ref = high
+        self._low_ref = low
+        self._volume_ref = volume
+        self._n_steps = <size_t>price.shape[0]
+
+        self._sim = new MarketSimulator(&price[0], &open_[0], &high[0], &low[0], &volume[0], self._n_steps, seed)
+        if self._sim is NULL:
+            raise MemoryError("Failed to allocate MarketSimulator")
+
         self._random_shocks_enabled = False
+        self._flash_probability = 0.0
         self._last_shock = False
-        # Set a default last price (e.g., 100.0 as a safe initial price)
-        self._last_price = 100.0
+        self._last_price = 0.0
+        self._last_step = 0
+
+        cdef int i
+        for i in range(4):
+            self._regime_probs[i] = 0.0
+        for i in range(168):
+            self._liquidity_multipliers[i] = 1.0
+
+        # Mirror the C++ default distribution (or configuration file if present)
+        try:
+            import json as _json
+            import os as _os
+            path = _os.getenv("MARKET_REGIMES_JSON", "configs/market_regimes.json")
+            with open(path, "r") as fh:
+                data = _json.load(fh)
+            probs = data.get("regime_probs", [0.8, 0.05, 0.10, 0.05])
+        except Exception:
+            probs = [0.8, 0.05, 0.10, 0.05]
+        self.set_regime_distribution(probs)
+
+    def __dealloc__(self):
+        if self._sim is not NULL:
+            del self._sim
+            self._sim = NULL
 
     cpdef void set_seed(self, uint64_t seed):
-        """Set the random seed for the market simulation (if applicable)."""
-        # NOTE: shim for integration
-        import random
-        random.seed(seed)  # Use Python RNG for stub simulation
-        self._last_price = 100.0  # reset price (optional)
-
-    cpdef void enable_random_shocks(self, bint enable):
-        """Enable or disable random shock events in the simulation."""
-        # NOTE: shim for integration
-        self._random_shocks_enabled = enable
-
-    cpdef void step(self, int step_index, double black_swan_probability, bint is_training_mode):
-        """Advance the market simulation by one step, with optional shock probability."""
-        # NOTE: shim for integration
-        # Simulate a single step: update last price and possibly trigger a shock
+        self._sim.set_seed(seed)
+        self._last_price = 0.0
         self._last_shock = False
-        if self._random_shocks_enabled and black_swan_probability > 0.0:
-            import random
-            # Determine if a shock event occurs this step
-            if random.random() < black_swan_probability:
-                # Trigger a shock: simulate a sudden large price drop (black swan event)
-                self._last_price *= 0.5  # e.g., 50% crash as a placeholder effect
-                self._last_shock = True
-        # If no shock, simulate a normal small price movement
-        if not self._last_shock:
-            import random
-            # Simple random walk for price (up or down one tick unit)
-            # Assume a tick is 1.0e-2 for simulation (1 cent if price ~ dollars)
-            tick = 1.0 / (getattr(math, "nan", 100.0) or 100.0)  # fallback tick (this line ensures tick is defined)
-            # Actually, simpler: use a fixed small increment as tick
-            tick = 0.01
-            if random.random() < 0.5:
-                # Price goes up by one tick
-                self._last_price += tick
-            else:
-                # Price goes down by one tick, but not below 0
-                new_price = self._last_price - tick
-                self._last_price = new_price if new_price > 0.0 else self._last_price
+        self._last_step = 0
 
-    cpdef bint shock_triggered(self):
-        """Return True if a shock event was triggered in the last step."""
-        # NOTE: shim for integration
-        return self._last_shock
+    cpdef void enable_random_shocks(self, bint enable, double probability=0.01):
+        if probability < 0.0:
+            probability = 0.0
+        self._sim.enable_random_shocks(enable, probability)
+        self._random_shocks_enabled = enable
+        self._flash_probability = probability
+
+    cpdef double step(self, int step_index, double black_swan_probability, bint is_training_mode):
+        if step_index < 0:
+            raise ValueError("step_index must be non-negative")
+        self._last_step = <size_t>step_index
+        self._last_price = self._sim.step(self._last_step, black_swan_probability, is_training_mode)
+        self._last_shock = self._sim.shock_triggered(self._last_step) != 0
+        return self._last_price
+
+    cpdef int shock_triggered(self, long step_idx=-1):
+        cdef size_t idx
+        if step_idx < 0:
+            idx = self._last_step
+        else:
+            idx = <size_t>step_idx
+        return self._sim.shock_triggered(idx)
 
     cpdef double get_last_price(self):
-        """Get the latest market price (close or mid price)."""
-        # NOTE: shim for integration
+        if self._last_step < self._n_steps:
+            return (<np.ndarray[np.float64_t, ndim=1]>self._price_ref)[self._last_step]
         return self._last_price
 
     cpdef double get_ma5(self):
-        """Get the 5-period moving average (MA5) indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_ma5(self._last_step)
 
     cpdef double get_ma20(self):
-        """Get the 20-period moving average (MA20) indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_ma20(self._last_step)
 
     cpdef double get_atr(self):
-        """Get the Average True Range (ATR) indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_atr(self._last_step)
 
     cpdef double get_rsi(self):
-        """Get the Relative Strength Index (RSI14) indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_rsi(self._last_step)
 
     cpdef double get_macd(self):
-        """Get the MACD indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_macd(self._last_step)
 
     cpdef double get_macd_signal(self):
-        """Get the MACD signal line (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_macd_signal(self._last_step)
 
     cpdef double get_momentum(self):
-        """Get the Momentum indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_momentum(self._last_step)
 
     cpdef double get_cci(self):
-        """Get the Commodity Channel Index (CCI) indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_cci(self._last_step)
 
     cpdef double get_obv(self):
-        """Get the On-Balance Volume (OBV) indicator (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_obv(self._last_step)
 
     cpdef double get_bb_lower(self):
-        """Get the Bollinger Bands lower band (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_bb_lower(self._last_step)
 
     cpdef double get_bb_upper(self):
-        """Get the Bollinger Bands upper band (if available)."""
-        # NOTE: shim for integration
-        return <double> float('nan')
+        return self._sim.get_bb_upper(self._last_step)
 
-    cpdef void force_market_regime(self, object name, int start, int duration):
-        """Force a specific market regime (e.g., NORMAL, TREND) for a given duration."""
-        # NOTE: shim for integration
-        # This stub does not implement regime changes. In integration, it would adjust internal market parameters.
-        return
+    cpdef void set_regime_distribution(self, object probabilities):
+        cdef np.ndarray[np.float64_t, ndim=1] probs = np.ascontiguousarray(probabilities, dtype=np.float64)
+        if probs.size != 4:
+            raise ValueError("regime distribution must contain exactly four values")
+        cdef double total = 0.0
+        cdef int i
+        for i in range(4):
+            if probs[i] < 0.0:
+                raise ValueError("regime probabilities must be non-negative")
+            total += probs[i]
+        if total <= 0.0:
+            raise ValueError("regime probabilities must sum to a positive value")
+        for i in range(4):
+            self._regime_probs[i] = probs[i] / total
+        self._sim.set_regime_distribution(self._regime_probs)
+
+    cpdef object get_regime_distribution(self):
+        cdef np.ndarray[np.float64_t, ndim=1] out = np.empty(4, dtype=np.float64)
+        cdef int i
+        for i in range(4):
+            out[i] = self._regime_probs[i]
+        return out
+
+    cpdef void set_liquidity_seasonality(self, object multipliers):
+        cdef np.ndarray[np.float64_t, ndim=1] mult = np.ascontiguousarray(multipliers, dtype=np.float64)
+        if mult.size != 168:
+            raise ValueError("liquidity seasonality must contain 168 hourly multipliers")
+        cdef int i
+        for i in range(168):
+            self._liquidity_multipliers[i] = _clamp_non_negative(mult[i])
+        self._sim.set_liquidity_seasonality(self._liquidity_multipliers)
+
+    cpdef object get_liquidity_seasonality(self):
+        cdef np.ndarray[np.float64_t, ndim=1] out = np.empty(168, dtype=np.float64)
+        cdef int i
+        for i in range(168):
+            out[i] = self._liquidity_multipliers[i]
+        return out
+
+    cpdef void force_market_regime(self, object regime, int start=0, int duration=0):
+        cdef MarketRegime regime_code
+        try:
+            regime_code = <MarketRegime><int>regime
+        except Exception:
+            raise ValueError("regime must be convertible to MarketRegime enum")
+        if start < 0 or duration < 0:
+            raise ValueError("start and duration must be non-negative")
+        self._sim.force_market_regime(regime_code, <size_t>start, <size_t>duration)


### PR DESCRIPTION
## Summary
- expose the C++ MarketSimulator interface in `marketmarket_simulator_wrapper.pxd`, including lifecycle state and regime/liquidity helpers
- reimplement `MarketSimulatorWrapper` to manage numpy-backed OHLCV buffers, forward calls to the C++ simulator, and keep metadata such as last step, shocks, and regime probabilities in sync
- add convenience accessors for regime distributions and liquidity seasonality while mirroring defaults from the shared JSON configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d466b02f44832fbe93ffd697298f05