### PR TITLE
Align min quantity threshold with lot size step

### DIFF
--- a/tests/test_execution_sim_symbol_filter.py
+++ b/tests/test_execution_sim_symbol_filter.py
@@ -1,0 +1,32 @@
+import math
+
+import pytest
+
+from execution_sim import SymbolFilterSnapshot
+
+
+def test_min_qty_threshold_aligns_with_step_rounding_up():
+    filters = SymbolFilterSnapshot(qty_min=0.0011, qty_step=0.0005)
+
+    assert filters.min_qty_threshold == pytest.approx(0.0015)
+
+
+def test_min_qty_threshold_without_step_uses_min_qty():
+    filters = SymbolFilterSnapshot(qty_min=0.25, qty_step=0.0)
+
+    assert filters.min_qty_threshold == pytest.approx(0.25)
+
+
+@pytest.mark.parametrize(
+    "qty_min, qty_step, expected",
+    [
+        (0.0, 0.0, 0.0),
+        (0.0, 0.001, 0.0),
+        (-0.5, 0.1, 0.0),
+        (1e-12, 0.1, 0.1),
+    ],
+)
+def test_min_qty_threshold_handles_edge_cases(qty_min: float, qty_step: float, expected: float):
+    filters = SymbolFilterSnapshot(qty_min=qty_min, qty_step=qty_step)
+
+    assert math.isclose(filters.min_qty_threshold, expected, rel_tol=0, abs_tol=1e-15)


### PR DESCRIPTION
## Summary
- align `SymbolFilterSnapshot.min_qty_threshold` with the exchange lot size step
- ensure zero is returned when no minimum constraints are present
- add unit tests that cover step rounding and edge cases

## Testing
- pytest tests/test_execution_sim_symbol_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ca110710832f9976c0be47082477