### PR TITLE
Fix execlob book interfaces and workspace error handling

### DIFF
--- a/coreworkspace.pxd
+++ b/coreworkspace.pxd
@@ -40,10 +40,14 @@ cdef class SimulationWorkspace:
     cdef int trade_count    # Number of trades recorded in the current step
     cdef int filled_count   # Number of order IDs recorded as fully filled in the current step
     cdef int _capacity      # Allocated slots for each buffer
+    cdef bint _has_error
+    cdef object _pending_exception
 
     # Methods for managing the workspace buffers.
     cdef void ensure_capacity(self, int min_capacity)
     cdef void _resize_buffers(self, int new_capacity)
     cdef void clear_step(self) nogil
-    cdef void push_trade(self, double price, double qty, char side, char is_agent_maker, long long ts) nogil
-    cdef void push_filled_order_id(self, long long order_id) nogil
+    cdef bint push_trade(self, double price, double qty, char side, char is_agent_maker, long long ts) noexcept nogil
+    cdef bint push_filled_order_id(self, long long order_id) noexcept nogil
+    cdef bint has_error(self) noexcept nogil
+    cpdef void raise_pending_error(self)

--- a/execlob_book.pxd
+++ b/execlob_book.pxd
@@ -1,43 +1,49 @@
 cimport cython
-from libcpp.vector cimport vector
-# cimport dependencies from other modules
-from execevents cimport MarketEvent, EventType, Side
+
+from execevents cimport EventType, MarketEvent, Side
 from coreworkspace cimport SimulationWorkspace
 
+
 cdef class CythonLOB:
-    """
-    Cython implementation of a Limit Order Book (LOB) for simulation.
-    """
-    # Internal storage for orders (bids and asks)
+    """Cython implementation of a simple in-memory limit order book used in tests."""
+
+    # Internal storage for bids and asks
     cdef int capacity_bids
     cdef int capacity_asks
     cdef int n_bids
     cdef int n_asks
-    cdef MarketEvent* bid_orders  # array of orders for bids (each contains id, price, qty, etc.)
-    cdef MarketEvent* ask_orders  # array of orders for asks
-    cdef:
-        # Best bid and ask indices (for quick access, updated as needed)
-        int best_bid_index
-        int best_ask_index
+    cdef MarketEvent* bid_orders
+    cdef MarketEvent* ask_orders
+
+    # Cached indices for best prices
+    cdef int best_bid_index
+    cdef int best_ask_index
+
+    # Flag denoting whether the currently executing market order belongs to the agent
     cdef bint _pending_market_is_agent
+    cdef bint _has_error
+    cdef object _pending_exception
 
     cpdef CythonLOB clone(self)
-    cdef void _ensure_capacity(self, bint is_bid, int min_capacity) nogil
-
-    cdef int _find_order_index_by_id(self, int order_id, bint is_bid) nogil
-    cdef void add_limit(self, int side, int price, int qty, bint is_agent, int order_id) nogil
-    cdef void cancel_order(self, int order_id) nogil
-    cdef void match_market(self, int side, int qty, SimulationWorkspace ws) nogil
-    cdef void _record_trade(self, SimulationWorkspace ws, int price, int qty, int side,
-                            bint agent_maker, bint agent_taker, int maker_order_id) nogil
+    cdef bint _ensure_capacity(self, bint is_bid, int min_capacity) noexcept nogil
+    cdef int _find_order_index_by_id(self, int order_id, bint is_bid) noexcept nogil
+    cdef bint add_limit(self, int side, int price, int qty, bint is_agent, int order_id) noexcept nogil
+    cdef bint cancel_order(self, int order_id) noexcept nogil
+    cdef bint match_market(self, int side, int qty, SimulationWorkspace ws) noexcept nogil
+    cdef bint _record_trade(
+        self,
+        SimulationWorkspace ws,
+        int price,
+        int qty,
+        int side,
+        bint agent_maker,
+        bint agent_taker,
+        int maker_order_id,
+    ) noexcept nogil
+    cdef void _reset_error_state(self)
+    cdef void _set_error(self, object exc) noexcept nogil
+    cdef void _raise_pending_error(self)
     cpdef double mid_price(self)
-    cdef void apply_events_batch_nogil(self, MarketEvent* events, int num_events, SimulationWorkspace ws) nogil
+    cdef bint apply_events_batch_nogil(self, MarketEvent* events, int num_events, SimulationWorkspace ws) noexcept nogil
     cpdef void apply_events_batch(self, list events, SimulationWorkspace ws)
-
-    cdef void add_limit(self, int side, int price, int qty, bint is_agent, int order_id) nogil
-    cdef void cancel_order(self, int order_id) nogil
-    cdef void match_market(self, int side, int qty, SimulationWorkspace ws) nogil
-    cpdef double mid_price(self)
-    cdef void apply_events_batch_nogil(self, MarketEvent* events, int num_events, SimulationWorkspace ws) nogil
-
     cpdef list iter_agent_orders(self)

--- a/execlob_book.pyx
+++ b/execlob_book.pyx
@@ -1,6 +1,7 @@
-# cython: language_level=3
+# cython: language_level=3, boundscheck=False, wraparound=False
 
 from libc.stdlib cimport malloc, realloc, free, rand
+from libc.stddef cimport size_t
 cimport cython
 from execevents cimport MarketEvent, EventType, Side
 from coreworkspace cimport SimulationWorkspace
@@ -22,6 +23,8 @@ cdef class CythonLOB:
         self.best_bid_index = -1
         self.best_ask_index = -1
         self._pending_market_is_agent = False
+        self._has_error = False
+        self._pending_exception = None
 
     def __dealloc__(self):
         # Free allocated memory
@@ -51,31 +54,77 @@ cdef class CythonLOB:
         # Update best indices in clone
         newlob.best_bid_index = self.best_bid_index
         newlob.best_ask_index = self.best_ask_index
+        newlob._has_error = False
+        newlob._pending_exception = None
         return newlob
 
-    cdef void _ensure_capacity(self, bint is_bid, int min_capacity) nogil:
-        """
-        Ensure the internal array capacity for bids or asks is at least min_capacity.
-        """
+    cdef bint _ensure_capacity(self, bint is_bid, int min_capacity) noexcept nogil:
+        """Ensure the internal array capacity for bids or asks is at least ``min_capacity``."""
+        cdef int current
         cdef int new_cap
+        cdef size_t bytes_required
+        cdef MarketEvent* new_ptr
+
+        if self._has_error:
+            return False
+
         if is_bid:
-            if min_capacity <= self.capacity_bids:
-                return
-            new_cap = self.capacity_bids
-            while new_cap < min_capacity:
-                new_cap = new_cap * 2
-            self.bid_orders = <MarketEvent*> realloc(self.bid_orders, new_cap * cython.sizeof(MarketEvent))
+            current = self.capacity_bids
+        else:
+            current = self.capacity_asks
+
+        if min_capacity <= current:
+            return True
+
+        new_cap = current if current > 0 else 1
+        while new_cap < min_capacity:
+            if new_cap > (1 << 29):
+                new_cap = min_capacity
+                break
+            new_cap = new_cap * 2
+
+        bytes_required = <size_t> new_cap * cython.sizeof(MarketEvent)
+        if is_bid:
+            new_ptr = <MarketEvent*> realloc(self.bid_orders, bytes_required)
+        else:
+            new_ptr = <MarketEvent*> realloc(self.ask_orders, bytes_required)
+
+        if new_ptr == <MarketEvent*> 0:
+            with gil:
+                if self._pending_exception is None:
+                    self._pending_exception = MemoryError("Failed to grow order buffer")
+                self._has_error = True
+            return False
+
+        if is_bid:
+            self.bid_orders = new_ptr
             self.capacity_bids = new_cap
         else:
-            if min_capacity <= self.capacity_asks:
-                return
-            new_cap = self.capacity_asks
-            while new_cap < min_capacity:
-                new_cap = new_cap * 2
-            self.ask_orders = <MarketEvent*> realloc(self.ask_orders, new_cap * cython.sizeof(MarketEvent))
+            self.ask_orders = new_ptr
             self.capacity_asks = new_cap
 
-    cdef int _find_order_index_by_id(self, int order_id, bint is_bid) nogil:
+        return True
+
+    cdef void _reset_error_state(self):
+        self._has_error = False
+        self._pending_exception = None
+
+    cdef void _set_error(self, object exc) noexcept nogil:
+        with gil:
+            if self._pending_exception is None:
+                self._pending_exception = exc
+            self._has_error = True
+
+    cdef void _raise_pending_error(self):
+        if self._has_error:
+            exc = self._pending_exception
+            self._pending_exception = None
+            self._has_error = False
+            if exc is None:
+                raise MemoryError("CythonLOB encountered an unknown error")
+            raise exc
+
+    cdef int _find_order_index_by_id(self, int order_id, bint is_bid) noexcept nogil:
         """
         Find the index of order with given id in the specified side array.
         Returns -1 if not found.
@@ -91,97 +140,68 @@ cdef class CythonLOB:
                     return i
         return -1
 
-    cdef void add_limit(self, int side, int price, int qty, bint is_agent, int order_id) nogil:
-        """
-        Add a limit order to the book. If the order crosses the opposing side, 
-        it will match available volume first, then any remainder is added.
-        side: Side.BUY (1) for buy order, Side.SELL (-1) for sell order.
-        price: price in ticks.
-        qty: quantity of the order.
-        is_agent: whether this order belongs to the agent.
-        order_id: unique identifier for the order.
-        """
+    cdef bint add_limit(self, int side, int price, int qty, bint is_agent, int order_id) noexcept nogil:
+        """Add a limit order to the book, optionally matching against resting liquidity."""
         cdef int i, insert_idx
 
         if qty <= 0:
-            return
+            return True
+        if self._has_error:
+            return False
 
         if side == Side.BUY:
-            # Matching against asks (sell orders) at or below price
             while qty > 0 and self.n_asks > 0:
-                # Best ask is the lowest ask price
-                self.best_ask_index = 0  # best ask at index 0 (since we maintain asks sorted ascending by price)
+                self.best_ask_index = 0
                 if self.ask_orders[0].price <= price:
-                    # There is an ask at price <= buy price -> trade occurs at ask price
                     if self.ask_orders[0].qty <= qty:
-                        # The ask order is fully filled
                         qty -= self.ask_orders[0].qty
-                        # Record trade in SimulationWorkspace (done in match_market for uniformity, so skip here)
-                        # Remove this ask order from book (shift array)
                         for i in range(1, self.n_asks):
-                            self.ask_orders[i-1] = self.ask_orders[i]
+                            self.ask_orders[i - 1] = self.ask_orders[i]
                         self.n_asks -= 1
                     else:
-                        # The ask order has more quantity than the buy order; partial fill
                         self.ask_orders[0].qty -= qty
                         qty = 0
-                    # Continue matching until qty is 0 or no asks at price <= limit price
                 else:
                     break
-            if qty <= 0:
-                return  # fully matched by existing asks, nothing to add
-            # If remaining qty, add as new bid order
-            # Ensure capacity for new bid
-            self._ensure_capacity(True, self.n_bids + 1)
-            # Find insertion index to keep bid_orders sorted ascending by price (lowest first)
+            if qty <= 0 or self._has_error:
+                return not self._has_error
+            if not self._ensure_capacity(True, self.n_bids + 1):
+                return False
             insert_idx = 0
             while insert_idx < self.n_bids and self.bid_orders[insert_idx].price < price:
                 insert_idx += 1
-            # Shift orders to make space at insert_idx
             for i in range(self.n_bids, insert_idx, -1):
-                self.bid_orders[i] = self.bid_orders[i-1]
-            # Insert new order
-            self.bid_orders[insert_idx].type = EventType.PUBLIC_LIMIT_ADD  # default label, will be updated by context if needed
+                self.bid_orders[i] = self.bid_orders[i - 1]
+            self.bid_orders[insert_idx].type = EventType.PUBLIC_LIMIT_ADD
             self.bid_orders[insert_idx].side = Side.BUY
             self.bid_orders[insert_idx].price = price
             self.bid_orders[insert_idx].qty = qty
             self.bid_orders[insert_idx].order_id = order_id
             if is_agent:
-                # Mark agent order by event type (for clarity) - uses AGENT_LIMIT_ADD for identification if needed
                 self.bid_orders[insert_idx].type = EventType.AGENT_LIMIT_ADD
             self.n_bids += 1
-            # Update best bid index (should be last index for highest price since list ascending)
-            # The highest price bid is at the end of list
             self.best_bid_index = self.n_bids - 1
-
         else:
-            # side == Side.SELL
-            # Matching against bids (buy orders) at or above price
             while qty > 0 and self.n_bids > 0:
-                # Best bid is the highest bid price (at end of array since ascending sort)
                 self.best_bid_index = self.n_bids - 1
                 if self.bid_orders[self.best_bid_index].price >= price:
-                    # There is a bid at price >= sell price -> trade occurs at bid price
                     if self.bid_orders[self.best_bid_index].qty <= qty:
                         qty -= self.bid_orders[self.best_bid_index].qty
-                        # Remove this bid order from book
                         self.n_bids -= 1
-                        # (no need to shift because we remove last element in array due to highest price at end)
                     else:
                         self.bid_orders[self.best_bid_index].qty -= qty
                         qty = 0
-                    # Continue matching until qty is 0 or no bids at price >= limit price
                 else:
                     break
-            if qty <= 0:
-                return  # fully matched by existing bids
-            # Add remaining as new ask order
-            self._ensure_capacity(False, self.n_asks + 1)
+            if qty <= 0 or self._has_error:
+                return not self._has_error
+            if not self._ensure_capacity(False, self.n_asks + 1):
+                return False
             insert_idx = 0
             while insert_idx < self.n_asks and self.ask_orders[insert_idx].price < price:
                 insert_idx += 1
             for i in range(self.n_asks, insert_idx, -1):
-                self.ask_orders[i] = self.ask_orders[i-1]
+                self.ask_orders[i] = self.ask_orders[i - 1]
             self.ask_orders[insert_idx].type = EventType.PUBLIC_LIMIT_ADD
             self.ask_orders[insert_idx].side = Side.SELL
             self.ask_orders[insert_idx].price = price
@@ -190,110 +210,129 @@ cdef class CythonLOB:
             if is_agent:
                 self.ask_orders[insert_idx].type = EventType.AGENT_LIMIT_ADD
             self.n_asks += 1
-            # Update best ask index (should always be 0 for lowest price ask since sorted ascending)
             self.best_ask_index = 0
 
-    cdef void cancel_order(self, int order_id) nogil:
-        """
-        Cancel (remove) an order by its order_id if it exists.
-        """
+        return not self._has_error
+
+    cdef bint cancel_order(self, int order_id) noexcept nogil:
+        """Cancel (remove) an order by its ``order_id`` if it exists."""
         cdef int idx
         cdef int j
-        # Try find in bids
+
+        if self._has_error:
+            return False
+
         idx = self._find_order_index_by_id(order_id, True)
         if idx != -1:
-            # Remove bid order at idx
             for j in range(idx + 1, self.n_bids):
                 self.bid_orders[j - 1] = self.bid_orders[j]
             self.n_bids -= 1
-            return
-        # Try find in asks
+            return True
+
         idx = self._find_order_index_by_id(order_id, False)
         if idx != -1:
             for j in range(idx + 1, self.n_asks):
                 self.ask_orders[j - 1] = self.ask_orders[j]
             self.n_asks -= 1
-            return
+        return True
 
-    cdef void _record_trade(self, SimulationWorkspace ws, int price, int qty, int side,
-                            bint agent_maker, bint agent_taker, int maker_order_id) nogil:
-        cdef int idx = ws.trade_count
-        ws.push_trade(<double> price, <double> qty, <char> side,
-                      <char> (1 if agent_maker else 0), 0)
+    cdef bint _record_trade(self, SimulationWorkspace ws, int price, int qty, int side,
+                            bint agent_maker, bint agent_taker, int maker_order_id) noexcept nogil:
+        cdef int idx
+
+        if self._has_error or ws.has_error():
+            return False
+
+        idx = ws.trade_count
+        if not ws.push_trade(<double> price, <double> qty, <char> side,
+                             <char> (1 if agent_maker else 0), 0):
+            return False
+        if ws.has_error():
+            return False
+
         ws.taker_is_agent_all_arr[idx] = <char> (1 if agent_taker else 0)
         if agent_maker:
             ws.maker_ids_all_arr[idx] = <unsigned long long> maker_order_id
         else:
             ws.maker_ids_all_arr[idx] = <unsigned long long> 0
+        return True
 
-    cdef void match_market(self, int side, int qty, SimulationWorkspace ws) nogil:
-        """
-        Execute a market order of given side and quantity against the book.
-        Consumes orders from the opposite side up to the given qty.
-        Records trades in SimulationWorkspace.
-        """
+    cdef bint match_market(self, int side, int qty, SimulationWorkspace ws) noexcept nogil:
+        """Execute a market order of given side and quantity against the book."""
         cdef int remaining = qty
         cdef int trade_qty
         cdef int trade_price
         cdef int j
         cdef bint is_agent_market = self._pending_market_is_agent
+        cdef bint maker_is_agent
+
         if qty <= 0:
-            return
+            return True
+        if self._has_error:
+            return False
+
         if side == Side.BUY:
-            # Market buy: take from lowest ask prices
-            while remaining > 0 and self.n_asks > 0:
+            while remaining > 0 and self.n_asks > 0 and not self._has_error and not ws.has_error():
                 self.best_ask_index = 0
                 trade_price = self.ask_orders[0].price
+                maker_is_agent = self.ask_orders[0].type == EventType.AGENT_LIMIT_ADD
                 if self.ask_orders[0].qty <= remaining:
                     trade_qty = self.ask_orders[0].qty
                     remaining -= trade_qty
-                    # Record trade in SimulationWorkspace
-                    self._record_trade(ws, trade_price, trade_qty, 1,
-                                       self.ask_orders[0].type == EventType.AGENT_LIMIT_ADD,
-                                       is_agent_market, self.ask_orders[0].order_id)
-                    if self.ask_orders[0].type == EventType.AGENT_LIMIT_ADD:
-                        ws.push_filled_order_id(self.ask_orders[0].order_id)
-                    # Remove the ask order
+                    if not self._record_trade(ws, trade_price, trade_qty, 1,
+                                              maker_is_agent, is_agent_market, self.ask_orders[0].order_id):
+                        return False
+                    if maker_is_agent:
+                        if not ws.push_filled_order_id(self.ask_orders[0].order_id):
+                            return False
+                        if ws.has_error():
+                            return False
                     for j in range(1, self.n_asks):
                         self.ask_orders[j - 1] = self.ask_orders[j]
                     self.n_asks -= 1
                 else:
-                    # Partial fill of the ask order
                     trade_qty = remaining
                     self.ask_orders[0].qty -= trade_qty
                     remaining = 0
-                    self._record_trade(ws, trade_price, trade_qty, 1,
-                                       self.ask_orders[0].type == EventType.AGENT_LIMIT_ADD,
-                                       is_agent_market, self.ask_orders[0].order_id)
-                    if self.ask_orders[0].type == EventType.AGENT_LIMIT_ADD and self.ask_orders[0].qty == 0:
-                        ws.push_filled_order_id(self.ask_orders[0].order_id)
-                    # remaining = 0 will break loop
-            # Note: any remaining unmatched volume is discarded (market order not fully filled)
+                    if not self._record_trade(ws, trade_price, trade_qty, 1,
+                                              maker_is_agent, is_agent_market, self.ask_orders[0].order_id):
+                        return False
+                    if maker_is_agent and self.ask_orders[0].qty == 0:
+                        if not ws.push_filled_order_id(self.ask_orders[0].order_id):
+                            return False
+                        if ws.has_error():
+                            return False
         else:
-            # side == Side.SELL
-            # Market sell: take from highest bid prices
-            while remaining > 0 and self.n_bids > 0:
+            while remaining > 0 and self.n_bids > 0 and not self._has_error and not ws.has_error():
                 self.best_bid_index = self.n_bids - 1
                 trade_price = self.bid_orders[self.best_bid_index].price
+                maker_is_agent = self.bid_orders[self.best_bid_index].type == EventType.AGENT_LIMIT_ADD
                 if self.bid_orders[self.best_bid_index].qty <= remaining:
                     trade_qty = self.bid_orders[self.best_bid_index].qty
                     remaining -= trade_qty
-                    self._record_trade(ws, trade_price, trade_qty, -1,
-                                       self.bid_orders[self.best_bid_index].type == EventType.AGENT_LIMIT_ADD,
-                                       is_agent_market, self.bid_orders[self.best_bid_index].order_id)
-                    if self.bid_orders[self.best_bid_index].type == EventType.AGENT_LIMIT_ADD:
-                        ws.push_filled_order_id(self.bid_orders[self.best_bid_index].order_id)
-                    # Remove this bid
+                    if not self._record_trade(ws, trade_price, trade_qty, -1,
+                                              maker_is_agent, is_agent_market, self.bid_orders[self.best_bid_index].order_id):
+                        return False
+                    if maker_is_agent:
+                        if not ws.push_filled_order_id(self.bid_orders[self.best_bid_index].order_id):
+                            return False
+                        if ws.has_error():
+                            return False
                     self.n_bids -= 1
                 else:
                     trade_qty = remaining
                     self.bid_orders[self.best_bid_index].qty -= trade_qty
                     remaining = 0
-                    self._record_trade(ws, trade_price, trade_qty, -1,
-                                       self.bid_orders[self.best_bid_index].type == EventType.AGENT_LIMIT_ADD,
-                                       is_agent_market, self.bid_orders[self.best_bid_index].order_id)
-                    if self.bid_orders[self.best_bid_index].type == EventType.AGENT_LIMIT_ADD and self.bid_orders[self.best_bid_index].qty == 0:
-                        ws.push_filled_order_id(self.bid_orders[self.best_bid_index].order_id)
+                    if not self._record_trade(ws, trade_price, trade_qty, -1,
+                                              maker_is_agent, is_agent_market, self.bid_orders[self.best_bid_index].order_id):
+                        return False
+                    if maker_is_agent and self.bid_orders[self.best_bid_index].qty == 0:
+                        if not ws.push_filled_order_id(self.bid_orders[self.best_bid_index].order_id):
+                            return False
+                        if ws.has_error():
+                            return False
+
+        return not self._has_error and not ws.has_error()
 
     cpdef double mid_price(self):
         """
@@ -314,51 +353,63 @@ cdef class CythonLOB:
             self.best_ask_index = 0
             return (self.bid_orders[self.best_bid_index].price + self.ask_orders[self.best_ask_index].price) / 2.0
 
-    cdef void apply_events_batch_nogil(self, MarketEvent* events, int num_events, SimulationWorkspace ws) nogil:
-        """
-        Apply a batch of events (agent + public) to the order book under nogil.
-        Events are processed in an order: all limit adds, then all market matches, then all cancels.
-        This enforces atomic step processing.
-        """
+    cdef bint apply_events_batch_nogil(self, MarketEvent* events, int num_events, SimulationWorkspace ws) noexcept nogil:
+        """Apply a batch of events (agent + public) to the order book."""
         cdef int i
         cdef int j
+
+        if self._has_error or ws.has_error():
+            return False
+
         self._pending_market_is_agent = False
-        # Process limit add events first
         for i in range(num_events):
             if events[i].type == EventType.AGENT_LIMIT_ADD or events[i].type == EventType.PUBLIC_LIMIT_ADD:
-                self.add_limit(events[i].side, events[i].price, events[i].qty,
-                               events[i].type == EventType.AGENT_LIMIT_ADD, events[i].order_id)
-        # Process market match events
+                if not self.add_limit(events[i].side, events[i].price, events[i].qty,
+                                      events[i].type == EventType.AGENT_LIMIT_ADD, events[i].order_id):
+                    return False
+                if self._has_error or ws.has_error():
+                    return False
+
         for i in range(num_events):
             if events[i].type == EventType.AGENT_MARKET_MATCH or events[i].type == EventType.PUBLIC_MARKET_MATCH:
                 self._pending_market_is_agent = events[i].type == EventType.AGENT_MARKET_MATCH
-                self.match_market(events[i].side, events[i].qty, ws)
+                if not self.match_market(events[i].side, events[i].qty, ws):
+                    self._pending_market_is_agent = False
+                    return False
+                if self._has_error or ws.has_error():
+                    self._pending_market_is_agent = False
+                    return False
         self._pending_market_is_agent = False
-        # Process cancel events
+
         for i in range(num_events):
             if events[i].type == EventType.AGENT_CANCEL_SPECIFIC or events[i].type == EventType.PUBLIC_CANCEL_RANDOM:
                 if events[i].type == EventType.AGENT_CANCEL_SPECIFIC:
-                    # Cancel specific order by id
-                    self.cancel_order(events[i].order_id)
+                    if not self.cancel_order(events[i].order_id):
+                        return False
                 else:
-                    # PUBLIC_CANCEL_RANDOM: cancel a random order from the specified side (or either side if side=0)
                     if self.n_bids + self.n_asks == 0:
                         continue
                     if events[i].side == Side.BUY or events[i].side == Side.SELL:
-                        # Cancel random order from the given side
                         if events[i].side == Side.BUY and self.n_bids > 0:
                             j = rand() % self.n_bids
-                            self.cancel_order(self.bid_orders[j].order_id)
+                            if not self.cancel_order(self.bid_orders[j].order_id):
+                                return False
                         elif events[i].side == Side.SELL and self.n_asks > 0:
                             j = rand() % self.n_asks
-                            self.cancel_order(self.ask_orders[j].order_id)
+                            if not self.cancel_order(self.ask_orders[j].order_id):
+                                return False
                     else:
-                        # Cancel random order from either side
                         j = rand() % (self.n_bids + self.n_asks)
                         if j < self.n_bids:
-                            self.cancel_order(self.bid_orders[j].order_id)
+                            if not self.cancel_order(self.bid_orders[j].order_id):
+                                return False
                         else:
-                            self.cancel_order(self.ask_orders[j - self.n_bids].order_id)
+                            if not self.cancel_order(self.ask_orders[j - self.n_bids].order_id):
+                                return False
+                if self._has_error:
+                    return False
+
+        return not self._has_error and not ws.has_error()
 
 
     cpdef void apply_events_batch(self, list events, SimulationWorkspace ws):
@@ -367,6 +418,11 @@ cdef class CythonLOB:
         cdef MarketEvent* buffer
         cdef Py_ssize_t i
         cdef object evt
+        cdef bint success
+
+        ws.raise_pending_error()
+        self._raise_pending_error()
+        self._reset_error_state()
 
         if n == 0:
             return
@@ -385,9 +441,16 @@ cdef class CythonLOB:
                 buffer[i].order_id = <int> evt[4]
 
             with nogil:
-                self.apply_events_batch_nogil(buffer, <int> n, ws)
+                success = self.apply_events_batch_nogil(buffer, <int> n, ws)
         finally:
             free(buffer)
+
+        if ws.has_error():
+            ws.raise_pending_error()
+        if self._has_error:
+            self._raise_pending_error()
+        if not success:
+            raise RuntimeError("CythonLOB failed to apply events batch")
 
 
 
@@ -395,6 +458,9 @@ cdef class CythonLOB:
         """Return a Python list of the current agent limit orders."""
         cdef list result = []
         cdef int i
+
+        self._raise_pending_error()
+
         for i in range(self.n_bids):
             if self.bid_orders[i].type == EventType.AGENT_LIMIT_ADD:
                 result.append((self.bid_orders[i].order_id, 1, self.bid_orders[i].price))


### PR DESCRIPTION
## Summary
- add explicit error state management to `execlob_book.CythonLOB` and propagate failures via boolean nogil helpers
- update `SimulationWorkspace` to track allocation errors safely and expose raisable pending exceptions
- rework batch application to return status codes without Cython warnings and add global directives for bounds/wraparound

## Testing
- cythonize -3 -i execlob_book.pyx
- cythonize -3 -i coreworkspace.pyx
- cythonize -3 -i execevents.pyx
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d5bc02dc38832fa9d3a03f4a901c5d