### PR TITLE
Prevent maker-priced limits from filling immediately

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -9369,7 +9369,7 @@ class ExecutionSimulator:
                         elif best_ask is not None and price_q < best_ask:
                             filled_price = float(price_q)
                             liquidity_role = "maker"
-                            filled = True
+                            filled = False
                     else:  # SELL
                         if best_bid is not None and price_q <= best_bid:
                             filled_price = float(best_bid)
@@ -9380,7 +9380,7 @@ class ExecutionSimulator:
                         elif best_bid is not None and price_q > best_bid:
                             filled_price = float(price_q)
                             liquidity_role = "maker"
-                            filled = True
+                            filled = False
 
                 if filled and liquidity_role == "taker":
                     if tif == "FOK" and exec_qty + 1e-12 < qty_q:

--- a/tests/test_execution_rules.py
+++ b/tests/test_execution_rules.py
@@ -194,6 +194,21 @@ def test_ttl_two_steps_sim():
     assert rep3.cancelled_ids == []
 
 
+def test_limit_maker_price_enqueues_without_trade():
+    sim = ExecutionSimulator(filters_path=None)
+    sim.set_market_snapshot(bid=100.0, ask=101.0)
+
+    proto = ActionProto(action_type=ActionType.LIMIT, volume_frac=0.1, abs_price=100.5)
+    oid = sim.submit(proto)
+
+    report = sim.pop_ready(ref_price=100.0)
+
+    assert report.trades == []
+    assert report.cancelled_ids == []
+    assert report.new_order_ids == [oid]
+    assert report.new_order_pos == [0]
+
+
 def test_latency_sample_slightly_above_step_waits_full_delay():
     sim = ExecutionSimulator(filters_path=None)
     sim.step_ms = 100


### PR DESCRIPTION
## Summary
- ensure limit orders priced inside the book stay queued as makers instead of filling immediately
- add regression coverage confirming maker-priced limit submissions enqueue without generating trades

## Testing
- pytest tests/test_execution_rules.py::test_limit_maker_price_enqueues_without_trade

------
https://chatgpt.com/codex/tasks/task_e_68d6dba533ec832f91df82ad8c6680b4