### PR TITLE
Add market simulator wrapper extension to build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,16 @@ ext_modules = [
         extra_compile_args=cxx_args,
         extra_link_args=link_args,
     ),
+    Extension(
+        name="marketmarket_simulator_wrapper",
+        sources=["marketmarket_simulator_wrapper.pyx", "MarketSimulator.cpp"],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c++",
+        extra_compile_args=cxx_args,
+        extra_link_args=link_args,
+    ),
 ]
 
 setup(


### PR DESCRIPTION
## Summary
- include the `marketmarket_simulator_wrapper` Cython module in the setuptools build so the C++ simulator wrapper is compiled with the rest of the project

## Testing
- python setup.py build_ext --inplace
- python - <<'PY'
import numpy as np
from marketmarket_simulator_wrapper import MarketSimulatorWrapper

n = 64
price = np.linspace(100.0, 164.0, n, dtype=np.float64)
open_ = price + 0.1
high = price + 0.5
low = price - 0.5
volume = np.full(n, 1000.0, dtype=np.float64)

sim = MarketSimulatorWrapper(price, open_, high, low, volume, seed=123)
sim.enable_random_shocks(False)

for i in range(n):
    last = sim.step(i, 0.0, True)

print({
    "last_price": last,
    "ma5": sim.get_ma5(),
    "ma20": sim.get_ma20(),
    "atr": sim.get_atr(),
    "rsi": sim.get_rsi(),
    "momentum": sim.get_momentum(),
    "shock": sim.shock_triggered()
})
PY

------
https://chatgpt.com/codex/tasks/task_e_68d667d0b0e0832fb021fe629ab4d08f