### PR TITLE
Fix new order ID tracking for market steps

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -10625,8 +10625,6 @@ class ExecutionSimulator:
             # оформление client_order_id
             cli_id = int(self._next_cli_id)
             self._next_cli_id += 1
-            new_order_ids.append(cli_id)
-            new_order_pos.append(0)
 
             # только MARKET
             if str(

--- a/tests/test_execution_profiles.py
+++ b/tests/test_execution_profiles.py
@@ -202,9 +202,34 @@ def test_run_step_reports_new_order_position_alignment(base_sim):
         actions=[(ActionType.MARKET, proto)],
     )
 
-    assert report.new_order_ids
     assert len(report.new_order_ids) == len(report.new_order_pos)
     assert report.new_order_pos == [0] * len(report.new_order_ids)
+
+
+def test_run_step_market_orders_do_not_emit_new_order_ids(base_sim):
+    sim = base_sim
+    proto = ActionProto(action_type=ActionType.MARKET, volume_frac=1.0)
+    report = sim.run_step(
+        ts=1_000,
+        ref_price=100.0,
+        bid=99.5,
+        ask=100.5,
+        liquidity=1.0,
+        actions=[(ActionType.MARKET, proto)],
+    )
+
+    assert report.new_order_ids == []
+    assert report.new_order_pos == []
+
+
+def test_limit_order_reports_new_order_position_alignment(base_sim):
+    sim = base_sim
+    proto = ActionProto(action_type=ActionType.LIMIT, volume_frac=1.0, abs_price=99.0)
+    oid = sim.submit(proto)
+    report = sim.pop_ready(ref_price=100.0)
+
+    assert report.new_order_ids == [oid]
+    assert report.new_order_pos == [0]
 
 
 def test_mkt_open_next_h1_profile_close_lag(base_sim):


### PR DESCRIPTION
## Summary
- stop appending client IDs to `new_order_ids` before an order is actually placed
- keep the new order position list aligned with IDs while omitting executed market orders
- add regression tests for market-only steps and limit order alignment

## Testing
- pytest tests/test_execution_profiles.py::test_run_step_reports_new_order_position_alignment tests/test_execution_profiles.py::test_run_step_market_orders_do_not_emit_new_order_ids tests/test_execution_profiles.py::test_limit_order_reports_new_order_position_alignment

------
https://chatgpt.com/codex/tasks/task_e_68d7e730d278832f8cc808bc9d5a6abf