### PR TITLE
Add qty step validation for market filters

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -8033,6 +8033,16 @@ class ExecutionSimulator:
             )
             return 0.0, reason
 
+        if filters.qty_step > 0.0:
+            snapped_qty = math.floor(qty_quantized / filters.qty_step) * filters.qty_step
+            if abs(qty_quantized - snapped_qty) > tolerance:
+                reason = FilterRejectionReason(
+                    code="LOT_SIZE",
+                    message="Quantity not aligned to step",
+                    constraint={"step": filters.qty_step, "quantity": qty_quantized},
+                )
+                return 0.0, reason
+
         if quant_result is not None:
             reason_code = getattr(quant_result, "reason_code", None)
             if reason_code:

--- a/tests/test_execution_rules.py
+++ b/tests/test_execution_rules.py
@@ -180,6 +180,21 @@ def test_next_open_risk_adjustment_rejected_when_off_filters():
     assert not sim._pending_next_open
 
 
+def test_market_step_violation_rejected_without_quantizer():
+    sim = ExecutionSimulator(filters_path=None)
+    sim.strict_filters = True
+    sim.enforce_ppbs = False
+    sim.quantizer = None
+    sim.filters = json.loads(json.dumps(filters))
+
+    qty_total, rejection = sim._apply_filters_market("BUY", 0.105, ref_price=100.0)
+
+    assert qty_total == pytest.approx(0.0)
+    assert rejection is not None
+    assert rejection.code == "LOT_SIZE"
+    assert rejection.message == "Quantity not aligned to step"
+
+
 def test_market_pop_ready_requantizes_post_risk_quantity():
     sim = make_sim(strict=True)
     sim._last_ref_price = 100.0


### PR DESCRIPTION
## Summary
- enforce quantity step validation for market orders in the legacy filter path
- add a regression test confirming non step-aligned market quantities are rejected without a quantizer

## Testing
- pytest tests/test_execution_rules.py -k "market_step_violation" -q


------
https://chatgpt.com/codex/tasks/task_e_68d6ed162818832f946c0e01b2481714