### PR TITLE
Fix capacity normalization to honor requested quantity

### DIFF
--- a/tests/test_execution_rules.py
+++ b/tests/test_execution_rules.py
@@ -311,6 +311,21 @@ def test_market_clamp_notional_growth_rejected_by_qty_limits():
     assert rejection.message == "Quantity above maximum"
 
 
+def test_capacity_normalization_caps_to_requested_qty_without_quantizer():
+    sim = ExecutionSimulator(symbol="BTCUSDT", filters_path=None)
+    sim.strict_filters = True
+    sim.enforce_ppbs = False
+    sim.quantizer = None
+    sim.filters = json.loads(json.dumps(filters))
+
+    normalized, rejection = sim._normalize_capacity_quantity(
+        0.15, remaining_base=0.3, ref_price=100.0
+    )
+
+    assert rejection is None
+    assert normalized == pytest.approx(0.1)
+
+
 def test_lowercase_filters_enforce_strict_checks():
     ref_price_high = 10000.0
     ref_price_low = 50.0


### PR DESCRIPTION
## Summary
- ensure `_normalize_capacity_quantity` only uses capacity-based fallbacks when the truncated quantity is constrained by remaining capacity
- clamp normalized quantities to stay within the original request while respecting filter limits, handling both quantizer and legacy paths
- cover the regression with a unit test that exercises an under-capacity request rounded by the lot-size step

## Testing
- `pytest tests/test_execution_rules.py::test_capacity_normalization_caps_to_requested_qty_without_quantizer`


------
https://chatgpt.com/codex/tasks/task_e_68d82512de14832fb607a294eee5d69d