### PR TITLE
Add bar-mode backtesting support

### DIFF
--- a/sandbox/backtest_adapter.py
+++ b/sandbox/backtest_adapter.py
@@ -621,6 +621,13 @@ class BacktestAdapter:
             )
             core_order_intents = [it.to_dict() for it in orders_to_order_intents(orders, _ctx)]
 
+            setter = getattr(self.sim, "set_active_symbol", None)
+            if callable(setter):
+                try:
+                    setter(sym)
+                except Exception:
+                    pass
+
             rep = self.sim.step(
                 ts_ms=ts,
                 ref_price=ref,


### PR DESCRIPTION
## Summary
- route bar-mode dependency injection to use the lightweight BarExecutor
- extend service_backtest with a bar-mode bridge that accumulates per-bar equity without an ExecutionSimulator
- synthesize trades and equity data in service_eval when fills are absent so metrics still compute

## Testing
- python -m compileall di_registry.py sandbox/backtest_adapter.py service_backtest.py service_eval.py

------
https://chatgpt.com/codex/tasks/task_e_68d98698c0e4832f905769310a6bbc3f