### PR TITLE
Handle missing values when reading fear & greed CSV

### DIFF
--- a/prepare_advanced_data.py
+++ b/prepare_advanced_data.py
@@ -45,7 +45,26 @@ def main():
             for r in rdr:
                 if not r:
                     continue
-                existing_rows.append([int(r[0]), int(r[1]) if len(r) > 1 else int(r[1]) if r[1].isdigit() else int(float(r[1]))])
+
+                try:
+                    ts = int(r[0])
+                except (TypeError, ValueError):
+                    continue
+
+                if len(r) < 2:
+                    # Skip rows without a value column to avoid indexing errors
+                    continue
+
+                raw_val = r[1]
+                try:
+                    val = int(raw_val)
+                except (TypeError, ValueError):
+                    try:
+                        val = float(raw_val)
+                    except (TypeError, ValueError):
+                        continue
+
+                existing_rows.append([ts, val])
             if existing_rows:
                 last_ts = max(x[0] for x in existing_rows)
 

--- a/tests/test_prepare_advanced_data.py
+++ b/tests/test_prepare_advanced_data.py
@@ -1,0 +1,12 @@
+import prepare_advanced_data
+
+
+def test_prepare_advanced_data_handles_single_column_rows(tmp_path, monkeypatch):
+    csv_path = tmp_path / "fear_greed.csv"
+    csv_path.write_text("timestamp\n123\n456\n", encoding="utf-8")
+
+    monkeypatch.setattr(prepare_advanced_data, "OUT_DIR", str(tmp_path))
+    monkeypatch.setattr(prepare_advanced_data, "OUT_PATH", str(csv_path))
+    monkeypatch.setattr(prepare_advanced_data, "fetch_fng", lambda limit=0: [])
+
+    prepare_advanced_data.main()


### PR DESCRIPTION
## Summary
- guard against missing value columns when reloading fear & greed CSV data
- ensure stored values are parsed numerically with int-to-float fallback
- add a regression test covering single-column CSV rows

## Testing
- pytest tests/test_prepare_advanced_data.py


------
https://chatgpt.com/codex/tasks/task_e_68d936a525d0832f9ebb167147e1091b