### PR TITLE
Fix MarketRegime enum redeclaration for Cython builds

### DIFF
--- a/core_constants.pxd
+++ b/core_constants.pxd
@@ -1,11 +1,12 @@
 # core_constants.pxd
 # Единый источник правды для Cython. Согласован с core_constants.py и core_constants.h.
 
-cdef enum MarketRegime:
-    NORMAL = 0
-    CHOPPY_FLAT = 1
-    STRONG_TREND = 2
-    ILLIQUID = 3
+cdef extern from "core_constants.h":
+    cdef enum MarketRegime:
+        NORMAL
+        CHOPPY_FLAT
+        STRONG_TREND
+        ILLIQUID
 
 # ВНИМАНИЕ: значение должно совпадать с core_constants.py и core_constants.h
 DEF PRICE_SCALE = 100

--- a/micro_sim.pyx
+++ b/micro_sim.pyx
@@ -7,19 +7,14 @@ from numpy cimport ndarray
 cimport numpy as cnp
 import numpy as np
 
+from core_constants cimport MarketRegime, NORMAL, CHOPPY_FLAT, STRONG_TREND, ILLIQUID
+
 cnp.import_array()
 
 # ---- C++ интерфейсы ----
 cdef extern from "OrderBook.h":
     cdef cppclass OrderBook:
         pass
-
-cdef extern from "core_constants.h":
-    cdef enum MarketRegime:
-        NORMAL
-        CHOPPY_FLAT
-        STRONG_TREND
-        ILLIQUID
 
 cdef extern from "cpp_microstructure_generator.h":
     cdef enum MicroEventType:


### PR DESCRIPTION
## Summary
- reuse the MarketRegime enum definition exported by core_constants.h in core_constants.pxd so Cython references the shared header
- update micro_sim.pyx to cimport the shared MarketRegime constants instead of redeclaring the enum locally

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d538b42fec832fa5b2714af573c0d7