### PR TITLE
Fix execution event enums and expose Python aliases

### DIFF
--- a/execevents.pxd
+++ b/execevents.pxd
@@ -1,18 +1,19 @@
-cpdef enum EventType:
-    AGENT_LIMIT_ADD = 0
-    AGENT_MARKET_MATCH = 1
-    AGENT_CANCEL_SPECIFIC = 2
-    PUBLIC_LIMIT_ADD = 3
-    PUBLIC_MARKET_MATCH = 4
-    PUBLIC_CANCEL_RANDOM = 5
+cdef extern from "include/execevents_types.h":
+    ctypedef enum EventType:
+        AGENT_LIMIT_ADD
+        AGENT_MARKET_MATCH
+        AGENT_CANCEL_SPECIFIC
+        PUBLIC_LIMIT_ADD
+        PUBLIC_MARKET_MATCH
+        PUBLIC_CANCEL_RANDOM
 
-cpdef enum Side:
-    BUY = 1
-    SELL = -1
+    ctypedef enum Side:
+        BUY
+        SELL
 
-cdef struct MarketEvent:
-    EventType type
-    Side side
-    int price    # price in ticks (for limit events; 0 if not applicable)
-    int qty      # quantity (volume) of order or trade
-    int order_id # order identifier (for add events, id to assign; for cancel, id to remove; unused for pure market events)
+    ctypedef struct MarketEvent:
+        EventType type
+        Side side
+        int price
+        int qty
+        int order_id

--- a/include/execevents_types.h
+++ b/include/execevents_types.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    AGENT_LIMIT_ADD = 0,
+    AGENT_MARKET_MATCH = 1,
+    AGENT_CANCEL_SPECIFIC = 2,
+    PUBLIC_LIMIT_ADD = 3,
+    PUBLIC_MARKET_MATCH = 4,
+    PUBLIC_CANCEL_RANDOM = 5
+} EventType;
+
+typedef enum {
+    BUY = 1,
+    SELL = -1
+} Side;
+
+typedef struct {
+    EventType type;
+    Side side;
+    int price;    /* price in ticks (for limit events; 0 if not applicable) */
+    int qty;      /* quantity (volume) of order or trade */
+    int order_id; /* order identifier */
+} MarketEvent;
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
## Summary
- move the execution event enums and struct definitions into a dedicated C header shared by Cython modules
- update `execevents.pxd` to import the shared header instead of duplicating cpdef enums
- expose Python `IntEnum` views and compatibility constants from `execevents.pyx` without triggering Cython redeclaration errors

## Testing
- python -m pip install -e .
- python -m cython --cplus execevents.pyx
- python -m cython --cplus execlob_book.pyx
- python -m cython --cplus micromicrogen.pyx

------
https://chatgpt.com/codex/tasks/task_e_68d571c213b8832f92b0f6d3206af9e0