### PR TITLE
Run non-Python compilation checks

### DIFF
--- a/COMPILATION_REPORT.md
+++ b/COMPILATION_REPORT.md
@@ -1,0 +1,34 @@
+# Compilation Report
+
+This report summarizes the automated compilation steps executed on non-Python sources.
+
+## Environment Preparation
+- Upgraded `pip` to ensure modern tooling.
+- Installed build dependencies: `cython`, `numpy`, and `setuptools`.
+
+## Cython Extension Build
+- Ran `python setup.py build_ext --inplace` to cythonize and compile the configured extension modules.
+
+## Standalone Cython Syntax Checks
+Executed `python -m cython` for each additional `.pyx` module not covered by the build script:
+- `execengine.pyx`
+- `execaction_interpreter.pyx`
+- `execfast_execution.pyx`
+- `micromicrogen.pyx`
+- `risk_manager.pyx` (with `--cplus`)
+- `environment.pyx` (with `--cplus`)
+- `lob_state_cython.pyx` (with `--cplus`)
+- `info_builder.pyx` (with `--cplus`)
+
+## C++ Syntax Checks
+Validated the standalone C++ sources with `g++ -std=gnu++17 -I. -fsyntax-only`:
+- `MarketSimulator.cpp`
+- `OrderBook.cpp`
+- `cpp_microstructure_generator.cpp`
+
+## Issues Identified & Resolved
+- Adjusted `execaction_interpreter.pyx` to declare C variables before conditional blocks, resolving Cython syntax errors.
+- Updated `risk_manager.pyx` to move C declarations outside conditional logic.
+- Simplified the `TradingEnv.__init__` signature in `environment.pyx` to avoid using a Python class as a Cython type annotation.
+
+All compilation checks now complete without syntax errors.

--- a/environment.pyx
+++ b/environment.pyx
@@ -27,7 +27,7 @@ cdef class TradingEnv:
     cdef object pending_order
     cdef double tick_size
 
-    def __init__(self, EnvConfig config=None):
+    def __init__(self, config=None):
         if config is None:
             config = EnvConfig.default()
         self.config = config

--- a/execaction_interpreter.pyx
+++ b/execaction_interpreter.pyx
@@ -276,18 +276,20 @@ def build_agent_event_set(state, tracker, params, action):
     cdef int existing_id = <int> lookup[1] if has_existing else -1
     cdef Side existing_side = desired_side
     cdef long long existing_price = -1
+    cdef int side_value = <int> desired_side
+    cdef bint should_cancel = False
     if has_existing and existing_id >= 0:
         try:
-            existing_side = <Side> int(lookup[2])
+            side_value = int(lookup[2])
+            existing_side = <Side> side_value
         except Exception:
             existing_side = desired_side
         try:
             existing_price = <long long> lookup[3]
         except Exception:
             existing_price = -1
-
+    should_cancel = False
     if has_existing and existing_id >= 0:
-        cdef bint should_cancel = False
         if use_market:
             should_cancel = True
         elif existing_side != desired_side:

--- a/risk_manager.pyx
+++ b/risk_manager.pyx
@@ -445,8 +445,9 @@ def _apply_close_if_needed_py(object state):
 
 def apply_close_if_needed(object state, bint readonly=False):
     """Python wrapper that accepts either EnvState or a duck-typed object."""
+    cdef ClosedReason reason
     if isinstance(state, PyEnvState):
-        cdef ClosedReason reason = _apply_close_if_needed_impl(state, readonly)
+        reason = _apply_close_if_needed_impl(state, readonly)
         return PyClosedReason(reason)
     if readonly:
         import copy


### PR DESCRIPTION
## Summary
- document the non-Python compilation steps performed across the project
- fix Cython syntax issues in execaction_interpreter, risk_manager, and environment modules revealed by the compilation checks

## Testing
- python setup.py build_ext --inplace
- python -m cython -3 execengine.pyx
- python -m cython -3 execaction_interpreter.pyx
- python -m cython -3 execfast_execution.pyx
- python -m cython -3 micromicrogen.pyx
- python -m cython -3 --cplus risk_manager.pyx
- python -m cython -3 --cplus environment.pyx
- python -m cython -3 --cplus lob_state_cython.pyx
- python -m cython -3 --cplus info_builder.pyx
- g++ -std=gnu++17 -I. -fsyntax-only MarketSimulator.cpp
- g++ -std=gnu++17 -I. -fsyntax-only OrderBook.cpp
- g++ -std=gnu++17 -I. -fsyntax-only cpp_microstructure_generator.cpp

------
https://chatgpt.com/codex/tasks/task_e_68d699a769ac832f88b93b800c9368d8