### PR TITLE
Adjust percent price bounds to honor side-specific multipliers

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -727,28 +727,19 @@ class SymbolFilterSnapshot:
     def percent_price_bounds(self, side: str) -> Tuple[Optional[float], Optional[float]]:
         """Return (upper, lower) multipliers for the provided side."""
         side_norm = str(side).upper()
+
         if side_norm == "BUY":
-            up = (
-                self.bid_multiplier_up
-                if self.bid_multiplier_up is not None
-                else self.multiplier_up
-            )
-            down = (
-                self.bid_multiplier_down
-                if self.bid_multiplier_down is not None
-                else self.multiplier_down
-            )
+            preferred_up = self.ask_multiplier_up
+            preferred_down = self.ask_multiplier_down
+        elif side_norm == "SELL":
+            preferred_up = self.bid_multiplier_up
+            preferred_down = self.bid_multiplier_down
         else:
-            up = (
-                self.ask_multiplier_up
-                if self.ask_multiplier_up is not None
-                else self.multiplier_up
-            )
-            down = (
-                self.ask_multiplier_down
-                if self.ask_multiplier_down is not None
-                else self.multiplier_down
-            )
+            preferred_up = None
+            preferred_down = None
+
+        up = preferred_up if preferred_up is not None else self.multiplier_up
+        down = preferred_down if preferred_down is not None else self.multiplier_down
         return up, down
 
     @property

--- a/tests/test_execution_sim_symbol_filter.py
+++ b/tests/test_execution_sim_symbol_filter.py
@@ -30,3 +30,41 @@ def test_min_qty_threshold_handles_edge_cases(qty_min: float, qty_step: float, e
     filters = SymbolFilterSnapshot(qty_min=qty_min, qty_step=qty_step)
 
     assert math.isclose(filters.min_qty_threshold, expected, rel_tol=0, abs_tol=1e-15)
+
+
+def test_percent_price_bounds_buy_prefers_ask_sell_prefers_bid():
+    filters = SymbolFilterSnapshot(
+        multiplier_up=1.2,
+        multiplier_down=0.8,
+        ask_multiplier_up=1.15,
+        ask_multiplier_down=0.85,
+        bid_multiplier_up=1.25,
+        bid_multiplier_down=0.75,
+    )
+
+    buy_up, buy_down = filters.percent_price_bounds("BUY")
+    sell_up, sell_down = filters.percent_price_bounds("SELL")
+
+    assert buy_up == pytest.approx(1.15)
+    assert buy_down == pytest.approx(0.85)
+    assert sell_up == pytest.approx(1.25)
+    assert sell_down == pytest.approx(0.75)
+
+
+def test_percent_price_bounds_fallback_to_generic_when_missing():
+    filters = SymbolFilterSnapshot(
+        multiplier_up=1.2,
+        multiplier_down=0.8,
+        ask_multiplier_up=None,
+        ask_multiplier_down=None,
+        bid_multiplier_up=None,
+        bid_multiplier_down=0.7,
+    )
+
+    buy_up, buy_down = filters.percent_price_bounds("BUY")
+    sell_up, sell_down = filters.percent_price_bounds("SELL")
+
+    assert buy_up == pytest.approx(1.2)
+    assert buy_down == pytest.approx(0.8)
+    assert sell_up == pytest.approx(1.2)
+    assert sell_down == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- update SymbolFilterSnapshot.percent_price_bounds to use ask multipliers for buy orders and bid multipliers for sell orders while keeping generic fallbacks
- add unit tests covering buy/sell preference for side-specific percent price bounds and fallback behavior

## Testing
- pytest tests/test_execution_sim_symbol_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f9dfe6d8832fa9e6c2174662b8a1