### PR TITLE
Fix obs_builder C interface and integrate with Cython build

### DIFF
--- a/obs_builder.pxd
+++ b/obs_builder.pxd
@@ -1,8 +1,8 @@
 # cython: language_level=3
 
-cdef int compute_n_features(list layout)
+cpdef int compute_n_features(list layout)
 
-cpdef void build_observation_vector_c(
+cdef void build_observation_vector_c(
     float price,
     float prev_price,
     float log_volume_norm,
@@ -35,3 +35,37 @@ cpdef void build_observation_vector_c(
     float[::1] norm_cols_values,
     float[::1] out_features
 ) noexcept nogil
+
+cpdef void build_observation_vector(
+    float price,
+    float prev_price,
+    float log_volume_norm,
+    float rel_volume,
+    float ma5,
+    float ma20,
+    float rsi14,
+    float macd,
+    float macd_signal,
+    float momentum,
+    float atr,
+    float cci,
+    float obv,
+    float bb_lower,
+    float bb_upper,
+    float is_high_importance,
+    float time_since_event,
+    float fear_greed_value,
+    bint has_fear_greed,
+    bint risk_off_flag,
+    float cash,
+    float units,
+    float last_vol_imbalance,
+    float last_trade_intensity,
+    float last_realized_spread,
+    float last_agent_fill_ratio,
+    int token_id,
+    int max_num_tokens,
+    int num_tokens,
+    float[::1] norm_cols_values,
+    float[::1] out_features
+) noexcept

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,15 @@ micro_cpp = "cpp_microstructure_generator.cpp"
 
 ext_modules = [
     Extension(
+        name="obs_builder",
+        sources=["obs_builder.pyx"],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c",
+        extra_compile_args=c_args,
+    ),
+    Extension(
         name="execlob_book",
         sources=["execlob_book.pyx"],
         include_dirs=include_dirs,


### PR DESCRIPTION
## Summary
- move the observation builder implementation into obs_builder.pyx with a fully defined C/Python API, including fear-greed and token metadata handling
- expose obs_builder as a compiled extension and switch lob_state_cython to reuse the shared nogil implementation instead of a duplicate definition

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d67f952a90832f9f77f1e9a1d2913c