### PR TITLE
Fix PPBS enforcement guard in legacy limit filter

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -8501,7 +8501,7 @@ class ExecutionSimulator:
                 return price_quantized, 0.0, reason
             qty_quantized = qty_for_notional
 
-        if self.enforce_ppbs:
+        if enforce_ppbs:
             if ref_ppbs is not None and ref_ppbs > 0.0:
                 ppbs_ok = True
                 if quantizer is not None:


### PR DESCRIPTION
## Summary
- ensure the legacy limit filter path only runs PPBS checks when the locally computed enforcement flag is enabled
- add a regression test confirming wide limit orders are accepted when strict filter enforcement is disabled

## Testing
- pytest tests/test_execution_rules.py::test_limit_ppbs_skipped_when_strict_filters_disabled

------
https://chatgpt.com/codex/tasks/task_e_68d7032759c0832fa7d59aad720f7ac7