### PR TITLE
Reset funding schedule when position is empty

### DIFF
--- a/fees.py
+++ b/fees.py
@@ -1139,7 +1139,7 @@ class FundingCalculator:
             return 0.0, []
         if mark_price is None or not math.isfinite(float(mark_price)) or abs(position_qty) <= 0.0:
             # Нет цены или позиции — funding не начисляем
-            self._next_ts_ms = None if self._next_ts_ms is None else self._next_ts_ms
+            self._next_ts_ms = None
             return 0.0, []
 
         total = 0.0

--- a/tests/test_funding_calculator.py
+++ b/tests/test_funding_calculator.py
@@ -1,0 +1,42 @@
+import math
+
+from fees import FundingCalculator
+
+
+def test_funding_schedule_reset_on_position_close():
+    calc = FundingCalculator(
+        enabled=True,
+        const_rate_per_interval=0.01,
+        interval_seconds=60,
+        align_to_epoch=False,
+    )
+
+    total_open, events_open = calc.accrue(
+        position_qty=1.0,
+        mark_price=100.0,
+        now_ts_ms=0,
+    )
+
+    assert math.isclose(total_open, 0.0)
+    assert events_open == []
+    assert calc._next_ts_ms == 60_000
+
+    total_close, events_close = calc.accrue(
+        position_qty=0.0,
+        mark_price=100.0,
+        now_ts_ms=30_000,
+    )
+
+    assert math.isclose(total_close, 0.0)
+    assert events_close == []
+    assert calc._next_ts_ms is None
+
+    total_reopen, events_reopen = calc.accrue(
+        position_qty=1.0,
+        mark_price=100.0,
+        now_ts_ms=90_000,
+    )
+
+    assert math.isclose(total_reopen, 0.0)
+    assert events_reopen == []
+    assert calc._next_ts_ms == 150_000


### PR DESCRIPTION
## Summary
- reset the funding calculator schedule whenever mark price or position is absent
- add a regression test to ensure funding does not accrue for closed positions

## Testing
- pytest tests/test_funding_calculator.py

------
https://chatgpt.com/codex/tasks/task_e_68d9433ec200832fbc33df7c1a40da2c