### PR TITLE
Fix percent price bounds side multipliers

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -729,11 +729,11 @@ class SymbolFilterSnapshot:
         side_norm = str(side).upper()
 
         if side_norm == "BUY":
-            preferred_up = self.ask_multiplier_up
-            preferred_down = self.ask_multiplier_down
-        elif side_norm == "SELL":
             preferred_up = self.bid_multiplier_up
             preferred_down = self.bid_multiplier_down
+        elif side_norm == "SELL":
+            preferred_up = self.ask_multiplier_up
+            preferred_down = self.ask_multiplier_down
         else:
             preferred_up = None
             preferred_down = None

--- a/tests/test_execution_sim_symbol_filter.py
+++ b/tests/test_execution_sim_symbol_filter.py
@@ -32,7 +32,7 @@ def test_min_qty_threshold_handles_edge_cases(qty_min: float, qty_step: float, e
     assert math.isclose(filters.min_qty_threshold, expected, rel_tol=0, abs_tol=1e-15)
 
 
-def test_percent_price_bounds_buy_prefers_ask_sell_prefers_bid():
+def test_percent_price_bounds_buy_prefers_bid_sell_prefers_ask():
     filters = SymbolFilterSnapshot(
         multiplier_up=1.2,
         multiplier_down=0.8,
@@ -45,10 +45,10 @@ def test_percent_price_bounds_buy_prefers_ask_sell_prefers_bid():
     buy_up, buy_down = filters.percent_price_bounds("BUY")
     sell_up, sell_down = filters.percent_price_bounds("SELL")
 
-    assert buy_up == pytest.approx(1.15)
-    assert buy_down == pytest.approx(0.85)
-    assert sell_up == pytest.approx(1.25)
-    assert sell_down == pytest.approx(0.75)
+    assert buy_up == pytest.approx(1.25)
+    assert buy_down == pytest.approx(0.75)
+    assert sell_up == pytest.approx(1.15)
+    assert sell_down == pytest.approx(0.85)
 
 
 def test_percent_price_bounds_fallback_to_generic_when_missing():
@@ -65,6 +65,6 @@ def test_percent_price_bounds_fallback_to_generic_when_missing():
     sell_up, sell_down = filters.percent_price_bounds("SELL")
 
     assert buy_up == pytest.approx(1.2)
-    assert buy_down == pytest.approx(0.8)
+    assert buy_down == pytest.approx(0.7)
     assert sell_up == pytest.approx(1.2)
-    assert sell_down == pytest.approx(0.7)
+    assert sell_down == pytest.approx(0.8)


### PR DESCRIPTION
## Summary
- use bid-side multipliers for BUY requests and ask-side multipliers for SELL requests in `SymbolFilterSnapshot.percent_price_bounds`
- adjust symbol filter unit tests to verify side-specific multipliers and fallback behaviour

## Testing
- pytest tests/test_execution_sim_symbol_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68d708cb1230832fafc2ad2d3f32edb5