### PR TITLE
Improve market quantity tolerance handling

### DIFF
--- a/tests/test_execution_sim_symbol_filter.py
+++ b/tests/test_execution_sim_symbol_filter.py
@@ -2,7 +2,7 @@ import math
 
 import pytest
 
-from execution_sim import SymbolFilterSnapshot
+from execution_sim import ExecutionSimulator, SymbolFilterSnapshot
 
 
 def test_min_qty_threshold_aligns_with_step_rounding_up():
@@ -74,3 +74,33 @@ def test_percent_price_bounds_fallback_to_generic_when_missing():
     assert buy_down == pytest.approx(0.7)
     assert sell_up == pytest.approx(1.2)
     assert sell_down == pytest.approx(0.8)
+
+
+def _make_market_legacy_sim(filters: SymbolFilterSnapshot) -> ExecutionSimulator:
+    sim = ExecutionSimulator.__new__(ExecutionSimulator)
+    sim.symbol = "TESTUSDT"
+    sim.strict_filters = True
+    sim.quantizer = None
+    sim._current_symbol_filters = lambda: filters
+    return sim
+
+
+def test_market_legacy_allows_large_step_aligned_quantity():
+    filters = SymbolFilterSnapshot(qty_step=1e-3, qty_min=0.0, qty_max=1e9)
+    sim = _make_market_legacy_sim(filters)
+
+    qty, rejection = sim._apply_filters_market_legacy("BUY", 123_456.789, None)
+
+    assert rejection is None
+    assert qty == pytest.approx(123_456.789)
+
+
+def test_market_legacy_rejects_misaligned_quantity():
+    filters = SymbolFilterSnapshot(qty_step=1e-3, qty_min=0.0, qty_max=1e9)
+    sim = _make_market_legacy_sim(filters)
+
+    qty, rejection = sim._apply_filters_market_legacy("BUY", 123_456.7891, None)
+
+    assert qty == 0.0
+    assert rejection is not None
+    assert rejection.code == "LOT_SIZE"


### PR DESCRIPTION
## Summary
- derive the market filter tolerance from the quantity step and order magnitude so it stays finite and within half a tick
- keep the refined tolerance when snapping quantities in the legacy market filter path
- add regression tests confirming large step-aligned quantities succeed and misaligned ones are rejected

## Testing
- pytest tests/test_execution_sim_symbol_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ee3073fc832fbfba4b5a3ec4a029