### PR TITLE
Add list-based numpy shim for execution simulator seasonality

### DIFF
--- a/tests/test_execution_sim_numpy_shim.py
+++ b/tests/test_execution_sim_numpy_shim.py
@@ -1,0 +1,50 @@
+import builtins
+import importlib
+import json
+import sys
+
+
+def test_execution_sim_numpy_shim(monkeypatch, tmp_path):
+    original_numpy = sys.modules.pop("numpy", None)
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "numpy" and globals and globals.get("__name__") == "execution_sim":
+            raise ImportError("numpy is intentionally unavailable for this test")
+        return original_import(name, globals, locals, fromlist, level)
+
+    original_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    sys.modules.pop("execution_sim", None)
+
+    try:
+        execution_sim = importlib.import_module("execution_sim")
+        data = {
+            "liquidity": [1.0] * 168,
+            "spread": [1.0] * 168,
+        }
+        path = tmp_path / "seasonality.json"
+        path.write_text(json.dumps(data))
+
+        sim = execution_sim.ExecutionSimulator(
+            liquidity_seasonality_path=str(path),
+            use_seasonality=True,
+            seasonality_auto_reload=False,
+        )
+
+        sim.load_seasonality_multipliers(
+            {
+                "liquidity": [1.0] * 168,
+                "spread": [1.0] * 168,
+            }
+        )
+
+        dumped = sim.dump_seasonality_multipliers()
+        assert dumped["liquidity"] == [1.0] * 168
+        assert dumped["spread"] == [1.0] * 168
+    finally:
+        sys.modules.pop("execution_sim", None)
+        sys.modules.pop("numpy", None)
+        if original_numpy is not None:
+            sys.modules["numpy"] = original_numpy
+


### PR DESCRIPTION
## Summary
- extend the lightweight numpy shim in `execution_sim` with list-backed `ndarray` support, including `ones`/`asarray` helpers and basic arithmetic
- expose the shimmed helpers for code paths that expect numpy arrays while keeping dtype keyword compatibility
- add a pytest smoke test that forces the shim to activate and exercises seasonality loading and multiplier updates

## Testing
- pytest tests/test_execution_sim_numpy_shim.py

------
https://chatgpt.com/codex/tasks/task_e_68d6cc95f184832fba018c99cdb69146