### PR TITLE
Fix Cython LOB integration and build pipeline

### DIFF
--- a/execlob_book.pxd
+++ b/execlob_book.pxd
@@ -41,7 +41,7 @@ cdef class CythonLOB:
         int maker_order_id,
     ) noexcept nogil
     cdef void _reset_error_state(self)
-    cdef void _set_error(self, object exc) noexcept nogil
+    cdef void _set_error(self, object exc) noexcept
     cdef void _raise_pending_error(self)
     cpdef double mid_price(self)
     cdef bint apply_events_batch_nogil(self, MarketEvent* events, int num_events, SimulationWorkspace ws) noexcept nogil

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,12 @@ class BuildExtWithNumpy(build_ext):
 
 # --- common flags ---
 if sys.platform.startswith("win"):
+    c_args = ["/O2"]
     cxx_args = ["/O2", "/std:c++17"]
     link_args = []
 else:
     # gnu++17 for <algorithm>, <random>, etc.
+    c_args = ["-O3", "-fvisibility=hidden"]
     cxx_args = ["-O3", "-std=gnu++17", "-fvisibility=hidden"]
     link_args = ["-std=gnu++17"]
 
@@ -41,6 +43,33 @@ orderbook_cpp = "OrderBook.cpp"  # your LOB implementation
 micro_cpp = "cpp_microstructure_generator.cpp"
 
 ext_modules = [
+    Extension(
+        name="execlob_book",
+        sources=["execlob_book.pyx"],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c",
+        extra_compile_args=c_args,
+    ),
+    Extension(
+        name="coreworkspace",
+        sources=["coreworkspace.pyx"],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c",
+        extra_compile_args=c_args,
+    ),
+    Extension(
+        name="execevents",
+        sources=["execevents.pyx"],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c",
+        extra_compile_args=c_args,
+    ),
     Extension(
         name="fast_lob",
         sources=["fast_lob.pyx", orderbook_cpp],


### PR DESCRIPTION
## Summary
- replace manual struct copies in `execlob_book` with `memcpy`/`memmove`, add robust error propagation, and keep cached best-price indices consistent
- extend the extension build to compile `execlob_book`, `coreworkspace`, and `execevents` with shared C compiler flags

## Testing
- `python setup.py build_ext --inplace`
- `python - <<'PY'
from execlob_book import CythonLOB
from coreworkspace import SimulationWorkspace
from execevents import EventTypeEnum, SideEnum
lob = CythonLOB()
ws = SimulationWorkspace()
packed = [
    (int(EventTypeEnum.AGENT_LIMIT_ADD), int(SideEnum.BUY), 100, 5, 1),
    (int(EventTypeEnum.PUBLIC_LIMIT_ADD), int(SideEnum.SELL), 102, 5, 2),
    (int(EventTypeEnum.AGENT_LIMIT_ADD), int(SideEnum.SELL), 103, 3, 3),
    (int(EventTypeEnum.PUBLIC_MARKET_MATCH), int(SideEnum.BUY), 0, 4, 0),
]
lob.apply_events_batch(packed, ws)
ws.raise_pending_error()
print({'mid': lob.mid_price(), 'agent_orders': sorted(lob.iter_agent_orders())})
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d6463a1c38832f953be41485aa6d9e