### PR TITLE
Fix lob_state Cython bindings and fast LOB interfaces

### DIFF
--- a/fast_lob.pxd
+++ b/fast_lob.pxd
@@ -1,0 +1,99 @@
+# cython: language_level=3, language=c++
+
+from libcpp cimport bool as cpp_bool
+from libcpp.vector cimport vector
+from libc.stddef cimport size_t
+
+ctypedef unsigned long long uint64_t
+ctypedef unsigned int uint32_t
+
+cdef extern from "OrderBook.h":
+    cdef struct FeeModel:
+        double maker_fee
+        double taker_fee
+        double slip_k
+
+    cdef struct Order:
+        uint64_t id
+        double volume
+        cpp_bool is_agent
+        int timestamp
+        int ttl_steps
+
+    cdef cppclass OrderBook:
+        OrderBook() except +
+        void add_limit_order(cpp_bool is_buy_side,
+                             long long price_ticks,
+                             double volume,
+                             uint64_t order_id,
+                             cpp_bool is_agent,
+                             int timestamp)
+        void remove_order(cpp_bool is_buy_side,
+                          long long price_ticks,
+                          uint64_t order_id)
+        uint32_t get_queue_position(uint64_t order_id) const
+        int match_market_order(cpp_bool is_buy_side,
+                               double volume,
+                               int timestamp,
+                               cpp_bool taker_is_agent,
+                               double* out_prices,
+                               double* out_volumes,
+                               int* out_is_buy,
+                               int* out_is_self,
+                               long long* out_ids,
+                               int max_len,
+                               double* out_fee_total)
+        long long get_best_bid()
+        long long get_best_ask()
+        void prune_stale_orders(int current_step, int max_age)
+        void cancel_random_public_orders(cpp_bool is_buy_side, int n)
+        cpp_bool contains_order(uint64_t order_id) const
+        OrderBook* clone() const
+        void swap(OrderBook& other)
+        void set_fee_model(const FeeModel& fm)
+        void set_seed(unsigned long long seed)
+        cpp_bool set_order_ttl(uint64_t order_id, int ttl_steps)
+        int decay_ttl_and_cancel(void (*on_cancel)(const Order&))
+
+cdef class CythonLOB:
+    cdef OrderBook* thisptr
+    cdef uint64_t _next_id
+
+    cpdef set_seed(self, unsigned long long seed)
+    cpdef set_fee_model(self, double maker_fee, double taker_fee, double slip_k)
+    cdef uint64_t _assign_order_id(self, unsigned long long order_id) noexcept
+    cpdef tuple add_limit_order(self,
+                                bint is_buy_side,
+                                long long price_ticks,
+                                double volume,
+                                int timestamp,
+                                bint taker_is_agent)
+    cpdef tuple add_limit_order_with_id(self,
+                                        bint is_buy_side,
+                                        long long price_ticks,
+                                        double volume,
+                                        unsigned long long order_id,
+                                        int timestamp,
+                                        bint taker_is_agent)
+    cpdef remove_order(self, bint is_buy_side, long long price_ticks, unsigned long long order_id)
+    cpdef bint set_order_ttl(self, unsigned long long order_id, int ttl_steps)
+    cpdef list decay_ttl_and_cancel(self)
+    cpdef tuple match_market_order(self,
+                                   bint is_buy_side,
+                                   double volume,
+                                   int timestamp,
+                                   bint taker_is_agent,
+                                   double[::1] out_prices,
+                                   double[::1] out_volumes,
+                                   int[::1] out_is_buy,
+                                   int[::1] out_is_self,
+                                   long long[::1] out_ids,
+                                   int max_len)
+    cpdef prune_stale_orders(self, int current_step, int max_age)
+    cpdef cancel_random_orders_batch(self, object sides)
+    cpdef bint contains_order(self, unsigned long long order_id)
+    cpdef long long get_best_bid(self)
+    cpdef long long get_best_ask(self)
+    cpdef size_t raw_ptr(self)
+    cpdef CythonLOB clone(self)
+    cpdef swap(self, CythonLOB other)

--- a/lob_state_cython.pxd
+++ b/lob_state_cython.pxd
@@ -1,4 +1,4 @@
-# cython: language_level=3
+# cython: language_level=3, language=c++
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
 
@@ -58,6 +58,8 @@ cdef extern from "AgentOrderTracker.h":
 
 cdef class CyMicrostructureGenerator:
     cdef CppMicrostructureGenerator* thisptr
+    cdef public double base_order_imbalance_ratio
+    cdef public double base_cancel_ratio
     cpdef long long generate_public_events_cy(
         self,
         vector[MarketEvent]& out_events,

--- a/tests/fast_lob.py
+++ b/tests/fast_lob.py
@@ -21,6 +21,17 @@ class CythonLOB:
         self.orders[oid] = {'is_buy': bool(is_buy_side), 'price': int(price_ticks), 'volume': float(volume), 'ttl': 0}
         return oid, 0
 
+    def add_limit_order_with_id(self, is_buy_side, price_ticks, volume, order_id, timestamp, taker_is_agent=True):
+        if order_id is not None and order_id != 0:
+            oid = int(order_id)
+            if oid >= self.next_id:
+                self.next_id = oid + 1
+        else:
+            oid = self.next_id
+            self.next_id += 1
+        self.orders[oid] = {'is_buy': bool(is_buy_side), 'price': int(price_ticks), 'volume': float(volume), 'ttl': 0}
+        return oid, 0
+
     def remove_order(self, is_buy_side, price_ticks, order_id):
         return self.orders.pop(order_id, None) is not None
 


### PR DESCRIPTION
## Summary
- add a dedicated `fast_lob.pxd` with explicit OrderBook declarations and expose an `add_limit_order_with_id` entry point that keeps ID sequencing in sync
- streamline `lob_state_cython.pyx` imports, add a deterministic shuffle helper, guard action inputs, and rely on Python constants for the price scale while marking observation builders `noexcept`
- update the fast LOB test stub to cover the new explicit-ID API

## Testing
- python - <<'PY' ... cythonize('lob_state_cython.pyx', ...) ...
- python - <<'PY' ... cythonize('fast_lob.pyx', ...) ...

------
https://chatgpt.com/codex/tasks/task_e_68d659b03368832f98a302739a9526ea