### PR TITLE
Fix market filter quantity checks after quantization

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -7982,28 +7982,32 @@ class ExecutionSimulator:
         if not validations_enabled or filters is None:
             return qty_quantized, None
 
-        if qty_raw <= 0.0:
+        if qty_quantized <= 0.0:
             reason = FilterRejectionReason(
                 code="LOT_SIZE",
                 message="Quantity is not positive",
-                constraint={"quantity": qty_raw},
+                constraint={"quantity": qty_quantized},
             )
             return 0.0, reason
 
         min_qty = filters.min_qty_threshold
-        if min_qty > 0.0 and qty_raw + tolerance < min_qty:
+        if min_qty > 0.0 and qty_quantized + tolerance < min_qty:
             reason = FilterRejectionReason(
                 code="LOT_SIZE",
                 message="Quantity below minimum",
-                constraint={"min_qty": min_qty, "step": filters.qty_step, "quantity": qty_raw},
+                constraint={
+                    "min_qty": min_qty,
+                    "step": filters.qty_step,
+                    "quantity": qty_quantized,
+                },
             )
             return 0.0, reason
 
-        if filters.qty_max < float("inf") and qty_raw - tolerance > filters.qty_max:
+        if filters.qty_max < float("inf") and qty_quantized - tolerance > filters.qty_max:
             reason = FilterRejectionReason(
                 code="LOT_SIZE",
                 message="Quantity above maximum",
-                constraint={"max_qty": filters.qty_max, "quantity": qty_raw},
+                constraint={"max_qty": filters.qty_max, "quantity": qty_quantized},
             )
             return 0.0, reason
 

--- a/tests/test_execution_rules.py
+++ b/tests/test_execution_rules.py
@@ -112,6 +112,16 @@ def test_unquantized_limit_rejected_strict():
     assert trade.price == pytest.approx(100.0)
 
 
+def test_market_quantity_rounded_up_passes_filters():
+    sim = ExecutionSimulator(filters_path=None)
+    sim.set_quantizer(Quantizer(filters, strict=True))
+
+    qty_total, rejection = sim._apply_filters_market("BUY", 0.099, ref_price=100.0)
+
+    assert qty_total == pytest.approx(0.1)
+    assert rejection is None
+
+
 def test_attach_quantizer_sets_metadata(tmp_path: pathlib.Path):
     filters_path = tmp_path / "filters.json"
     filters_path.write_text(json.dumps({"filters": filters}), encoding="utf-8")


### PR DESCRIPTION
## Summary
- update market-order filter validation to use the quantized quantity when comparing against exchange limits
- ensure filter rejection details reflect the adjusted quantity values
- add a regression test showing a near-threshold market order now passes once quantities are quantized

## Testing
- pytest tests/test_execution_rules.py::test_market_quantity_rounded_up_passes_filters

------
https://chatgpt.com/codex/tasks/task_e_68d6d7a78180832f98940b7f0924b45d