### PR TITLE
Add synthetic limit quote fallback when book is empty

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -10359,9 +10359,20 @@ class ExecutionSimulator:
                 exec_qty = qty_q
                 intrabar_fill_price = self._finite_float(limit_intrabar_price)
                 tolerance = 1e-12
-                if self._last_bid is not None or self._last_ask is not None:
-                    best_ask = self._last_ask
-                    best_bid = self._last_bid
+                best_bid = self._finite_float(self._last_bid)
+                best_ask = self._finite_float(self._last_ask)
+                if best_bid is None and best_ask is None:
+                    synthetic_best = self._finite_float(price_q)
+                    if synthetic_best is None:
+                        synthetic_best = self._finite_float(ref_limit)
+                    if synthetic_best is None:
+                        synthetic_best = self._finite_float(ref)
+                    if synthetic_best is not None:
+                        if side == "BUY":
+                            best_ask = synthetic_best
+                        else:
+                            best_bid = synthetic_best
+                if best_bid is not None or best_ask is not None:
                     if side == "BUY":
                         if best_ask is not None and price_q >= best_ask:
                             filled_price = float(best_ask)

--- a/tests/test_execution_rules.py
+++ b/tests/test_execution_rules.py
@@ -139,10 +139,20 @@ def test_unquantized_limit_executes_permissive():
     report = sim.pop_ready(ref_price=100.0)
 
     assert report.cancelled_ids == []
+    assert report.new_order_ids == []
     assert len(report.trades) == 1
     trade = report.trades[0]
     assert trade.client_order_id == oid
-    assert trade.price == pytest.approx(100.0)
+    expected_price = sim.quantizer.quantize_price("BTCUSDT", proto.abs_price)
+    expected_qty = sim.quantizer.quantize_qty("BTCUSDT", abs(proto.volume_frac))
+    expected_qty = sim.quantizer.clamp_notional(
+        "BTCUSDT",
+        expected_price if expected_price > 0 else proto.abs_price,
+        expected_qty,
+    )
+    assert trade.price == pytest.approx(expected_price)
+    assert trade.qty == pytest.approx(expected_qty)
+    assert sim._last_bid is None and sim._last_ask is None
     assert sim.strict_filters is False
 
 
@@ -154,10 +164,20 @@ def test_unquantized_limit_rejected_strict():
     report = sim.pop_ready(ref_price=100.0)
 
     assert report.cancelled_ids == []
+    assert report.new_order_ids == []
     assert len(report.trades) == 1
     trade = report.trades[0]
     assert trade.client_order_id == oid
-    assert trade.price == pytest.approx(100.0)
+    expected_price = sim.quantizer.quantize_price("BTCUSDT", proto.abs_price)
+    expected_qty = sim.quantizer.quantize_qty("BTCUSDT", abs(proto.volume_frac))
+    expected_qty = sim.quantizer.clamp_notional(
+        "BTCUSDT",
+        expected_price if expected_price > 0 else proto.abs_price,
+        expected_qty,
+    )
+    assert trade.price == pytest.approx(expected_price)
+    assert trade.qty == pytest.approx(expected_qty)
+    assert sim._last_bid is None and sim._last_ask is None
 
 
 def test_cancel_all_cancels_open_limits():


### PR DESCRIPTION
## Summary
- add a synthetic best bid/ask fallback for limit orders when the simulator has no latest quote
- ensure the fallback uses quantized limit price data to respect filters
- extend execution rule tests to cover immediate execution without a prior snapshot in permissive and strict modes

## Testing
- pytest tests/test_execution_rules.py::test_unquantized_limit_executes_permissive tests/test_execution_rules.py::test_unquantized_limit_rejected_strict

------
https://chatgpt.com/codex/tasks/task_e_68d80d626d78832f9bed7dcddf4e34d6