### PR TITLE
Fix zero timestamp handling in execution simulator

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -2738,7 +2738,7 @@ class ExecutionSimulator:
             open_price = self._float_or_none(self._next_h1_open_price)
         high_price = self._float_or_none(snapshot.high)
         low_price = self._float_or_none(snapshot.low)
-        ts = int(snapshot.ts_open or now_ms())
+        ts = int(snapshot.ts_open) if snapshot.ts_open is not None else int(now_ms())
         if open_price is None or not math.isfinite(open_price):
             expired_count = 0
             pending = list(self._pending_next_open.values())
@@ -2939,7 +2939,7 @@ class ExecutionSimulator:
         bar_low: Optional[float],
         bar_close: Optional[float],
     ) -> ExecReport:
-        ts = int(now_ts or now_ms())
+        ts = int(now_ts) if now_ts is not None else int(now_ms())
         trades = list(self._next_open_ready_trades)
         self._next_open_ready_trades.clear()
         fee_total = float(self._next_open_ready_fee_total)
@@ -7368,7 +7368,7 @@ class ExecutionSimulator:
         qty_raw = abs(vol)
         if qty_raw <= 0.0:
             return cid
-        ts = int(now_ts or now_ms())
+        ts = int(now_ts) if now_ts is not None else int(now_ms())
         ref_market = self._float_or_none(self._last_ref_price)
         if ref_market is None or ref_market <= 0.0:
             self._next_open_cancelled.append(cid)
@@ -7473,7 +7473,7 @@ class ExecutionSimulator:
                 proto=proto,
                 client_order_id=cid,
                 remaining_lat=remaining,
-                timestamp=int(now_ts or now_ms()),
+                timestamp=int(now_ts) if now_ts is not None else int(now_ms()),
                 lat_ms=int(lat_ms),
                 timeout=bool(timeout),
                 spike=bool(spike),
@@ -8435,7 +8435,7 @@ class ExecutionSimulator:
         risk_events_buffer: List[RiskEvent] = []  # type: ignore[var-annotated]
         filter_rejections_step: List[Dict[str, Any]] = []
 
-        ts = int(now_ts or now_ms())
+        ts = int(now_ts) if now_ts is not None else int(now_ms())
         ref = self._ref(ref_price)
         self._vwap_on_tick(ts, ref, self._last_liquidity)
 

--- a/tests/test_execution_timestamp_zero.py
+++ b/tests/test_execution_timestamp_zero.py
@@ -1,0 +1,30 @@
+import importlib.util
+import pathlib
+import sys
+
+base = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(base))
+spec = importlib.util.spec_from_file_location("execution_sim", base / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec)
+sys.modules["execution_sim"] = exec_mod
+spec.loader.exec_module(exec_mod)
+
+ActionProto = exec_mod.ActionProto
+ActionType = exec_mod.ActionType
+ExecutionSimulator = exec_mod.ExecutionSimulator
+
+
+def test_zero_timestamp_preserved_on_submit_and_execution():
+    sim = ExecutionSimulator(filters_path=None, latency_steps=0)
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=1.0)
+
+    sim.submit(proto, now_ts=0)
+
+    # The order should remain queued with the provided timestamp.
+    pending_entries = getattr(sim._q, "_q", [])
+    assert pending_entries, "expected pending order in latency queue"
+    assert pending_entries[0].timestamp == 0
+
+    report = sim.pop_ready(now_ts=0, ref_price=10.0)
+    assert report.trades, "expected trade execution"
+    assert all(trade.ts == 0 for trade in report.trades)


### PR DESCRIPTION
## Summary
- ensure execution simulator timestamp calculations fall back to now_ms() only when now_ts is None
- update next-open helpers and submission paths to preserve zero-valued timestamps
- add a regression test that submits with now_ts=0 and asserts the queued order and resulting trade keep the provided timestamp

## Testing
- pytest tests/test_execution_timestamp_zero.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c36de2c8832f925f0794229eb2b3