### PR TITLE
Fix MicroSim memory management and CyMicrostructureGenerator nogil updates

### DIFF
--- a/micro_sim.pyx
+++ b/micro_sim.pyx
@@ -100,17 +100,11 @@ cdef inline cnp.ndarray[cnp.float64_t, ndim=1] _features_to_numpy(const MicroFea
 # --- основной класс ---
 
 cdef class MicroSim:
-    cdef MicrostructureGenerator* gen
+    cdef MicrostructureGenerator gen
     cdef size_t _lob_ptr  # OrderBook*
 
     def __cinit__(self):
-        self.gen = new MicrostructureGenerator()
         self._lob_ptr = 0
-
-    def __dealloc__(self):
-        if self.gen is not NULL:
-            del self.gen
-            self.gen = NULL
 
     cpdef attach_lob(self, fast_lob):
         """


### PR DESCRIPTION
## Summary
- store the MicrostructureGenerator directly inside MicroSim to avoid relying on C++-only new/delete operations
- keep generate_public_events_into fully nogil by moving state updates into a gil section after the event loop
- ensure the public generator interface exposes a valid default for max_events while remaining compatible with the .pxd declaration

## Testing
- python -m cython --cplus micro_sim.pyx
- python -m cython micromicrogen.pyx

------
https://chatgpt.com/codex/tasks/task_e_68d674032c88832f95b260883f2f2d3e