### PR TITLE
Fix fast execution taker flag

### DIFF
--- a/execfast_execution.pyx
+++ b/execfast_execution.pyx
@@ -31,7 +31,7 @@ def execute_market_fast(state, tracker, params, SimulationWorkspace ws, int side
         return
     cdef double exec_price = price
     cdef long long ts = _resolve_timestamp(state, ws)
-    ws.push_trade(exec_price, qty, <char> side, <char> 2, ts)
+    ws.push_trade(exec_price, qty, <char> side, <char> constants.AGENT_TAKER, ts)
     # Note: No order remains open in fast execution (market order fully executed immediately).
 
 def execute_limit_fast(state, tracker, params, SimulationWorkspace ws, int side, int qty, double price):
@@ -50,6 +50,6 @@ def execute_limit_fast(state, tracker, params, SimulationWorkspace ws, int side,
     if filled:
         exec_price = price
         ts = _resolve_timestamp(state, ws)
-        ws.push_trade(exec_price, qty, <char> side, <char> 1, ts)
+        ws.push_trade(exec_price, qty, <char> side, <char> constants.AGENT_MAKER, ts)
         # No open order to carry since it was filled
     return filled


### PR DESCRIPTION
## Summary
- set the fast market execution path to record trades with the agent taker flag instead of the incorrect literal
- align the fast limit execution path with shared agent maker/taker constants

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d5ba1ac910832f891ce8f774e9b7d6