### PR TITLE
Improve tolerance when snapping quantities

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -7661,6 +7661,13 @@ class ExecutionSimulator:
             return None
         return val
 
+    @staticmethod
+    def _snap_qty_with_tolerance(value: float, step: float, tolerance: float) -> float:
+        if step <= 0.0:
+            return float(value)
+        tol = tolerance if tolerance > 0.0 else 0.0
+        return math.floor((float(value) + tol) / step) * step
+
     def _apply_close_lag(self, ts: Optional[int]) -> Optional[int]:
         if ts is None:
             return None
@@ -8068,7 +8075,9 @@ class ExecutionSimulator:
             return 0.0, reason
 
         if filters.qty_step > 0.0:
-            snapped_qty = math.floor(qty_quantized / filters.qty_step) * filters.qty_step
+            snapped_qty = self._snap_qty_with_tolerance(
+                qty_quantized, filters.qty_step, tolerance
+            )
             if abs(qty_quantized - snapped_qty) > tolerance:
                 reason = FilterRejectionReason(
                     code="LOT_SIZE",
@@ -8178,8 +8187,8 @@ class ExecutionSimulator:
                 return 0.0, reason
 
             if filters.qty_step > 0.0:
-                snapped_qty = (
-                    math.floor(qty_for_notional / filters.qty_step) * filters.qty_step
+                snapped_qty = self._snap_qty_with_tolerance(
+                    qty_for_notional, filters.qty_step, tolerance
                 )
                 if abs(qty_for_notional - snapped_qty) > tolerance:
                     reason = FilterRejectionReason(
@@ -8457,7 +8466,9 @@ class ExecutionSimulator:
             return price_quantized, 0.0, reason
 
         if filters.qty_step > 0.0:
-            snapped_qty = math.floor(qty_quantized / filters.qty_step) * filters.qty_step
+            snapped_qty = self._snap_qty_with_tolerance(
+                qty_quantized, filters.qty_step, tolerance
+            )
             if abs(qty_quantized - snapped_qty) > tolerance:
                 reason = FilterRejectionReason(
                     code="LOT_SIZE",
@@ -8578,8 +8589,8 @@ class ExecutionSimulator:
                 return price_quantized, 0.0, reason
 
             if filters.qty_step > 0.0:
-                snapped_qty = (
-                    math.floor(qty_for_notional / filters.qty_step) * filters.qty_step
+                snapped_qty = self._snap_qty_with_tolerance(
+                    qty_for_notional, filters.qty_step, tolerance
                 )
                 if abs(qty_for_notional - snapped_qty) > tolerance:
                     reason = FilterRejectionReason(


### PR DESCRIPTION
## Summary
- add a shared helper to snap quantities using a tolerance-adjusted divisor
- apply the tolerance-aware snapping in legacy market and limit filter checks to reduce spurious LOT_SIZE failures

## Testing
- pytest tests/test_execution_rules.py::test_market_quantity_rounded_up_passes_filters tests/test_execution_rules.py::test_market_clamp_notional_growth_rejected_by_qty_limits

------
https://chatgpt.com/codex/tasks/task_e_68d71388c880832fa2bc110b33ad07f8