### PR TITLE
Fix Cython signature for micro event generator

### DIFF
--- a/micromicrogen.pxd
+++ b/micromicrogen.pxd
@@ -31,7 +31,7 @@ cdef class CyMicrostructureGenerator:
                                          size_t buf_len,
                                          int max_events) nogil
     cpdef list generate_public_events(self, object state, object tracker,
-                                      object lob, int max_events=*)
+                                      object lob, int max_events=?)
     cdef void _reset_parameters(self)
 
 


### PR DESCRIPTION
## Summary
- fix the CyMicrostructureGenerator.generate_public_events declaration to use a valid optional argument marker so that Cython accepts the interface

## Testing
- python -m cython micromicrogen.pyx

------
https://chatgpt.com/codex/tasks/task_e_68d69786f5a0832f9ae190c7493ce5fb