### PR TITLE
Ensure run_step emits matching new order positions

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -10456,6 +10456,7 @@ class ExecutionSimulator:
             cli_id = int(self._next_cli_id)
             self._next_cli_id += 1
             new_order_ids.append(cli_id)
+            new_order_pos.append(0)
 
             # только MARKET
             if str(

--- a/tests/test_execution_profiles.py
+++ b/tests/test_execution_profiles.py
@@ -190,6 +190,23 @@ def test_execution_simulator_close_lag_applied():
     assert all(t.ts == 1_002_000 for t in release.trades)
 
 
+def test_run_step_reports_new_order_position_alignment(base_sim):
+    sim = base_sim
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=1.0)
+    report = sim.run_step(
+        ts=1_000,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[(ActionType.MARKET, proto)],
+    )
+
+    assert report.new_order_ids
+    assert len(report.new_order_ids) == len(report.new_order_pos)
+    assert report.new_order_pos == [0] * len(report.new_order_ids)
+
+
 def test_mkt_open_next_h1_profile_close_lag(base_sim):
     sim = base_sim
     sim.close_lag_ms = 1500


### PR DESCRIPTION
## Summary
- update `ExecutionSimulator.run_step` so `new_order_pos` is populated whenever `new_order_ids` is updated
- add a regression test to confirm the per-step report keeps `new_order_ids` and `new_order_pos` in sync

## Testing
- pytest tests/test_execution_profiles.py::test_run_step_reports_new_order_position_alignment

------
https://chatgpt.com/codex/tasks/task_e_68d7cf72ce38832f8241da769f0683ca