### PR TITLE
Apply inventory tolerance when clearing positions

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -7390,6 +7390,7 @@ class ExecutionSimulator:
         px = float(price)
         pos = float(self.position_qty)
         avg = self._avg_entry_price
+        tolerance = 1e-12
 
         if str(side).upper() == "BUY":
             if pos < 0.0:
@@ -7398,12 +7399,13 @@ class ExecutionSimulator:
                     realized += (avg - px) * close_qty
                 pos += close_qty
                 q_rem = q - close_qty
-                if q_rem > 0.0:
+                if q_rem > tolerance:
                     self.position_qty = q_rem
                     self._avg_entry_price = px
                 else:
                     self.position_qty = pos
-                    if self.position_qty == 0.0:
+                    if abs(self.position_qty) <= tolerance:
+                        self.position_qty = 0.0
                         self._avg_entry_price = None
             else:
                 new_pos = pos + q
@@ -7422,12 +7424,13 @@ class ExecutionSimulator:
                     realized += (px - avg) * close_qty
                 pos -= close_qty
                 q_rem = q - close_qty
-                if q_rem > 0.0:
+                if q_rem > tolerance:
                     self.position_qty = -q_rem
                     self._avg_entry_price = px
                 else:
                     self.position_qty = pos
-                    if self.position_qty == 0.0:
+                    if abs(self.position_qty) <= tolerance:
+                        self.position_qty = 0.0
                         self._avg_entry_price = None
             else:
                 new_pos = pos - q
@@ -7439,6 +7442,10 @@ class ExecutionSimulator:
                 else:
                     self._avg_entry_price = None
                 self.position_qty = new_pos
+
+        if abs(self.position_qty) <= tolerance:
+            self.position_qty = 0.0
+            self._avg_entry_price = None
 
         self.realized_pnl_cum += float(realized)
         return float(realized)

--- a/tests/test_trade_inventory_tolerance.py
+++ b/tests/test_trade_inventory_tolerance.py
@@ -1,0 +1,34 @@
+import importlib.util
+import pathlib
+import sys
+
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_execution_simulator():
+    existing = sys.modules.get("execution_sim")
+    if existing is not None:
+        return existing.ExecutionSimulator
+
+    spec = importlib.util.spec_from_file_location(
+        "execution_sim", BASE_DIR / "execution_sim.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["execution_sim"] = module
+    spec.loader.exec_module(module)
+    return module.ExecutionSimulator
+
+
+ExecutionSimulator = _load_execution_simulator()
+
+
+def test_apply_trade_inventory_resets_position_with_tolerance():
+    sim = ExecutionSimulator(filters_path=None)
+
+    sim._apply_trade_inventory("BUY", price=100.0, qty=0.1)
+    sim._apply_trade_inventory("BUY", price=110.0, qty=0.2)
+    sim._apply_trade_inventory("SELL", price=105.0, qty=0.3)
+
+    assert sim.position_qty == 0.0
+    assert sim._avg_entry_price is None


### PR DESCRIPTION
## Summary
- add an absolute tolerance to ExecutionSimulator._apply_trade_inventory so tiny residual quantities are zeroed
- ensure the average entry price is cleared when positions fall below the tolerance
- cover a buy/buy/sell sequence with a new test to verify the position resets cleanly

## Testing
- pytest tests/test_trade_inventory_tolerance.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c0216488832f9992bca81e7802e6