### PR TITLE
Build micro_sim extension without cython warnings

### DIFF
--- a/cpp_microstructure_generator.h
+++ b/cpp_microstructure_generator.h
@@ -195,6 +195,12 @@ public:
 
     // Доступ к λ̂ (после применения шоков/режимов)
     const std::array<double, CH_K>& lambda_hat() const { return m_lambda_hat; }
+    void copy_lambda_hat(double* out) const {
+        if (!out) return;
+        for (int k = 0; k < CH_K; ++k) {
+            out[k] = m_lambda_hat[k];
+        }
+    }
 
 private:
     // ----------------- внутреннее состояние -----------------

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,16 @@ ext_modules = [
         extra_compile_args=cxx_args,
         extra_link_args=link_args,
     ),
+    Extension(
+        name="micro_sim",
+        sources=["micro_sim.pyx", orderbook_cpp, micro_cpp],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c++",
+        extra_compile_args=cxx_args,
+        extra_link_args=link_args,
+    ),
 ]
 
 setup(


### PR DESCRIPTION
## Summary
- expose a safe MicrostructureGenerator::copy_lambda_hat helper so λ̂ data can be exported without raw pointer hacks
- update the MicroSim cython wrapper to use typed enums, validate regimes, and populate numpy arrays via the new helper
- register the micro_sim Cython module with setuptools so it is compiled together with fast_lob

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d46c59ed54832fac0da224d6777f47