### PR TITLE
Relax PnL reconciliation checks

### DIFF
--- a/tests/test_execution_sim_pnl_tolerance.py
+++ b/tests/test_execution_sim_pnl_tolerance.py
@@ -1,0 +1,27 @@
+import logging
+
+import pytest
+
+from execution_sim import (
+    _PNL_RECONCILE_REL_TOL,
+    _check_pnl_reconciliation,
+)
+
+
+def test_pnl_reconciliation_large_notional(caplog: pytest.LogCaptureFixture) -> None:
+    expected = 1e12
+    allowed_diff = expected * _PNL_RECONCILE_REL_TOL * 0.5
+
+    with caplog.at_level(logging.WARNING):
+        _check_pnl_reconciliation(expected, expected + allowed_diff)
+
+    assert not caplog.records
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        _check_pnl_reconciliation(expected, expected + allowed_diff * 4)
+
+    assert any(
+        "PnL reconciliation drift exceeds tolerance" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- replace strict PnL reconciliation assertions with tolerance-based checks that only emit warnings when exceeded
- add a regression test to cover large notional reconciliation tolerances

## Testing
- pytest tests/test_execution_sim_pnl_tolerance.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b6ae6d48832f86a65a9de97c162c