### PR TITLE
Refactor latency queue to avoid unconditional Python dependency

### DIFF
--- a/fast_market.pyx
+++ b/fast_market.pyx
@@ -4,7 +4,7 @@ from libcpp.vector cimport vector
 from cython cimport Py_ssize_t
 from cpython.object cimport PyObject
 
-cdef extern from "include/latency_queue.h":
+cdef extern from "include/latency_queue_py.h":
     cdef cppclass LatencyQueuePy:
         LatencyQueuePy(size_t delay=0) except +
         void push(PyObject* o)

--- a/include/latency_queue.h
+++ b/include/latency_queue.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Python.h>
-
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -64,57 +62,3 @@ private:
     std::size_t m_lat;
     std::size_t m_head;
 };
-
-// Python-aware wrapper that keeps PyObject* alive while they are queued.
-class LatencyQueuePy {
-public:
-    explicit LatencyQueuePy(std::size_t delay = 0) : m_queue(delay) {}
-
-    ~LatencyQueuePy() {
-        clear();
-    }
-
-    void push(PyObject* obj) {
-        Py_INCREF(obj);
-        m_queue.push(obj);
-    }
-
-    void tick() {
-        auto ready = m_queue.pop_ready();
-        for (auto* obj : ready) {
-            Py_DECREF(obj);
-        }
-    }
-
-    std::vector<PyObject*> pop_ready() {
-        return m_queue.pop_ready();
-    }
-
-    void clear() {
-        const std::size_t total_slots = m_queue.slots();
-        for (std::size_t i = 0; i < total_slots; ++i) {
-            auto ready = m_queue.pop_ready();
-            for (auto* obj : ready) {
-                Py_DECREF(obj);
-            }
-        }
-        m_queue.clear();
-    }
-
-    void set_latency(std::size_t delay) {
-        clear();
-        m_queue.set_latency(delay);
-    }
-
-    std::size_t latency() const {
-        return m_queue.latency();
-    }
-
-    std::size_t slots() const {
-        return m_queue.slots();
-    }
-
-private:
-    LatencyQueue<PyObject*> m_queue;
-};
-

--- a/include/latency_queue_py.h
+++ b/include/latency_queue_py.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Python.h>
+
+#include <cstddef>
+#include <vector>
+
+#include "latency_queue.h"
+
+// Python-aware wrapper that keeps PyObject* alive while they are queued.
+class LatencyQueuePy {
+public:
+    explicit LatencyQueuePy(std::size_t delay = 0) : m_queue(delay) {}
+
+    ~LatencyQueuePy() {
+        clear();
+    }
+
+    void push(PyObject* obj) {
+        Py_INCREF(obj);
+        m_queue.push(obj);
+    }
+
+    void tick() {
+        auto ready = m_queue.pop_ready();
+        for (auto* obj : ready) {
+            Py_DECREF(obj);
+        }
+    }
+
+    std::vector<PyObject*> pop_ready() {
+        return m_queue.pop_ready();
+    }
+
+    void clear() {
+        const std::size_t total_slots = m_queue.slots();
+        for (std::size_t i = 0; i < total_slots; ++i) {
+            auto ready = m_queue.pop_ready();
+            for (auto* obj : ready) {
+                Py_DECREF(obj);
+            }
+        }
+        m_queue.clear();
+    }
+
+    void set_latency(std::size_t delay) {
+        clear();
+        m_queue.set_latency(delay);
+    }
+
+    std::size_t latency() const {
+        return m_queue.latency();
+    }
+
+    std::size_t slots() const {
+        return m_queue.slots();
+    }
+
+private:
+    LatencyQueue<PyObject*> m_queue;
+};


### PR DESCRIPTION
## Summary
- separate the generic latency queue template from the Python-specific wrapper so the base header no longer requires Python headers
- add a dedicated `latency_queue_py.h` that manages `PyObject*` lifetime while reusing the generic queue implementation
- update the Cython binding to reference the new header layout

## Testing
- python setup.py build_ext --inplace


------
https://chatgpt.com/codex/tasks/task_e_68d531ccf2bc832f89d08b9c96e5ee04