### PR TITLE
Fix micromicrogen Cython definitions

### DIFF
--- a/micromicrogen.pxd
+++ b/micromicrogen.pxd
@@ -10,22 +10,11 @@ cdef class CyMicrostructureGenerator:
     cdef libc.stdint.uint64_t _inc
     cdef libc.stdint.uint32_t _order_seq
 
-
-
-
-
-# Cython declarations for the microstructure event generator
-cdef class CyMicrostructureGenerator:
-    """Simple microstructure generator used from Python code."""
-    cdef object _rng
-
-
     cdef double momentum_factor
     cdef double mean_reversion_factor
     cdef double base_order_imbalance_ratio
     cdef double base_cancel_ratio
     cdef double adversarial_factor
-
 
     cdef int _last_side
     cdef int current_price
@@ -40,28 +29,10 @@ cdef class CyMicrostructureGenerator:
                           double adversarial_factor)
     cdef int generate_public_events_into(self, MarketEvent* out_events,
                                          size_t buf_len,
-                                         int max_events)
-    cdef void _reset_parameters(self)
-
-
-
-
-    cdef int _last_side
-    cpdef void seed(self, unsigned long long seed)
-    cpdef void set_regime(self, double base_order_imbalance_ratio,
-                           double base_cancel_ratio,
-                           double momentum_factor,
-                           double mean_reversion_factor,
-                           double adversarial_factor)
+                                         int max_events) nogil
     cpdef list generate_public_events(self, object state, object tracker,
                                       object lob, int max_events=*)
-    cdef void _reset_defaults(self)
-    cdef int _determine_event_count(self, int max_events)
-    cdef double _resolve_mid_price(self, object state, object lob)
-    cdef tuple _build_single_event(self, int mid_ticks)
-    cdef int _choose_side(self)
-    cdef int _sample_limit_price(self, int mid_ticks, int side)
-    cdef int _sample_quantity(self)
+    cdef void _reset_parameters(self)
 
 
 

--- a/micromicrogen.pyx
+++ b/micromicrogen.pyx
@@ -1,12 +1,11 @@
-
 # cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
 """Low level public microstructure event generator.
 
 This module exposes :class:`CyMicrostructureGenerator` which mirrors the
 behaviour of the historical implementation relied upon by the execution
 simulator.  The generator operates entirely under ``nogil`` when filling a
-``MarketEvent`` memoryview, uses a PCG32 random number generator and maintains
-an internal representation of the best bid/ask and last trade price so that the
+``MarketEvent`` buffer, uses a PCG32 random number generator and maintains an
+internal representation of the best bid/ask and last trade price so that the
 produced flow reacts to prior activity.  Each limit order receives a unique
 ``order_id`` allowing downstream components to reconstruct book state.
 """
@@ -93,77 +92,42 @@ cdef class CyMicrostructureGenerator:
             self.best_bid = 0
         self.best_ask = self.current_price + 1
 
-
-
-
-"""Simple microstructure generator used by the Python simulation stack.
-
-The previous revision attempted to implement a fully ``nogil`` PCG based
-event generator that wrote directly into a ``MarketEvent`` memory view.  The
-structure definition that code relied on no longer exists which caused Cython
-to emit multiple syntax and attribute errors (missing ``owner`` field,
-unmatched method signature used from Python, invalid ``cdef`` statements in a
-``with gil`` block, etc.).  For the high level simulator we only need a small
-Python friendly generator that returns tuples describing public events.  The
-rewritten implementation below keeps the configuration surface intact while
-removing the invalid low level constructs so the module can compile again.
-"""
-
-# cython: language_level=3
-from libc.stdint cimport uint64_t
-
-import random
-
-import core_constants as constants
-from execevents cimport EventType, Side
-
-
-cdef class CyMicrostructureGenerator:
-    """Generate lightweight public order flow for tests and Python sims."""
-
-    def __cinit__(self):
-        self._rng = random.Random()
-        self._reset_defaults()
-
-    cpdef void seed(self, uint64_t seed):
-        """Seed the internal RNG (``random.Random`` wrapper)."""
-        self._rng.seed(seed)
-        self._last_side = 0
-
-
-
-
-
     cpdef void set_regime(self,
                           double base_order_imbalance_ratio,
                           double base_cancel_ratio,
                           double momentum_factor,
                           double mean_reversion_factor,
                           double adversarial_factor):
-
-
-
-
-        """Configure the generator parameters used when producing events."""
-
-
-
-
+        """Configure behavioural coefficients used when sampling events."""
         self.base_order_imbalance_ratio = base_order_imbalance_ratio
         self.base_cancel_ratio = base_cancel_ratio
         self.momentum_factor = momentum_factor
         self.mean_reversion_factor = mean_reversion_factor
         self.adversarial_factor = adversarial_factor
 
+    cdef void _reset_parameters(self):
+        self.momentum_factor = 0.0
+        self.mean_reversion_factor = 0.0
+        self.base_order_imbalance_ratio = 1.0
+        self.base_cancel_ratio = 0.05
+        self.adversarial_factor = 0.0
+        self._last_side = 0
+        self.current_price = 100 * PRICE_SCALE
+        if self.current_price < PRICE_SCALE:
+            self.current_price = PRICE_SCALE
+        self.best_bid = self.current_price - 1
+        if self.best_bid < 0:
+            self.best_bid = 0
+        self.best_ask = self.current_price + 1
 
     cdef int generate_public_events_into(self,
                                          MarketEvent* out_events,
                                          size_t buf_len,
-                                         int max_events):
+                                         int max_events) nogil:
         """Fill ``out_events`` with up to ``max_events`` public market events."""
-        if out_events == NULL or buf_len <= 0 or max_events <= 0:
+        if out_events == NULL or buf_len == 0 or max_events <= 0:
             return 0
-        if max_events > buf_len:
+        if max_events > <int>buf_len:
             max_events = <int>buf_len
 
         cdef double lam = 1.0 + self.adversarial_factor
@@ -349,10 +313,18 @@ cdef class CyMicrostructureGenerator:
 
         return events_count
 
-    def generate_public_events(self, object state, object tracker, object lob, int max_events=16):
-        """Python helper returning a list of tuples for compatibility layers."""
+    cpdef list generate_public_events(self,
+                                      object state,
+                                      object tracker,
+                                      object lob,
+                                      int max_events=16):
+        """Return a Python list of tuples representing generated events."""
         if max_events <= 0:
             return []
+
+        # ``tracker`` is currently unused but retained for API compatibility.
+        if tracker is not None:
+            pass
 
         cdef long long bid_hint = 0
         cdef long long ask_hint = 0
@@ -365,32 +337,32 @@ cdef class CyMicrostructureGenerator:
             if lob is not None:
                 getter = getattr(lob, "get_best_bid", None)
                 if getter is not None:
-                    bid_hint = <long long> getter()
+                    bid_hint = <long long>getter()
                     have_bid = bid_hint > 0
                 elif hasattr(lob, "best_bid"):
-                    bid_hint = <long long> getattr(lob, "best_bid")
+                    bid_hint = <long long>getattr(lob, "best_bid")
                     have_bid = bid_hint > 0
 
                 getter = getattr(lob, "get_best_ask", None)
                 if getter is not None:
-                    ask_hint = <long long> getter()
+                    ask_hint = <long long>getter()
                     have_ask = ask_hint > 0
                 elif hasattr(lob, "best_ask"):
-                    ask_hint = <long long> getattr(lob, "best_ask")
+                    ask_hint = <long long>getattr(lob, "best_ask")
                     have_ask = ask_hint > 0
         except Exception:
             have_bid = have_ask = False
 
         if have_bid and have_ask and ask_hint > bid_hint:
-            self.best_bid = <int> bid_hint
-            self.best_ask = <int> ask_hint
-            self.current_price = <int> ((bid_hint + ask_hint) // 2)
+            self.best_bid = <int>bid_hint
+            self.best_ask = <int>ask_hint
+            self.current_price = <int>((bid_hint + ask_hint) // 2)
         elif have_bid and not have_ask and bid_hint > 0:
-            self.best_bid = <int> bid_hint
+            self.best_bid = <int>bid_hint
             self.best_ask = self.best_bid + 1
             self.current_price = self.best_bid
         elif have_ask and not have_bid and ask_hint > 0:
-            self.best_ask = <int> ask_hint
+            self.best_ask = <int>ask_hint
             self.best_bid = self.best_ask - 1 if self.best_ask > 0 else 0
             self.current_price = self.best_ask
 
@@ -400,7 +372,7 @@ cdef class CyMicrostructureGenerator:
                 if price_attr is not None:
                     last_price = float(price_attr)
                     if last_price > 0:
-                        price_ticks = <int> (last_price * PRICE_SCALE)
+                        price_ticks = <int>(last_price * PRICE_SCALE)
                         if price_ticks > 0:
                             self.current_price = price_ticks
                             if self.best_bid <= 0:
@@ -410,150 +382,24 @@ cdef class CyMicrostructureGenerator:
             except Exception:
                 pass
 
-        cdef size_t capacity = <size_t> max_events
-        cdef MarketEvent* buffer = <MarketEvent*> PyMem_Malloc(capacity * cython.sizeof(MarketEvent))
+        cdef size_t capacity = <size_t>max_events
+        cdef MarketEvent* buffer = <MarketEvent*>PyMem_Malloc(capacity * cython.sizeof(MarketEvent))
         if buffer == NULL:
             raise MemoryError("Failed to allocate event buffer")
 
         cdef int produced = 0
+        cdef list result = []
         cdef int i
+
         try:
             produced = self.generate_public_events_into(buffer, capacity, max_events)
-            result = []
             for i in range(produced):
-                result.append((<int> buffer[i].type,
-                               <int> buffer[i].side,
+                result.append((<int>buffer[i].type,
+                               <int>buffer[i].side,
                                buffer[i].price,
                                buffer[i].qty,
                                buffer[i].order_id))
-            return result
         finally:
             PyMem_Free(buffer)
 
-    cdef void _reset_parameters(self):
-        self.momentum_factor = 0.0
-        self.mean_reversion_factor = 0.0
-        self.base_order_imbalance_ratio = 1.0
-        self.base_cancel_ratio = 0.05
-        self.adversarial_factor = 0.0
-        self._last_side = 0
-        self.current_price = 100 * PRICE_SCALE
-        if self.current_price < PRICE_SCALE:
-            self.current_price = PRICE_SCALE
-        self.best_bid = self.current_price - 1
-        if self.best_bid < 0:
-            self.best_bid = 0
-        self.best_ask = self.current_price + 1
-
-
-
-
-    cpdef list generate_public_events(self,
-                                      object state,
-                                      object tracker,
-                                      object lob,
-                                      int max_events=16):
-        """Return a list of public events as tuples.
-
-        The tuples follow the same layout as agent events generated elsewhere in
-        the code base: ``(event_type, side, price_ticks, qty, order_id)``.
-        ``event_type`` and ``side`` are returned as plain integers compatible
-        with the ``EventType`` and ``Side`` enums defined in :mod:`execevents`.
-        """
-
-        cdef list events = []
-        cdef int num_events = self._determine_event_count(max_events)
-        if num_events == 0:
-            return events
-
-        cdef double mid_price = self._resolve_mid_price(state, lob)
-        cdef int mid_ticks = <int> (mid_price * constants.PRICE_SCALE)
-        if mid_ticks < 1:
-            mid_ticks = constants.PRICE_SCALE  # fall back to one currency unit
-
-        cdef int i
-        for i in range(num_events):
-            events.append(self._build_single_event(mid_ticks))
-
-        return events
-
-    cdef void _reset_defaults(self):
-        self.momentum_factor = 0.0
-        self.mean_reversion_factor = 0.0
-        self.base_order_imbalance_ratio = 1.0
-        self.base_cancel_ratio = 0.1
-        self.adversarial_factor = 0.0
-        self._last_side = 0
-
-    cdef int _determine_event_count(self, int max_events):
-        if max_events <= 0:
-            return 0
-        # Use a simple geometric style distribution to keep things light weight.
-        cdef double intensity = 0.5 + max(0.0, self.adversarial_factor)
-        cdef int count = 0
-        while count < max_events and self._rng.random() < intensity:
-            count += 1
-            intensity *= 0.6  # diminishing probability of long bursts
-        return count
-
-    cdef double _resolve_mid_price(self, object state, object lob):
-        """Best effort mid price retrieval used for pricing new orders."""
-        try:
-            if lob is not None:
-                return float(lob.mid_price()) / constants.PRICE_SCALE
-        except Exception:
-            pass
-
-        try:
-            return float(getattr(state, "last_price"))
-        except Exception:
-            return 1.0  # final fallback prevents zero pricing
-
-    cdef tuple _build_single_event(self, int mid_ticks):
-        cdef int side = self._choose_side()
-        cdef double cancel_threshold = max(0.0, min(1.0, self.base_cancel_ratio))
-        cdef double draw = self._rng.random()
-
-        if draw < cancel_threshold:
-            return (<int> EventType.PUBLIC_CANCEL_RANDOM, side, 0, 0, 0)
-
-        cdef double market_bias = 0.5 + 0.5 * (self.momentum_factor - self.mean_reversion_factor)
-        market_bias = max(0.0, min(1.0, market_bias))
-
-        if self._rng.random() < market_bias:
-            price = max(1, mid_ticks + (constants.PRICE_SCALE if side == <int> Side.BUY else -constants.PRICE_SCALE))
-            qty = self._sample_quantity()
-            self._last_side = side
-            return (<int> EventType.PUBLIC_MARKET_MATCH, side, price, qty, 0)
-
-        price = self._sample_limit_price(mid_ticks, side)
-        qty = self._sample_quantity()
-        self._last_side = side
-        return (<int> EventType.PUBLIC_LIMIT_ADD, side, price, qty, 0)
-
-    cdef int _choose_side(self):
-        cdef double base_prob = 0.5
-        if self.base_order_imbalance_ratio > 0.0:
-            base_prob = self.base_order_imbalance_ratio / (1.0 + self.base_order_imbalance_ratio)
-
-        if self._last_side == <int> Side.BUY:
-            base_prob += self.momentum_factor
-            base_prob -= self.mean_reversion_factor
-        elif self._last_side == <int> Side.SELL:
-            base_prob -= self.momentum_factor
-            base_prob += self.mean_reversion_factor
-
-        base_prob = max(0.0, min(1.0, base_prob))
-        return <int> Side.BUY if self._rng.random() < base_prob else <int> Side.SELL
-
-    cdef int _sample_limit_price(self, int mid_ticks, int side):
-        cdef int tick_offset = 1 + self._rng.randint(0, 5 + int(abs(self.adversarial_factor) * 4))
-        if side == <int> Side.BUY:
-            return max(1, mid_ticks - tick_offset)
-        else:
-            return max(1, mid_ticks + tick_offset)
-
-    cdef int _sample_quantity(self):
-        return 1 + self._rng.randint(0, 4 + int(abs(self.adversarial_factor) * 6))
-
-
+        return result


### PR DESCRIPTION
## Summary
- clean up `micromicrogen.pxd` so the generator interface and members are defined once with the correct Cython signatures
- rewrite `micromicrogen.pyx` to provide a single PCG-based generator implementation with consistent seeding, regime controls, nogil event emission and Python helpers

## Testing
- cythonize -3 micromicrogen.pyx

------
https://chatgpt.com/codex/tasks/task_e_68d4f92b39b0832f8b5508131dcfad66