### PR TITLE
Fix ADV base dataset loading for multiple symbols

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -3520,7 +3520,7 @@ class ExecutionSimulator:
                     continue
                 if numeric_val < 0.0:
                     numeric_val = 0.0
-            dataset[symbol_key] = numeric_val
+                dataset[symbol_key] = numeric_val
         return dataset, meta
 
     def _resolve_cap_base_per_bar(

--- a/tests/test_execution_sim_adv_base_dataset.py
+++ b/tests/test_execution_sim_adv_base_dataset.py
@@ -1,0 +1,17 @@
+import json
+
+from execution_sim import ExecutionSimulator
+
+
+def test_load_adv_base_dataset_preserves_all_symbols(tmp_path):
+    payload = {
+        "BTCUSDT": 123.45,
+        "ETHUSDT": 67.89,
+    }
+    dataset_path = tmp_path / "adv_base.json"
+    dataset_path.write_text(json.dumps(payload))
+
+    simulator = ExecutionSimulator.__new__(ExecutionSimulator)
+    dataset, _ = ExecutionSimulator._load_adv_base_dataset(simulator, str(dataset_path))
+
+    assert dataset == {"BTCUSDT": 123.45, "ETHUSDT": 67.89}


### PR DESCRIPTION
## Summary
- ensure the ADV base dataset loader records each validated symbol entry
- add a regression test covering multiple-symbol payloads

## Testing
- pytest tests/test_execution_sim_adv_base_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68d6cbcd387c832fab526b3d027b112a