### PR TITLE
Align next-open new order positions

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -3137,6 +3137,7 @@ class ExecutionSimulator:
         self._next_open_cancelled_reasons = {}
         new_order_ids = list(self._next_open_new_orders)
         self._next_open_new_orders = []
+        new_order_pos = [0 for _ in new_order_ids]
         risk_events_all: List[RiskEvent] = list(self._next_open_ready_risk_events)  # type: ignore[var-annotated]
         self._next_open_ready_risk_events.clear()
         status = self._next_open_ready_status
@@ -3220,7 +3221,7 @@ class ExecutionSimulator:
             cancelled_reasons=cancelled_reasons,
             new_order_ids=new_order_ids,
             fee_total=fee_total,
-            new_order_pos=[],
+            new_order_pos=new_order_pos,
             funding_cashflow=funding_cashflow,
             funding_events=funding_events_list,  # type: ignore
             position_qty=float(self.position_qty),


### PR DESCRIPTION
## Summary
- ensure `_pop_ready_next_open` forwards placeholder positions so `SimStepReport.new_order_pos` lines up with `new_order_ids`
- keep next-bar-open consumers aligned by returning zeroed position entries for each order id

## Testing
- pytest tests/test_execution_rules.py::test_limit_maker_price_enqueues_without_trade

------
https://chatgpt.com/codex/tasks/task_e_68d7c1ad71fc832fb2fa287c8e633cf4