### PR TITLE
Fix TTL rounding when parsing ExecAction TTL steps

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -333,7 +333,10 @@ def _normalize_ttl_steps(
                 ttl_from_ms = 0
 
     if ttl_steps_val is not None:
-        ttl_final = int(ttl_steps_val)
+        if ttl_steps_val > 0:
+            ttl_final = int(math.ceil(ttl_steps_val))
+        else:
+            ttl_final = int(ttl_steps_val)
     elif ttl_from_ms is not None:
         ttl_final = int(ttl_from_ms)
     else:

--- a/tests/test_exec_action_ttl.py
+++ b/tests/test_exec_action_ttl.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from execution_sim import ActionType, as_exec_action
+
+
+def _make_proto(ttl_steps):
+    return SimpleNamespace(
+        action_type=ActionType.LIMIT,
+        volume_frac=1.0,
+        abs_price=100.0,
+        ttl_steps=ttl_steps,
+    )
+
+
+def test_as_exec_action_rounds_fractional_ttl_half_up():
+    action = as_exec_action(_make_proto(0.5), step_ms=100)
+    assert action.ttl_steps == 1
+
+
+def test_as_exec_action_rounds_fractional_ttl_to_next_int():
+    action = as_exec_action(_make_proto(2.5), step_ms=100)
+    assert action.ttl_steps == 3


### PR DESCRIPTION
## Summary
- update TTL normalization to round positive fractional ttl_steps up to the next step
- add regression tests covering fractional ttl inputs when building ExecAction

## Testing
- `pytest tests/test_exec_action_ttl.py`


------
https://chatgpt.com/codex/tasks/task_e_68d721f31e50832f8e43c9819395fdbd