### PR TITLE
Refactor ClosedReason definitions into shared module

### DIFF
--- a/info_builder.pyx
+++ b/info_builder.pyx
@@ -3,7 +3,7 @@
 """Helper utilities to build the info dictionary for environment metrics."""
 
 from lob_state_cython cimport EnvState
-from risk_manager cimport ClosedReason
+from risk_enums cimport ClosedReason
 
 
 cdef inline double _safe_div(double a, double b) nogil:

--- a/reward.pxd
+++ b/reward.pxd
@@ -1,7 +1,7 @@
 # cython: language_level=3, language=c++
 
 from lob_state_cython cimport EnvState
-from risk_manager cimport ClosedReason
+from risk_enums cimport ClosedReason
 
 
 cdef double log_return(double net_worth, double prev_net_worth) noexcept nogil

--- a/reward.pyx
+++ b/reward.pyx
@@ -5,7 +5,7 @@
 from libc.math cimport fabs, log, tanh
 
 from lob_state_cython cimport EnvState
-from risk_manager cimport ClosedReason
+from risk_enums cimport ClosedReason
 
 
 cdef inline double _clamp(double value, double lower, double upper) noexcept nogil:

--- a/risk_enums.pxd
+++ b/risk_enums.pxd
@@ -1,0 +1,11 @@
+# cython: language_level=3
+cdef enum ClosedReason:
+    NONE = 0
+    ATR_SL_LONG = 1
+    ATR_SL_SHORT = 2
+    TRAILING_SL_LONG = 3
+    TRAILING_SL_SHORT = 4
+    STATIC_TP_LONG = 5
+    STATIC_TP_SHORT = 6
+    BANKRUPTCY = 7
+    MAX_DRAWDOWN = 8

--- a/risk_enums.py
+++ b/risk_enums.py
@@ -1,0 +1,17 @@
+"""Python helpers mirroring the C-level risk enums."""
+from enum import IntEnum
+
+
+class ClosedReason(IntEnum):
+    NONE = 0
+    ATR_SL_LONG = 1
+    ATR_SL_SHORT = 2
+    TRAILING_SL_LONG = 3
+    TRAILING_SL_SHORT = 4
+    STATIC_TP_LONG = 5
+    STATIC_TP_SHORT = 6
+    BANKRUPTCY = 7
+    MAX_DRAWDOWN = 8
+
+
+__all__ = ["ClosedReason"]

--- a/risk_manager.pxd
+++ b/risk_manager.pxd
@@ -1,12 +1,5 @@
 # cython: language_level=3
-cpdef enum ClosedReason:
-    NONE
-    ATR_SL_LONG
-    ATR_SL_SHORT
-    TRAILING_SL_LONG
-    TRAILING_SL_SHORT
-    STATIC_TP_LONG
-    STATIC_TP_SHORT
-    BANKRUPTCY
-    MAX_DRAWDOWN
+from risk_enums cimport ClosedReason as _ClosedReason
+
+ctypedef _ClosedReason ClosedReason
 


### PR DESCRIPTION
## Summary
- introduce a dedicated `risk_enums` module exposing the shared `ClosedReason` enum for both Cython and Python code
- update `risk_manager` to import the shared enum, re-export Python aliases, and return Python enum values in helper functions
- repoint other Cython modules that use `ClosedReason` to the shared declarations to eliminate redeclaration errors

## Testing
- `python -m pip install -e .`
- `pytest tests/test_read_only_mode.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6886fcb10832f988ae534ad4c6367