### PR TITLE
Clamp child fills to intrabar volume after quantization

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -10590,6 +10590,13 @@ class ExecutionSimulator:
                     elif cap_enforced:
                         fill_qty_base = min(fill_qty_base, remaining_base)
 
+                    fill_qty_base = self._limit_by_intrabar_volume(fill_qty_base)
+                    if cap_enforced:
+                        remaining_base = max(
+                            0.0, cap_base_per_bar - used_base_before_child
+                        )
+                        fill_qty_base = min(fill_qty_base, remaining_base)
+
                     if cap_enforced and fill_qty_base <= 0.0:
                         ts_zero = int(base_ts + lat_ms)
                         cid_int = int(p.client_order_id)
@@ -10794,6 +10801,13 @@ class ExecutionSimulator:
                     fill_qty_base = max(0.0, float(quant_qty))
                     if fill_qty_base <= 0.0:
                         continue
+
+                    fill_qty_base = self._limit_by_intrabar_volume(fill_qty_base)
+                    if cap_enforced:
+                        remaining_base = max(
+                            0.0, cap_base_per_bar - used_base_before_child
+                        )
+                        fill_qty_base = min(fill_qty_base, remaining_base)
 
                     q_child = float(fill_qty_base)
                     self._consume_intrabar_volume(q_child)
@@ -12547,6 +12561,13 @@ class ExecutionSimulator:
                     elif cap_enforced:
                         fill_qty_base = min(fill_qty_base, remaining_base)
 
+                    fill_qty_base = self._limit_by_intrabar_volume(fill_qty_base)
+                    if cap_enforced:
+                        remaining_base = max(
+                            0.0, cap_base_per_bar - used_base_before_child
+                        )
+                        fill_qty_base = min(fill_qty_base, remaining_base)
+
                     if cap_enforced and fill_qty_base <= 0.0:
                         ts_zero = int(ts_send)
                         if cli_id not in cancelled_ids:
@@ -12728,6 +12749,13 @@ class ExecutionSimulator:
                     fill_qty_base = max(0.0, float(quant_qty))
                     if fill_qty_base <= 0.0:
                         continue
+
+                    fill_qty_base = self._limit_by_intrabar_volume(fill_qty_base)
+                    if cap_enforced:
+                        remaining_base = max(
+                            0.0, cap_base_per_bar - used_base_before_child
+                        )
+                        fill_qty_base = min(fill_qty_base, remaining_base)
 
                     q_child = float(fill_qty_base)
                     self._consume_intrabar_volume(q_child)


### PR DESCRIPTION
## Summary
- reapply intrabar volume limits to child order sizes in `pop_ready` after quantize/min-notional adjustments so fills cannot exceed the intrabar profile
- apply the same post-quantization intrabar limiting in `run_step` before consuming volume and update capacity bookkeeping accordingly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d837d405a8832fa6243a4f4cbd34d0