### PR TITLE
Fix C++ configuration for fast fast modules

### DIFF
--- a/fast_lob.pyx
+++ b/fast_lob.pyx
@@ -1,4 +1,5 @@
 # cython: language_level=3
+# cython: language=c++
 # distutils: language = c++
 # cython: c_string_type=unicode, c_string_encoding=utf8, boundscheck=False, wraparound=False
 
@@ -7,6 +8,7 @@ cimport numpy as cnp
 import numpy as np
 from libcpp cimport bool as cpp_bool
 from libcpp.vector cimport vector
+from libc.stddef cimport size_t
 
 ctypedef unsigned long long uint64_t
 ctypedef unsigned int uint32_t

--- a/fast_market.pyx
+++ b/fast_market.pyx
@@ -1,12 +1,15 @@
 # cython: language_level=3
+# cython: language=c++
 # distutils: language = c++
 from libcpp.vector cimport vector
 from cython cimport Py_ssize_t
 from cpython.object cimport PyObject
+from libc.stddef cimport size_t
 
 cdef extern from "include/latency_queue_py.h":
     cdef cppclass LatencyQueuePy:
-        LatencyQueuePy(size_t delay=0) except +
+        LatencyQueuePy() except +
+        LatencyQueuePy(size_t delay) except +
         void push(PyObject* o)
         void tick()
         vector[PyObject*] pop_ready()

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,16 @@ ext_modules = [
         extra_link_args=link_args,
     ),
     Extension(
+        name="fast_market",
+        sources=["fast_market.pyx"],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c++",
+        extra_compile_args=cxx_args,
+        extra_link_args=link_args,
+    ),
+    Extension(
         name="micro_sim",
         sources=["micro_sim.pyx", orderbook_cpp, micro_cpp],
         include_dirs=include_dirs,


### PR DESCRIPTION
## Summary
- ensure the fast_lob and fast_market Cython modules explicitly compile in C++ mode and import the required C types
- adjust the LatencyQueuePy binding to avoid default-argument issues and register fast_market in setup.py so it builds with the other extensions

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d64d6221d0832f8a9f2ca703edcf2a