### PR TITLE
Improve non-datetime index continuity handling

### DIFF
--- a/tests/test_pii_detection.py
+++ b/tests/test_pii_detection.py
@@ -40,3 +40,25 @@ def test_accepts_clean_data():
     df = _make_df('seasonal pattern')
     validator = DataValidator()
     validator.validate(df)
+
+
+def test_integer_index_with_custom_step_passes():
+    idx = pd.Index([0, 5, 10], name="row")
+    timestamps = pd.date_range('2024-01-01', periods=3, freq='1T')
+    data = {
+        'timestamp': timestamps,
+        'symbol': ['BTCUSDT'] * 3,
+        'open': [1.0, 1.1, 1.2],
+        'high': [1.1, 1.2, 1.3],
+        'low': [0.9, 1.0, 1.1],
+        'close': [1.05, 1.15, 1.25],
+        'volume': [1.0, 1.0, 1.0],
+        'quote_asset_volume': [1.0, 1.0, 1.0],
+        'number_of_trades': [1, 1, 1],
+        'taker_buy_base_asset_volume': [1.0, 1.0, 1.0],
+        'taker_buy_quote_asset_volume': [1.0, 1.0, 1.0],
+        'note': ['clean'] * 3,
+    }
+    df = pd.DataFrame(data, index=idx)
+    validator = DataValidator()
+    validator.validate(df)


### PR DESCRIPTION
## Summary
- allow numeric indexes with steps greater than 1 to pass continuity checks by validating against the first non-zero increment
- raise a clear error when the index type is unsupported for non-datetime continuity validation
- add a regression test ensuring integer indexes with steps greater than 1 pass validation

## Testing
- pytest tests/test_pii_detection.py

------
https://chatgpt.com/codex/tasks/task_e_68d93dcf0904832faf739708cfe21088