### PR TITLE
Fix numpy cimport usage and lambda_hat signature

### DIFF
--- a/micro_sim.pyx
+++ b/micro_sim.pyx
@@ -7,6 +7,8 @@ from numpy cimport ndarray
 cimport numpy as cnp
 import numpy as np
 
+cnp.import_array()
+
 # ---- C++ интерфейсы ----
 cdef extern from "OrderBook.h":
     cdef cppclass OrderBook:
@@ -156,12 +158,6 @@ cdef class MicroSim:
 
 
     cpdef ndarray lambda_hat(self):
-        """
-        Вектор λ̂ (shape=(LAMBDA_DIM,)) в порядке lambda_channel_names()
-        """
-
-
-    cpdef np.ndarray lambda_hat(self):
         """
         Вектор λ̂ (shape=(LAMBDA_DIM,)) в порядке lambda_channel_names()
         """


### PR DESCRIPTION
## Summary
- initialize the NumPy C API once when the module is imported
- remove the duplicate `lambda_hat` declaration and return a typed NumPy array

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d5115970ec832f96532bfc252b10a3