### PR TITLE
Fix min qty threshold rounding for near-integer steps

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -756,11 +756,12 @@ class SymbolFilterSnapshot:
             # minimum while keeping the result a multiple of ``qty_step``.
             if qty_min > 0.0:
                 ratio = qty_min / qty_step
-                # Subtracting a tiny epsilon compensates for floating-point
-                # rounding errors when ``qty_min`` is already an exact multiple
-                # of ``qty_step``.
-                steps = math.ceil(ratio - 1e-12)
-                steps = max(steps, 1)
+                nearest = round(ratio)
+                tolerance = max(math.ulp(ratio), math.ulp(float(nearest)))
+                if math.isclose(ratio, nearest, rel_tol=0.0, abs_tol=tolerance):
+                    steps = max(int(nearest), 1)
+                else:
+                    steps = math.ceil(ratio)
             else:
                 steps = 1
             return steps * qty_step

--- a/tests/test_execution_sim_symbol_filter.py
+++ b/tests/test_execution_sim_symbol_filter.py
@@ -17,6 +17,12 @@ def test_min_qty_threshold_without_step_uses_min_qty():
     assert filters.min_qty_threshold == pytest.approx(0.25)
 
 
+def test_min_qty_threshold_rounds_up_when_above_multiple():
+    filters = SymbolFilterSnapshot(qty_min=0.010000000000001, qty_step=0.01)
+
+    assert filters.min_qty_threshold == pytest.approx(0.02)
+
+
 @pytest.mark.parametrize(
     "qty_min, qty_step, expected",
     [


### PR DESCRIPTION
## Summary
- ensure `SymbolFilterSnapshot.min_qty_threshold` only relaxes rounding when the ratio is within a floating-point ULP of an integer
- add a regression test confirming minimum quantities just above a step now round up to the next step

## Testing
- pytest tests/test_execution_sim_symbol_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ab04ad3c832fa13ae5f48edffef7