### PR TITLE
Fix reward module Cython integration

### DIFF
--- a/environment.pyx
+++ b/environment.pyx
@@ -159,6 +159,8 @@ cdef class TradingEnv:
         cdef double realized_spread = 0.0
         cdef double tick = 0.0
 
+        self.state.last_executed_notional = 0.0
+
         if isinstance(action, (list, tuple, np.ndarray)):
             if len(action) >= 2:
                 target_fraction = <double> action[0]
@@ -314,6 +316,7 @@ cdef class TradingEnv:
         reward = base_reward
         if self.config.reward.use_potential_shaping:
             current_atr = self.config.market.initial_atr
+            self.state.last_bar_atr = current_atr
             open_risk = 0.0
             if self.state.net_worth > 1e-9:
                 open_risk = (abs(self.state.units) * current_atr) / self.state.net_worth

--- a/lob_state_cython.pxd
+++ b/lob_state_cython.pxd
@@ -122,6 +122,8 @@ cdef class EnvState:
     cdef public double risk_aversion_drawdown
     cdef public double trade_frequency_penalty
     cdef public double turnover_penalty_coef
+    cdef public double last_executed_notional
+    cdef public double last_bar_atr
     cdef public double risk_off_level
     cdef public double risk_on_level
     cdef public double max_position_risk_off

--- a/lob_state_cython.pyx
+++ b/lob_state_cython.pyx
@@ -409,6 +409,8 @@ cdef class EnvState:
         self.last_event_step = -1
         self.token_index = 0
         self.last_realized_spread = 0.0
+        self.last_executed_notional = 0.0
+        self.last_bar_atr = 0.0
         self.lob = None
         if self.agent_orders_ptr is NULL:
             raise MemoryError("Failed to allocate AgentOrderTracker")
@@ -1030,6 +1032,8 @@ cpdef tuple run_full_step_logic_cython(
                 state._low_extremum = final_price
     
     state.last_pos = delta.final_last_pos
+    state.last_executed_notional = delta.executed_notional
+    state.last_bar_atr = bar_atr
 
     # Применяем финальные вычисленные значения
     state.net_worth = delta.final_net_worth

--- a/reward.pxd
+++ b/reward.pxd
@@ -1,8 +1,9 @@
-# reward.pxd
+# cython: language_level=3
 
 from lob_state_cython cimport EnvState
 
-cdef enum ClosedReason:  # Importing ClosedReason enum for closed position reasons
+
+cdef enum ClosedReason:
     NONE = 0
     ATR_SL_LONG = 1
     ATR_SL_SHORT = 2
@@ -13,9 +14,48 @@ cdef enum ClosedReason:  # Importing ClosedReason enum for closed position reaso
     BANKRUPTCY = 7
     MAX_DRAWDOWN = 8
 
-cdef double log_return(EnvState* state) nogil noexcept
-cdef double potential_phi(EnvState* state) nogil noexcept
-cdef double potential_shaping(EnvState* state, double phi_t) nogil noexcept
-cdef double trade_frequency_penalty_fn(EnvState* state, int trades_count) nogil noexcept
-cdef double event_reward(EnvState* state, ClosedReason closed_reason) nogil noexcept
-cdef double compute_reward(EnvState* state, ClosedReason closed_reason, int trades_count) nogil noexcept
+
+cdef double log_return(double net_worth, double prev_net_worth) noexcept nogil
+cdef double potential_phi(
+    double net_worth,
+    double peak_value,
+    double units,
+    double atr,
+    double risk_aversion_variance,
+    double risk_aversion_drawdown,
+    double potential_shaping_coef,
+) noexcept nogil
+cdef double potential_shaping(double gamma, double last_potential, double phi_t) noexcept nogil
+cdef double trade_frequency_penalty_fn(double penalty, int trades_count) noexcept nogil
+cdef double event_reward(
+    double profit_bonus,
+    double loss_penalty,
+    double bankruptcy_penalty,
+    ClosedReason closed_reason,
+) noexcept nogil
+cdef double compute_reward_view(
+    double net_worth,
+    double prev_net_worth,
+    double last_potential,
+    bint use_legacy_log_reward,
+    bint use_potential_shaping,
+    double gamma,
+    double potential_shaping_coef,
+    double units,
+    double atr,
+    double risk_aversion_variance,
+    double peak_value,
+    double risk_aversion_drawdown,
+    int trades_count,
+    double trade_frequency_penalty,
+    double last_executed_notional,
+    double turnover_penalty_coef,
+    double profit_close_bonus,
+    double loss_close_penalty,
+    double bankruptcy_penalty,
+    ClosedReason closed_reason,
+    double* out_potential,
+) noexcept nogil
+
+cpdef double compute_reward(EnvState state, ClosedReason closed_reason, int trades_count)
+

--- a/reward.pyx
+++ b/reward.pyx
@@ -1,104 +1,176 @@
-# reward.pyx
+# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+"""Reward shaping utilities shared between Python and Cython environments."""
 
-from libc.math cimport log, tanh, fabs  # use C math for performance (no Python)
+from libc.math cimport fabs, log, tanh
+
 from lob_state_cython cimport EnvState
-cdef enum ClosedReason:
-    NONE, ATR_SL_LONG, ATR_SL_SHORT, TRAILING_SL_LONG, TRAILING_SL_SHORT, STATIC_TP_LONG, STATIC_TP_SHORT, BANKRUPTCY, MAX_DRAWDOWN
 
-cdef inline double _safe_div(double a, double b) nogil:
-    """Safe division to avoid division by zero, returns 0.0 if denominator is 0"""
-    return a / b if b != 0.0 else 0.0
 
-cdef double log_return(EnvState* state) nogil:
-    """Logarithmic return: log(net_worth / prev_net_worth) with clipping:contentReference[oaicite:0]{index=0}"""
-    cdef double ratio = 0.0
-    # Compute ratio and guard against non-positive values (clip to 1e-12 to avoid log(0))
-    if state.prev_net_worth > 0.0:
-        ratio = state.net_worth / state.prev_net_worth
-    # Ensure ratio is at least 1e-12 (avoid log of zero or negative)
-    if ratio < 1e-12:
-        ratio = 1e-12
+cdef inline double _clamp(double value, double lower, double upper) noexcept nogil:
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
+cdef double log_return(double net_worth, double prev_net_worth) noexcept nogil:
+    cdef double ratio
+    if prev_net_worth <= 0.0 or net_worth <= 0.0:
+        return 0.0
+    ratio = net_worth / (prev_net_worth + 1e-9)
+    ratio = _clamp(ratio, 0.1, 10.0)
     return log(ratio)
 
-cdef double potential_phi(EnvState* state) nogil:
-    """Compute potential Φ(state) combining risk variance and drawdown penalties:contentReference[oaicite:1]{index=1}"""
-    cdef double phi_variance = 0.0
-    cdef double phi_drawdown = 0.0
-    # Penalty for open risk: |units| * ATR / net_worth, scaled by risk_aversion_variance:contentReference[oaicite:2]{index=2}
-    if state.net_worth > 0.0:
-        # Assume state has a method or attribute to get current ATR value
-        cdef double atr_value = 0.0
-        # If EnvState provides current ATR via a method or attribute, use it (for example: state.get_atr() or state.atr)
-        # Otherwise, atr_value remains 0 (no penalty if ATR not available)
-        try:
-            atr_value = state.get_atr(state.step_idx)
-        except:
-            try:
-                atr_value = state.atr  # if current ATR stored as attribute
-            except:
-                atr_value = 0.0
-        phi_variance = state.risk_aversion_variance * (fabs(state.units) * atr_value / state.net_worth)
-    else:
-        phi_variance = 0.0
-    # Penalty for drawdown from peak: (1 - net_worth / peak_value), scaled by risk_aversion_drawdown:contentReference[oaicite:3]{index=3}
-    if state.peak_value > 0.0:
-        phi_drawdown = state.risk_aversion_drawdown * (1.0 - _safe_div(state.net_worth, state.peak_value))
-    else:
-        # If peak_value is 0 (unlikely, usually initial equity), treat drawdown penalty as 0
-        phi_drawdown = 0.0
-    # Combine and apply smoothing tanh, then scale by potential_shaping_coef:contentReference[oaicite:4]{index=4}
-    cdef double raw_potential = phi_variance + phi_drawdown
-    cdef double phi = state.potential_shaping_coef * tanh(raw_potential)
-    return phi
 
-cdef double potential_shaping(EnvState* state, double phi_t) nogil:
-    """Compute potential-based shaping reward: γ * Φ_t - Φ_{t-1}, and update last_potential:contentReference[oaicite:5]{index=5}"""
-    cdef double shaping_reward = 0.0
-    if state.use_potential_shaping:
-        shaping_reward = state.gamma * phi_t - state.last_potential  # γ·Φ_t – Φ_{t-1}
-    else:
-        shaping_reward = 0.0
-    # Update last_potential in state to current Φ_t for next step
-    state.last_potential = phi_t
-    return shaping_reward
+cdef double potential_phi(
+    double net_worth,
+    double peak_value,
+    double units,
+    double atr,
+    double risk_aversion_variance,
+    double risk_aversion_drawdown,
+    double potential_shaping_coef,
+) noexcept nogil:
+    cdef double risk_penalty = 0.0
+    cdef double dd_penalty = 0.0
 
-cdef double trade_frequency_penalty_fn(EnvState* state, int trades_count) nogil:
-    """Penalty for trade frequency: trade_frequency_penalty * number of trades this step:contentReference[oaicite:6]{index=6}"""
-    if trades_count <= 0:
+    if net_worth > 1e-9 and atr > 0.0 and units != 0.0:
+        risk_penalty = -risk_aversion_variance * fabs(units) * atr / (fabs(net_worth) + 1e-9)
+
+    if peak_value > 1e-9:
+        dd_penalty = -risk_aversion_drawdown * (peak_value - net_worth) / peak_value
+
+    return potential_shaping_coef * tanh(risk_penalty + dd_penalty)
+
+
+cdef double potential_shaping(double gamma, double last_potential, double phi_t) noexcept nogil:
+    return gamma * phi_t - last_potential
+
+
+cdef double trade_frequency_penalty_fn(double penalty, int trades_count) noexcept nogil:
+    if penalty <= 0.0 or trades_count <= 0:
         return 0.0
-    return state.trade_frequency_penalty * trades_count
+    return penalty * trades_count
 
-cdef double event_reward(EnvState* state, ClosedReason closed_reason) nogil:
-    """Event-based bonus/penalty for closing a position:contentReference[oaicite:7]{index=7}"""
+
+cdef double event_reward(
+    double profit_bonus,
+    double loss_penalty,
+    double bankruptcy_penalty,
+    ClosedReason closed_reason,
+) noexcept nogil:
     if closed_reason == ClosedReason.NONE:
         return 0.0
-    # If closed in profit (e.g. take-profit), grant bonus; if closed in loss (e.g. stop-loss), apply penalty:contentReference[oaicite:8]{index=8}
-    if closed_reason == ClosedReason.STATIC_TP_LONG or closed_reason == ClosedReason.STATIC_TP_SHORT:
-        # Take-profit closure (profit scenario)
-        return state.profit_close_bonus
-    else:
-        # Any other closure (stop-loss, trailing stop, bankruptcy, drawdown) treated as loss scenario
-        return -state.loss_close_penalty
 
-cdef double compute_reward(EnvState* state, ClosedReason closed_reason, int trades_count) nogil:
-    """Compute total reward for the step: log_return + γ·Φ_t – Φ_{t-1} + frequency penalty + event reward:contentReference[oaicite:9]{index=9}:contentReference[oaicite:10]{index=10}"""
-    cdef double r_log = log_return(state)
+    if closed_reason == ClosedReason.BANKRUPTCY:
+        if bankruptcy_penalty > 0.0:
+            return -bankruptcy_penalty
+        return -loss_penalty
+
+    if closed_reason == ClosedReason.STATIC_TP_LONG or closed_reason == ClosedReason.STATIC_TP_SHORT:
+        return profit_bonus
+
+    return -loss_penalty
+
+
+cdef double compute_reward_view(
+    double net_worth,
+    double prev_net_worth,
+    double last_potential,
+    bint use_legacy_log_reward,
+    bint use_potential_shaping,
+    double gamma,
+    double potential_shaping_coef,
+    double units,
+    double atr,
+    double risk_aversion_variance,
+    double peak_value,
+    double risk_aversion_drawdown,
+    int trades_count,
+    double trade_frequency_penalty,
+    double last_executed_notional,
+    double turnover_penalty_coef,
+    double profit_close_bonus,
+    double loss_close_penalty,
+    double bankruptcy_penalty,
+    ClosedReason closed_reason,
+    double* out_potential,
+) noexcept nogil:
+    cdef double reward = net_worth - prev_net_worth
     cdef double phi_t = 0.0
-    cdef double shaping_component = 0.0
+
+    if use_legacy_log_reward:
+        reward += log_return(net_worth, prev_net_worth)
+        if use_potential_shaping:
+            phi_t = potential_phi(
+                net_worth,
+                peak_value,
+                units,
+                atr,
+                risk_aversion_variance,
+                risk_aversion_drawdown,
+                potential_shaping_coef,
+            )
+            reward += potential_shaping(gamma, last_potential, phi_t)
+    elif use_potential_shaping:
+        phi_t = potential_phi(
+            net_worth,
+            peak_value,
+            units,
+            atr,
+            risk_aversion_variance,
+            risk_aversion_drawdown,
+            potential_shaping_coef,
+        )
+
+    reward -= trade_frequency_penalty_fn(trade_frequency_penalty, trades_count)
+
+    if turnover_penalty_coef > 0.0 and last_executed_notional > 0.0:
+        reward -= turnover_penalty_coef * last_executed_notional
+
+    reward += event_reward(
+        profit_close_bonus,
+        loss_close_penalty,
+        bankruptcy_penalty,
+        closed_reason,
+    )
+
+    if out_potential != <double*>0:
+        out_potential[0] = phi_t
+
+    return reward
+
+
+cpdef double compute_reward(EnvState state, ClosedReason closed_reason, int trades_count):
+    cdef double new_potential = 0.0
+    cdef double reward = compute_reward_view(
+        state.net_worth,
+        state.prev_net_worth,
+        state.last_potential,
+        state.use_legacy_log_reward,
+        state.use_potential_shaping,
+        state.gamma,
+        state.potential_shaping_coef,
+        state.units,
+        state.last_bar_atr,
+        state.risk_aversion_variance,
+        state.peak_value,
+        state.risk_aversion_drawdown,
+        trades_count,
+        state.trade_frequency_penalty,
+        state.last_executed_notional,
+        state.turnover_penalty_coef,
+        state.profit_close_bonus,
+        state.loss_close_penalty,
+        state.bankruptcy_penalty,
+        closed_reason,
+        &new_potential,
+    )
+
     if state.use_potential_shaping:
-        # Compute current potential Φ_t
-        phi_t = potential_phi(state)
-        # Compute shaping reward = γ·Φ_t – Φ_{t-1}
-        shaping_component = state.gamma * phi_t - state.last_potential
-        # Update last_potential for next step
-        state.last_potential = phi_t
+        state.last_potential = new_potential
     else:
-        shaping_component = 0.0
-    # Frequency penalty for trades this step
-    cdef double freq_penalty = 0.0
-    if trades_count > 0:
-        freq_penalty = state.trade_frequency_penalty * trades_count
-    # Event-based reward/penalty for closing position
-    cdef double evt_reward = event_reward(state, closed_reason)
-    # Total reward
-    return r_log + shaping_component + (-freq_penalty) + evt_reward
+        state.last_potential = 0.0
+
+    return reward


### PR DESCRIPTION
## Summary
- Track last bar ATR and executed notional directly on `EnvState` and propagate them from the Python environment.
- Redesign the reward Cython interface to operate on scalar state views and expose a safe `compute_reward` helper.
- Re-implement reward computations without Python fallbacks, keeping trade, turnover, and event adjustments under `nogil`.

## Testing
- python -m cython reward.pyx
- cython --cplus -I . reward.pyx

------
https://chatgpt.com/codex/tasks/task_e_68d5022274c8832fbf71d7201d3c8990