### PR TITLE
Add structured runtime execution portfolio and cost configuration

### DIFF
--- a/configs/runtime_trade.yaml
+++ b/configs/runtime_trade.yaml
@@ -1,0 +1,18 @@
+# Reference runtime trade configuration showcasing bar-mode tuning knobs.
+# This snippet is intended for inclusion/inspection rather than direct execution.
+portfolio:
+  equity_usd: 1_000_000.0
+costs:
+  taker_fee_bps: 7.5
+  half_spread_bps: 1.5
+  impact:
+    sqrt_coeff: 15.0
+    linear_coeff: 2.5
+execution:
+  mode: bar
+  bar_price: close
+  min_rebalance_step: 0.05
+risk:
+  max_weight: 0.25
+  turnover_cap: 0.5
+  cooldown_bars: 2

--- a/di_registry.py
+++ b/di_registry.py
@@ -22,6 +22,8 @@ from core_config import (
     CommonRunConfig,
     RetryConfig,
     AdvRuntimeConfig,
+    PortfolioConfig,
+    SpotCostConfig,
 )
 from impl_quantizer import QuantizerImpl
 
@@ -110,6 +112,14 @@ def build_graph(components: Components, run_config: Optional[CommonRunConfig] = 
         container["run_config"] = run_config
         container["retry_cfg"] = run_config.retry
         container[RetryConfig] = run_config.retry
+        portfolio_cfg = getattr(run_config, "portfolio", None)
+        if isinstance(portfolio_cfg, PortfolioConfig):
+            container["portfolio"] = portfolio_cfg
+            container[PortfolioConfig] = portfolio_cfg
+        costs_cfg = getattr(run_config, "costs", None)
+        if isinstance(costs_cfg, SpotCostConfig):
+            container["costs"] = costs_cfg
+            container[SpotCostConfig] = costs_cfg
         q_cfg = getattr(run_config, "quantizer", None)
         if isinstance(q_cfg, Mapping):
             try:

--- a/tests/test_common_run_config_sections.py
+++ b/tests/test_common_run_config_sections.py
@@ -1,0 +1,93 @@
+import textwrap
+import sys
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core_config import load_config_from_str, PortfolioConfig, SpotCostConfig
+
+
+def _wrap_payload(payload: str) -> str:
+    base = textwrap.dedent(
+        """
+        mode: sim
+        symbols: ["BTCUSDT"]
+        components:
+          market_data:
+            target: "module:Cls"
+            params: {}
+          executor:
+            target: "module:Cls"
+            params: {}
+          feature_pipe:
+            target: "module:Cls"
+            params: {}
+          policy:
+            target: "module:Cls"
+            params: {}
+          risk_guards:
+            target: "module:Cls"
+            params: {}
+        data:
+          symbols: ["BTCUSDT"]
+          timeframe: "1m"
+        """
+    ).strip()
+    payload_block = textwrap.dedent(payload).strip()
+    return "\n".join([base, payload_block, ""]) if payload_block else f"{base}\n"
+
+
+def test_common_run_config_syncs_top_level_sections():
+    yaml_cfg = _wrap_payload(
+        """
+        portfolio:
+          equity_usd: 500000.0
+        costs:
+          taker_fee_bps: 8.0
+          half_spread_bps: 1.0
+          impact:
+            sqrt_coeff: 10.0
+            linear_coeff: 3.0
+        """
+    )
+    cfg = load_config_from_str(yaml_cfg)
+
+    assert isinstance(cfg.portfolio, PortfolioConfig)
+    assert cfg.portfolio.equity_usd == 500000.0
+    assert isinstance(cfg.execution.portfolio, PortfolioConfig)
+    assert cfg.execution.portfolio.equity_usd == 500000.0
+
+    assert isinstance(cfg.costs, SpotCostConfig)
+    assert cfg.costs.taker_fee_bps == 8.0
+    assert cfg.costs.half_spread_bps == 1.0
+    assert cfg.costs.impact.sqrt_coeff == 10.0
+    assert cfg.execution.costs.impact.linear_coeff == 3.0
+
+
+def test_common_run_config_reads_embedded_sections():
+    yaml_cfg = _wrap_payload(
+        """
+        execution:
+          mode: bar
+          portfolio:
+            equity_usd: 250000.0
+          costs:
+            taker_fee_bps: 4.5
+            half_spread_bps: 0.8
+            impact:
+              sqrt_coeff: 6.0
+              linear_coeff: 1.5
+        """
+    )
+    cfg = load_config_from_str(yaml_cfg)
+
+    assert cfg.execution.mode == "bar"
+    assert isinstance(cfg.portfolio, PortfolioConfig)
+    assert cfg.portfolio.equity_usd == 250000.0
+    assert isinstance(cfg.costs, SpotCostConfig)
+    assert cfg.costs.half_spread_bps == 0.8
+    assert cfg.execution.costs.taker_fee_bps == 4.5
+    assert cfg.costs.impact.sqrt_coeff == 6.0
+    assert cfg.execution.costs.impact.linear_coeff == 1.5


### PR DESCRIPTION
## Summary
- add structured portfolio and spot cost models to `ExecutionRuntimeConfig` along with bar execution knobs
- expose the new sections on `CommonRunConfig`, wire them into the DI container, and document defaults via a runtime trade reference YAML
- cover the legacy compatibility paths with a regression test that exercises both top-level and embedded sections

## Testing
- pytest tests/test_common_run_config_sections.py tests/test_live_config_execution_profile.py


------
https://chatgpt.com/codex/tasks/task_e_68d9782082e0832fba11e2f1550ac4e1