### PR TITLE
Adjust minimum quantity threshold rounding

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -725,7 +725,7 @@ class SymbolFilterSnapshot:
                 steps = math.ceil(ratio - 1e-12)
                 steps = max(steps, 1)
             else:
-                steps = 0
+                steps = 1
             return steps * qty_step
 
         if qty_min > 0.0:

--- a/tests/test_execution_sim_symbol_filter.py
+++ b/tests/test_execution_sim_symbol_filter.py
@@ -21,8 +21,8 @@ def test_min_qty_threshold_without_step_uses_min_qty():
     "qty_min, qty_step, expected",
     [
         (0.0, 0.0, 0.0),
-        (0.0, 0.001, 0.0),
-        (-0.5, 0.1, 0.0),
+        (0.0, 0.001, 0.001),
+        (-0.5, 0.1, 0.1),
         (1e-12, 0.1, 0.1),
     ],
 )


### PR DESCRIPTION
## Summary
- ensure SymbolFilterSnapshot returns at least one quantity step when minimum quantity is non-positive
- update symbol filter tests to cover the new minimum threshold behavior

## Testing
- pytest tests/test_execution_sim_symbol_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68d6eb8b7114832fa7ded489d5012f79