### PR TITLE
Fix intrabar fallback slippage handling

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -9132,7 +9132,7 @@ class ExecutionSimulator:
                             taker_bps=fallback_slip
                         )
                         if blended is None:
-                            slip_bps = 0.0
+                            slip_bps = float(fallback_slip)
                         else:
                             slip_bps = float(blended)
                         if apply_slippage_price is not None:
@@ -9601,7 +9601,7 @@ class ExecutionSimulator:
             elif fallback_slip is not None:
                 blended = self._blend_expected_spread(taker_bps=fallback_slip)
                 if blended is None:
-                    slip_bps = 0.0
+                    slip_bps = float(fallback_slip)
                 else:
                     slip_bps = float(blended)
                 if apply_slippage_price is not None:
@@ -10513,7 +10513,7 @@ class ExecutionSimulator:
                             taker_bps=fallback_slip
                         )
                         if blended is None:
-                            slip_bps = 0.0
+                            slip_bps = float(fallback_slip)
                         else:
                             slip_bps = float(blended)
                         if apply_slippage_price is not None:

--- a/tests/test_execution_sim_intrabar_slippage.py
+++ b/tests/test_execution_sim_intrabar_slippage.py
@@ -1,0 +1,73 @@
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+
+base = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(base))
+spec = importlib.util.spec_from_file_location("execution_sim", base / "execution_sim.py")
+exec_mod = importlib.util.module_from_spec(spec)
+sys.modules["execution_sim"] = exec_mod
+spec.loader.exec_module(exec_mod)
+
+ActionProto = exec_mod.ActionProto
+ActionType = exec_mod.ActionType
+ExecutionSimulator = exec_mod.ExecutionSimulator
+
+
+def test_intrabar_fallback_slip_uses_estimate(monkeypatch):
+    fallback_bps = 12.5
+
+    def fake_apply_slippage_price(*, side, quote_price, slippage_bps):
+        base = float(quote_price)
+        slip = float(slippage_bps) / 1e4
+        if str(side).upper() == "BUY":
+            return base * (1.0 + slip)
+        return base * (1.0 - slip)
+
+    def fake_estimate_slippage_bps(**_kwargs):
+        return fallback_bps
+
+    blend_calls: list[float] = []
+
+    def no_blend(self, *, taker_bps, maker_bps=None, maker_share=None):
+        blend_calls.append(float(taker_bps))
+        return None
+
+    monkeypatch.setattr(exec_mod, "apply_slippage_price", fake_apply_slippage_price)
+    monkeypatch.setattr(exec_mod, "estimate_slippage_bps", fake_estimate_slippage_bps)
+    monkeypatch.setattr(ExecutionSimulator, "_blend_expected_spread", no_blend)
+
+    latency_cfg = {"base_ms": 0, "jitter_ms": 0, "spike_p": 0.0, "timeout_ms": 1000, "retries": 0}
+    slippage_cfg = {"default_spread_bps": 0.0, "k": 0.0, "min_half_spread_bps": 0.0}
+
+    sim = ExecutionSimulator(
+        latency_config=latency_cfg,
+        slippage_config=slippage_cfg,
+    )
+
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=1.0)
+
+    report = sim.run_step(
+        ts=0,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.0,
+        vol_factor=1.0,
+        liquidity=10.0,
+        trade_price=100.0,
+        trade_qty=0.0,
+        actions=[(ActionType.MARKET, proto)],
+    )
+
+    assert report.trades, "Expected at least one trade to be generated"
+    trade = report.trades[0]
+    expected_price = fake_apply_slippage_price(
+        side="BUY", quote_price=100.0, slippage_bps=fallback_bps
+    )
+
+    assert trade.slippage_bps == pytest.approx(fallback_bps)
+    assert trade.price == pytest.approx(expected_price)
+    assert any(pytest.approx(fallback_bps) == call for call in blend_calls)


### PR DESCRIPTION
## Summary
- ensure intrabar fallback slippage uses the configured fallback spread when blending fails across all execution paths
- add a regression test that forces the fallback slippage path to exercise the new behavior

## Testing
- `pytest tests/test_execution_sim_intrabar_slippage.py`
- `pytest tests/test_execution_determinism.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6df2de494832f846eb2e2a936c853