### PR TITLE
Handle negative fees in cumulative totals

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -4764,9 +4764,9 @@ class ExecutionSimulator:
             getattr(self, "_fees_last_quote_equivalent", None)
         )
         fee_value = ExecutionSimulator._trade_cost_float(fee)
-        if quote_equivalent is not None and quote_equivalent > 0.0:
+        if quote_equivalent is not None:
             self.fees_cum += float(quote_equivalent)
-        elif fee_value is not None and fee_value > 0.0:
+        elif fee_value is not None:
             self.fees_cum += float(fee_value)
         self._fees_last_quote_equivalent = None
 

--- a/tests/test_execution_sim_fee_discount.py
+++ b/tests/test_execution_sim_fee_discount.py
@@ -69,3 +69,45 @@ def test_zero_fee_discount_multiplier_maintains_zero_fees():
     assert report.fee_total == pytest.approx(0.0)
     assert trade.fee == pytest.approx(0.0)
     assert sim.fees_cum == pytest.approx(fees_before)
+
+
+def test_negative_fee_reduces_cumulative_fee(monkeypatch):
+    sim = ExecutionSimulator(filters_path=None)
+    sim.set_quantizer(DummyQuantizer())
+
+    def fake_compute_trade_fee(self, *, side, price, qty, liquidity):
+        del side, price, qty, liquidity
+        self._fees_last_quote_equivalent = -2.5
+        return -1.0
+
+    monkeypatch.setattr(
+        ExecutionSimulator, "_compute_trade_fee", fake_compute_trade_fee
+    )
+
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=1.0)
+
+    sim.run_step(
+        ts=1,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[],
+    )
+    fees_before = sim.fees_cum
+
+    report = sim.run_step(
+        ts=2,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[(ActionType.MARKET, proto)],
+    )
+
+    assert report.trades, "Expected at least one trade to be executed"
+    trade = report.trades[0]
+
+    assert trade.fee == pytest.approx(-1.0)
+    assert report.fee_total == pytest.approx(-1.0)
+    assert sim.fees_cum == pytest.approx(fees_before - 2.5)


### PR DESCRIPTION
## Summary
- remove the positive-only guard when applying fees so rebates affect the cumulative total
- add a regression test that simulates a negative-fee trade and checks the cumulative accounting

## Testing
- pytest tests/test_execution_sim_fee_discount.py::test_negative_fee_reduces_cumulative_fee

------
https://chatgpt.com/codex/tasks/task_e_68d6d4ac2df4832fa312916912f4810f