### PR TITLE
Fix reward module Cython interface and build configuration

### DIFF
--- a/cpp_microstructure_generator.h
+++ b/cpp_microstructure_generator.h
@@ -272,3 +272,5 @@ private:
     // Подготовить признаки на основе LOB
     MicroFeatures _features_from_lob(const OrderBook& lob) const;
 };
+
+using CppMicrostructureGenerator = MicrostructureGenerator;

--- a/reward.pxd
+++ b/reward.pxd
@@ -1,18 +1,7 @@
-# cython: language_level=3
+# cython: language_level=3, language=c++
 
 from lob_state_cython cimport EnvState
-
-
-cdef enum ClosedReason:
-    NONE = 0
-    ATR_SL_LONG = 1
-    ATR_SL_SHORT = 2
-    TRAILING_SL_LONG = 3
-    TRAILING_SL_SHORT = 4
-    STATIC_TP_LONG = 5
-    STATIC_TP_SHORT = 6
-    BANKRUPTCY = 7
-    MAX_DRAWDOWN = 8
+from risk_manager cimport ClosedReason
 
 
 cdef double log_return(double net_worth, double prev_net_worth) noexcept nogil

--- a/reward.pyx
+++ b/reward.pyx
@@ -1,9 +1,11 @@
-# cython: language_level=3, boundscheck=False, wraparound=False, cdivision=True
+# cython: language_level=3, language=c++, boundscheck=False, wraparound=False, cdivision=True
+# distutils: language = c++
 """Reward shaping utilities shared between Python and Cython environments."""
 
 from libc.math cimport fabs, log, tanh
 
 from lob_state_cython cimport EnvState
+from risk_manager cimport ClosedReason
 
 
 cdef inline double _clamp(double value, double lower, double upper) noexcept nogil:

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,16 @@ ext_modules = [
         extra_link_args=link_args,
     ),
     Extension(
+        name="reward",
+        sources=["reward.pyx"],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c++",
+        extra_compile_args=cxx_args,
+        extra_link_args=link_args,
+    ),
+    Extension(
         name="micro_sim",
         sources=["micro_sim.pyx", orderbook_cpp, micro_cpp],
         include_dirs=include_dirs,


### PR DESCRIPTION
## Summary
- import the existing ClosedReason enum from risk_manager in reward.pxd and mark the module for C++ compilation to resolve Cython interface errors
- update reward.pyx to compile in C++, reference the shared ClosedReason type, and eliminate duplicate enum declarations
- add a compatibility alias for CppMicrostructureGenerator in the C++ header and register the reward extension in setup.py so it builds with the other modules

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68d68486c828832fb751764f8271c842