### PR TITLE
Ensure limit fills update cumulative fee totals

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -9538,6 +9538,7 @@ class ExecutionSimulator:
                         liquidity=liquidity_role,
                     )
                     fee_total += float(fee)
+                    self._fees_apply_to_cumulative(fee)
                     _ = self._apply_trade_inventory(
                         side=side, price=filled_price, qty=exec_qty
                     )
@@ -9599,6 +9600,7 @@ class ExecutionSimulator:
                         liquidity=liquidity_role,
                     )
                     fee_total += float(fee)
+                    self._fees_apply_to_cumulative(fee)
                     _ = self._apply_trade_inventory(
                         side=side, price=filled_price, qty=qty_q
                     )


### PR DESCRIPTION
## Summary
- call the cumulative fee accumulator when limit-order taker and maker fills incur fees

## Testing
- pytest tests/test_execution_sim_maker_fee.py

------
https://chatgpt.com/codex/tasks/task_e_68d70d50a6c4832f8637135205fa60cf