### PR TITLE
Fix SimulationWorkspace capacity management

### DIFF
--- a/coreworkspace.pxd
+++ b/coreworkspace.pxd
@@ -32,7 +32,7 @@ cdef class SimulationWorkspace:
     cdef int _capacity      # Allocated slots for each buffer
 
     # Methods for managing the workspace buffers.
-    cdef void ensure_capacity(self, int min_capacity) nogil
+    cdef void ensure_capacity(self, int min_capacity)
     cdef void _resize_buffers(self, int new_capacity)
     cdef void clear_step(self) nogil
     cdef void push_trade(self, double price, double qty, char side, char is_agent_maker, long long ts) nogil


### PR DESCRIPTION
## Summary
- require the SimulationWorkspace.ensure_capacity implementation declared in the pxd to run with the GIL so attributes and methods stay in sync with the pyx definition
- grow workspace buffers under an explicit `with gil` block in push helpers and default maker/taker metadata to zero so downstream code sees clean values

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d53a6adc24832faebefc4c703e523d