### PR TITLE
Add bar executor for portfolio-weight rebalancing

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -1,0 +1,516 @@
+# -*- coding: utf-8 -*-
+"""Bar-based execution helper utilities.
+
+This module provides a light-weight :class:`TradeExecutor` implementation that
+operates on bar data instead of full order-book snapshots.  The executor keeps
+track of portfolio weights per symbol, accepts high-level rebalance payloads and
+produces deterministic schedules describing how the rebalance should be
+performed (e.g. single-shot or TWAP style).  No actual fills are emitted –
+callers are expected to interpret the returned instructions and account for the
+resulting state updates on their end.
+
+Two payload flavours are supported:
+
+``target_weight``
+    Absolute target for the next bar (expressed as a fraction of portfolio
+    equity).  The executor computes the required delta vs the current weight,
+    enforces ``min_rebalance_step`` and emits a single rebalance instruction by
+    default.
+
+``delta_weight``
+    Relative adjustment to the current weight.  Optional TWAP configuration and
+    participation caps can be provided and are mapped onto deterministic child
+    instructions.
+
+The helper :func:`decide_spot_trade` encapsulates the simple spot-market cost
+model used by the executor.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from core_config import SpotCostConfig
+from core_contracts import TradeExecutor
+from core_models import (
+    Bar,
+    ExecReport,
+    ExecStatus,
+    Liquidity,
+    Order,
+    OrderType,
+    Position,
+    Side,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _as_decimal(value: float | Decimal) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _clamp_01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _ensure_cost_config(cost_config: SpotCostConfig | Mapping[str, Any] | None) -> SpotCostConfig:
+    if cost_config is None:
+        return SpotCostConfig()
+    if isinstance(cost_config, SpotCostConfig):
+        return cost_config
+    try:
+        return SpotCostConfig.parse_obj(cost_config)
+    except Exception:  # pragma: no cover - defensive fallback
+        logger.exception("Failed to parse cost_config, falling back to defaults")
+        return SpotCostConfig()
+
+
+@dataclass
+class PortfolioState:
+    symbol: str
+    weight: float = 0.0
+    equity_usd: float = 0.0
+    price: Decimal = Decimal("0")
+    ts: int = 0
+
+    def with_bar(self, bar: Bar, price: Decimal) -> "PortfolioState":
+        return replace(self, price=price, ts=bar.ts)
+
+
+@dataclass
+class RebalanceInstruction:
+    symbol: str
+    ts: int
+    slice_index: int
+    slices_total: int
+    target_weight: float
+    delta_weight: float
+    notional_usd: float
+    quantity: Decimal
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "ts": self.ts,
+            "slice_index": self.slice_index,
+            "slices_total": self.slices_total,
+            "target_weight": self.target_weight,
+            "delta_weight": self.delta_weight,
+            "notional_usd": self.notional_usd,
+            "quantity": float(self.quantity),
+        }
+
+
+def decide_spot_trade(
+    signal: Mapping[str, Any],
+    portfolio_state: PortfolioState,
+    cost_config: SpotCostConfig,
+    adv_quote: Optional[float],
+    safety_margin_bps: float = 0.0,
+) -> Dict[str, Any]:
+    """Evaluate whether the current signal justifies trading.
+
+    Parameters
+    ----------
+    signal:
+        Mapping describing the desired rebalance.  Expected keys include
+        ``edge_bps`` and either ``target_weight`` or ``delta_weight``.  When
+        both are present, ``target_weight`` takes precedence.
+    portfolio_state:
+        Current portfolio snapshot for the symbol.
+    cost_config:
+        Spot execution cost assumptions.
+    adv_quote:
+        Average daily volume proxy expressed in quote currency.  ``None`` or
+        non-positive values disable the participation-based impact model.
+    safety_margin_bps:
+        Additional buffer subtracted from the signal edge before deciding to
+        trade.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``edge_bps``, ``cost_bps``, ``net_bps``,
+        ``turnover_usd`` and ``act_now``.
+    """
+
+    edge_bps = float(signal.get("edge_bps") or 0.0)
+
+    if "target_weight" in signal:
+        raw_target = float(signal.get("target_weight") or 0.0)
+        target_weight = _clamp_01(raw_target)
+    elif "delta_weight" in signal:
+        delta_weight = float(signal.get("delta_weight") or 0.0)
+        target_weight = _clamp_01(portfolio_state.weight + delta_weight)
+    else:
+        target_weight = portfolio_state.weight
+
+    delta_weight = target_weight - portfolio_state.weight
+    turnover_usd = abs(delta_weight) * float(portfolio_state.equity_usd)
+
+    base_cost = float(cost_config.taker_fee_bps) + float(cost_config.half_spread_bps)
+
+    participation = 0.0
+    if adv_quote is not None and adv_quote > 0.0:
+        participation = turnover_usd / float(adv_quote)
+    impact = 0.0
+    if participation > 0.0:
+        sqrt_coeff = float(cost_config.impact.sqrt_coeff)
+        linear_coeff = float(cost_config.impact.linear_coeff)
+        impact += sqrt_coeff * math.sqrt(participation)
+        impact += linear_coeff * participation
+
+    cost_bps = base_cost + impact
+    net_bps = edge_bps - cost_bps - float(safety_margin_bps)
+    act_now = net_bps > 0.0 and turnover_usd > 0.0
+
+    return {
+        "edge_bps": edge_bps,
+        "cost_bps": cost_bps,
+        "net_bps": net_bps,
+        "turnover_usd": turnover_usd,
+        "act_now": act_now,
+    }
+
+
+class BarExecutor(TradeExecutor):
+    """Simple portfolio-weight executor operating on bar data."""
+
+    def __init__(
+        self,
+        *,
+        run_id: str = "bar",
+        bar_price: str = "close",
+        min_rebalance_step: float = 0.0,
+        cost_config: SpotCostConfig | Mapping[str, Any] | None = None,
+        safety_margin_bps: float = 0.0,
+        default_equity_usd: float = 0.0,
+        initial_weights: Optional[Mapping[str, float]] = None,
+    ) -> None:
+        self.run_id = run_id
+        self.bar_price_field = str(bar_price or "close")
+        self.min_rebalance_step = max(0.0, float(min_rebalance_step))
+        self.cost_config = _ensure_cost_config(cost_config)
+        self.safety_margin_bps = float(safety_margin_bps)
+        self.default_equity_usd = float(default_equity_usd)
+        self._states: Dict[str, PortfolioState] = {}
+        if initial_weights:
+            for symbol, weight in initial_weights.items():
+                self._states[symbol] = PortfolioState(
+                    symbol=symbol,
+                    weight=_clamp_01(float(weight)),
+                    equity_usd=self.default_equity_usd,
+                )
+
+    # ------------------------------------------------------------------
+    # TradeExecutor protocol
+    # ------------------------------------------------------------------
+    def execute(self, order: Order) -> ExecReport:
+        symbol = order.symbol
+        state = self._states.get(symbol)
+        if state is None:
+            state = PortfolioState(symbol=symbol, equity_usd=self.default_equity_usd)
+
+        payload = self._extract_payload(order.meta)
+        adv_quote = self._coerce_float(order.meta.get("adv_quote"))
+        bar = self._extract_bar(order.meta)
+
+        if bar is not None:
+            price = self._select_bar_price(bar)
+            state = state.with_bar(bar, price)
+        else:
+            price = state.price
+
+        equity_override = self._coerce_float(order.meta.get("equity_usd"))
+        if equity_override is not None:
+            state = replace(state, equity_usd=equity_override)
+
+        target_weight, mode, delta_weight = self._resolve_target_weight(state, payload)
+
+        decision_signal: Dict[str, Any] = dict(payload)
+        decision_signal.setdefault("target_weight", target_weight)
+        metrics = decide_spot_trade(
+            decision_signal,
+            state,
+            self.cost_config,
+            adv_quote,
+            self.safety_margin_bps,
+        )
+
+        min_step = self.min_rebalance_step
+        skip_due_to_step = False
+        if min_step > 0.0 and abs(delta_weight) < min_step:
+            skip_due_to_step = True
+            metrics["act_now"] = False
+
+        instructions: List[RebalanceInstruction] = []
+        final_state = state
+
+        if metrics["act_now"] and not skip_due_to_step:
+            instructions = self._build_instructions(
+                state=state,
+                target_weight=target_weight,
+                delta_weight=delta_weight,
+                payload=payload,
+                bar=bar,
+                adv_quote=adv_quote,
+            )
+            final_state = replace(state, weight=target_weight)
+        else:
+            logger.debug(
+                "Skipping rebalance for %s (mode=%s, delta=%.6f, metrics=%s)",
+                symbol,
+                mode,
+                delta_weight,
+                metrics,
+            )
+
+        self._states[symbol] = final_state
+
+        report_meta: Dict[str, Any] = {
+            "mode": mode,
+            "decision": metrics,
+            "target_weight": target_weight,
+            "delta_weight": delta_weight,
+            "instructions": [instr.to_dict() for instr in instructions],
+        }
+        if skip_due_to_step:
+            report_meta["min_step_enforced"] = True
+        if bar is not None:
+            report_meta["bar_ts"] = bar.ts
+        if price is not None:
+            report_meta["reference_price"] = float(price)
+        if adv_quote is not None:
+            report_meta["adv_quote"] = adv_quote
+
+        return ExecReport(
+            ts=bar.ts if bar is not None else order.ts,
+            run_id=self.run_id,
+            symbol=symbol,
+            side=order.side if isinstance(order.side, Side) else Side.BUY,
+            order_type=order.order_type if isinstance(order.order_type, OrderType) else OrderType.MARKET,
+            price=Decimal("0"),
+            quantity=Decimal("0"),
+            fee=Decimal("0"),
+            fee_asset=None,
+            exec_status=ExecStatus.CANCELED,
+            liquidity=Liquidity.UNKNOWN,
+            client_order_id=order.client_order_id,
+            meta=report_meta,
+        )
+
+    def cancel(self, client_order_id: str) -> None:  # pragma: no cover - no-op
+        logger.debug("cancel() called on BarExecutor for %s", client_order_id)
+
+    def get_open_positions(self, symbols: Optional[Iterable[str]] = None) -> MutableMapping[str, Position]:
+        if symbols is None:
+            symbols = self._states.keys()
+        result: Dict[str, Position] = {}
+        for symbol in symbols:
+            state = self._states.get(symbol)
+            if state is None:
+                continue
+            price = state.price if state.price != Decimal("0") else Decimal("0")
+            if price != Decimal("0"):
+                qty_value = (Decimal(str(state.weight)) * Decimal(str(state.equity_usd))) / price
+            else:
+                qty_value = Decimal("0")
+            position = Position(
+                symbol=symbol,
+                qty=qty_value,
+                avg_entry_price=price if price != Decimal("0") else Decimal("0"),
+                realized_pnl=Decimal("0"),
+                fee_paid=Decimal("0"),
+                ts=state.ts or None,
+                meta={
+                    "weight": state.weight,
+                    "equity_usd": state.equity_usd,
+                },
+            )
+            result[symbol] = position
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _extract_payload(self, meta: Mapping[str, Any]) -> Dict[str, Any]:
+        payload = meta.get("payload")
+        if isinstance(payload, Mapping):
+            return dict(payload)
+        rebalance_payload = meta.get("rebalance")
+        if isinstance(rebalance_payload, Mapping):
+            return dict(rebalance_payload)
+        return {}
+
+    def _coerce_float(self, value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _extract_bar(self, meta: Mapping[str, Any]) -> Optional[Bar]:
+        bar_value = meta.get("bar")
+        if isinstance(bar_value, Bar):
+            return bar_value
+        if isinstance(bar_value, Mapping):
+            try:
+                return Bar.from_dict(bar_value)
+            except Exception:
+                logger.exception("Failed to coerce bar payload")
+        return None
+
+    def _select_bar_price(self, bar: Bar) -> Decimal:
+        price_value = getattr(bar, self.bar_price_field, None)
+        if price_value is None:
+            logger.debug(
+                "Bar does not contain '%s', falling back to close price", self.bar_price_field
+            )
+            price_value = bar.close
+        return _as_decimal(price_value)
+
+    def _resolve_target_weight(
+        self, state: PortfolioState, payload: Mapping[str, Any]
+    ) -> tuple[float, str, float]:
+        current_weight = state.weight
+        mode = "none"
+        if "target_weight" in payload or "target" in payload or "weight" in payload:
+            raw_value = (
+                payload.get("target_weight")
+                if payload.get("target_weight") is not None
+                else payload.get("target")
+            )
+            if raw_value is None:
+                raw_value = payload.get("weight")
+            try:
+                target_weight = _clamp_01(float(raw_value))
+            except (TypeError, ValueError):
+                target_weight = current_weight
+            mode = "target"
+        elif "delta_weight" in payload or "delta" in payload:
+            raw_delta = payload.get("delta_weight")
+            if raw_delta is None:
+                raw_delta = payload.get("delta")
+            try:
+                delta = float(raw_delta)
+            except (TypeError, ValueError):
+                delta = 0.0
+            unclamped_target = current_weight + delta
+            target_weight = _clamp_01(unclamped_target)
+            mode = "delta"
+        else:
+            target_weight = current_weight
+        delta_weight = target_weight - current_weight
+        return target_weight, mode, delta_weight
+
+    def _build_instructions(
+        self,
+        *,
+        state: PortfolioState,
+        target_weight: float,
+        delta_weight: float,
+        payload: Mapping[str, Any],
+        bar: Optional[Bar],
+        adv_quote: Optional[float],
+    ) -> List[RebalanceInstruction]:
+        total_notional = abs(delta_weight) * float(state.equity_usd)
+        if total_notional <= 0.0:
+            return []
+
+        twap_cfg: Mapping[str, Any] = {}
+        twap_value = payload.get("twap")
+        if isinstance(twap_value, Mapping):
+            twap_cfg = twap_value
+
+        parts = 1
+        if "parts" in twap_cfg:
+            try:
+                parts = max(1, int(twap_cfg.get("parts")))
+            except (TypeError, ValueError):
+                parts = 1
+        elif payload.get("twap_parts") is not None:
+            try:
+                parts = max(1, int(payload.get("twap_parts")))
+            except (TypeError, ValueError):
+                parts = 1
+
+        max_participation = self._coerce_float(
+            twap_cfg.get("max_participation", payload.get("max_participation"))
+        )
+        if max_participation is not None and max_participation > 0.0 and adv_quote and adv_quote > 0.0:
+            max_slice_notional = adv_quote * max_participation
+            if max_slice_notional > 0.0:
+                required_parts = math.ceil(total_notional / max_slice_notional)
+                parts = max(parts, required_parts)
+
+        if parts <= 0:
+            parts = 1
+
+        interval_ms = None
+        if "interval_ms" in twap_cfg:
+            try:
+                interval_ms = int(twap_cfg.get("interval_ms"))
+            except (TypeError, ValueError):
+                interval_ms = None
+        if interval_ms is None and "interval_s" in twap_cfg:
+            try:
+                interval_ms = int(float(twap_cfg.get("interval_s")) * 1000)
+            except (TypeError, ValueError):
+                interval_ms = None
+        if interval_ms is None and payload.get("twap_interval_ms") is not None:
+            try:
+                interval_ms = int(payload.get("twap_interval_ms"))
+            except (TypeError, ValueError):
+                interval_ms = None
+        if interval_ms is None and payload.get("twap_interval_s") is not None:
+            try:
+                interval_ms = int(float(payload.get("twap_interval_s")) * 1000)
+            except (TypeError, ValueError):
+                interval_ms = None
+        if interval_ms is None:
+            interval_ms = 0
+
+        instructions: List[RebalanceInstruction] = []
+        price = state.price if state.price != Decimal("0") else Decimal("0")
+        per_weight = delta_weight / float(parts)
+        accumulated_weight = state.weight
+        for idx in range(parts):
+            if idx == parts - 1:
+                slice_delta = target_weight - accumulated_weight
+            else:
+                slice_delta = per_weight
+            accumulated_weight += slice_delta
+            slice_notional = abs(slice_delta) * float(state.equity_usd)
+            if price != Decimal("0"):
+                slice_qty = (Decimal(str(abs(slice_delta))) * Decimal(str(state.equity_usd))) / price
+            else:
+                slice_qty = Decimal("0")
+            ts = state.ts if bar is None else bar.ts
+            if interval_ms and bar is not None:
+                ts = int(bar.ts + idx * interval_ms)
+            instructions.append(
+                RebalanceInstruction(
+                    symbol=state.symbol,
+                    ts=ts,
+                    slice_index=idx,
+                    slices_total=parts,
+                    target_weight=accumulated_weight,
+                    delta_weight=slice_delta,
+                    notional_usd=slice_notional,
+                    quantity=slice_qty,
+                )
+            )
+        return instructions
+
+
+__all__ = ["BarExecutor", "PortfolioState", "RebalanceInstruction", "decide_spot_trade"]
+

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -1,0 +1,136 @@
+from decimal import Decimal
+
+import pytest
+
+from core_config import SpotCostConfig, SpotImpactConfig
+from core_models import Bar, Order, OrderType, Side
+
+from impl_bar_executor import BarExecutor, PortfolioState, decide_spot_trade
+
+
+def make_bar(ts: int, price: float) -> Bar:
+    return Bar(
+        ts=ts,
+        symbol="BTCUSDT",
+        open=Decimal(str(price)),
+        high=Decimal(str(price * 1.01)),
+        low=Decimal(str(price * 0.99)),
+        close=Decimal(str(price)),
+        volume_base=Decimal("1"),
+        volume_quote=Decimal(str(price)),
+    )
+
+
+def test_decide_spot_trade_costs_and_net():
+    state = PortfolioState(symbol="BTCUSDT", weight=0.1, equity_usd=1000.0)
+    cfg = SpotCostConfig(
+        taker_fee_bps=5.0,
+        half_spread_bps=10.0,
+        impact=SpotImpactConfig(sqrt_coeff=15.0, linear_coeff=2.0),
+    )
+    signal = {"target_weight": 0.3, "edge_bps": 50.0}
+    metrics = decide_spot_trade(signal, state, cfg, adv_quote=50000.0, safety_margin_bps=3.0)
+
+    # Expected delta = 0.2 -> turnover_usd = 200.0, participation = 0.004
+    assert metrics["turnover_usd"] == pytest.approx(200.0)
+    base_cost = 15.0  # 5 + 10
+    impact = 15.0 * (0.004 ** 0.5) + 2.0 * 0.004
+    assert metrics["cost_bps"] == pytest.approx(base_cost + impact)
+    assert metrics["edge_bps"] == 50.0
+    assert metrics["net_bps"] == pytest.approx(50.0 - (base_cost + impact) - 3.0)
+    assert metrics["act_now"] is True
+
+
+def test_bar_executor_target_weight_single_instruction():
+    executor = BarExecutor(
+        run_id="test",
+        bar_price="close",
+        min_rebalance_step=0.0,
+        cost_config=SpotCostConfig(),
+        default_equity_usd=1000.0,
+    )
+    order = Order(
+        ts=1,
+        symbol="BTCUSDT",
+        side=Side.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("0"),
+        price=None,
+        meta={
+            "bar": make_bar(1, 10000.0),
+            "payload": {"target_weight": 0.5, "edge_bps": 20.0},
+        },
+    )
+    report = executor.execute(order)
+    instructions = report.meta["instructions"]
+    assert len(instructions) == 1
+    instr = instructions[0]
+    assert instr["target_weight"] == 0.5
+    assert instr["delta_weight"] == 0.5
+    assert instr["slice_index"] == 0
+    positions = executor.get_open_positions()
+    pos = positions["BTCUSDT"]
+    assert pos.meta["weight"] == 0.5
+
+
+def test_bar_executor_delta_weight_twap_and_participation():
+    executor = BarExecutor(
+        run_id="test",
+        bar_price="close",
+        cost_config=SpotCostConfig(),
+        default_equity_usd=1000.0,
+    )
+    bar = make_bar(2, 5000.0)
+    order = Order(
+        ts=2,
+        symbol="BTCUSDT",
+        side=Side.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("0"),
+        price=None,
+        meta={
+            "bar": bar,
+            "adv_quote": 1000.0,
+            "payload": {
+                "delta_weight": 0.4,
+                "edge_bps": 30.0,
+                "twap": {"parts": 2, "interval_s": 60},
+                "max_participation": 0.05,
+            },
+        },
+    )
+    report = executor.execute(order)
+    instructions = report.meta["instructions"]
+    # Max participation with adv 1000 => max slice notional 50, total notional = 400
+    # Requires at least 8 slices (400 / 50)
+    assert len(instructions) == 8
+    assert instructions[0]["slice_index"] == 0
+    assert instructions[-1]["slice_index"] == 7
+    assert instructions[-1]["target_weight"] == 0.4
+
+
+def test_bar_executor_respects_min_rebalance_step():
+    executor = BarExecutor(
+        run_id="test",
+        min_rebalance_step=0.2,
+        cost_config=SpotCostConfig(),
+        default_equity_usd=1000.0,
+    )
+    order = Order(
+        ts=3,
+        symbol="BTCUSDT",
+        side=Side.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("0"),
+        price=None,
+        meta={
+            "bar": make_bar(3, 100.0),
+            "payload": {"target_weight": 0.1, "edge_bps": 10.0},
+        },
+    )
+    report = executor.execute(order)
+    assert report.meta.get("min_step_enforced") is True
+    assert report.meta["instructions"] == []
+    positions = executor.get_open_positions()
+    assert positions["BTCUSDT"].meta["weight"] == 0.0
+


### PR DESCRIPTION
## Summary
- add a bar-oriented TradeExecutor that consumes bar payloads, keeps portfolio weights, and emits rebalance instructions without fills
- introduce the decide_spot_trade helper to score edges versus costs and drive execution decisions
- cover target-weight, delta-weight, TWAP, and min-step scenarios with focused unit tests

## Testing
- pytest tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68d97a17fd7c832f9db9743720a70e55