### PR TITLE
Add portfolio weight cap normalisation and tests

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -433,6 +433,15 @@ class PortfolioConfig(BaseModel):
         ge=0.0,
         description="Capital base in USD; ``None`` leaves it unspecified (legacy behaviour).",
     )
+    max_total_weight: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Optional cap on the sum of absolute portfolio weights submitted in a single bar "
+            "run. When the requested targets exceed the cap the runner will scale them "
+            "pro-rata. ``None`` disables the guard."
+        ),
+    )
 
     class Config:
         extra = "allow"

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -1,11 +1,14 @@
+import logging
 from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from core_config import SpotCostConfig, SpotImpactConfig
 from core_models import Bar, Order, OrderType, Side
-
 from impl_bar_executor import BarExecutor, PortfolioState, decide_spot_trade
+from service_signal_runner import _Worker
 
 
 def make_bar(ts: int, price: float) -> Bar:
@@ -205,4 +208,120 @@ def test_bar_executor_skips_when_edge_insufficient():
     assert report.meta["instructions"] == []
     assert report.meta["decision"]["act_now"] is False
     assert executor.get_open_positions()["BTCUSDT"].meta["weight"] == 0.0
+
+
+def _make_worker(max_total_weight: float | None, *, existing_weights: dict[str, float] | None = None) -> _Worker:
+    class DummyFeaturePipe:
+        def __init__(self) -> None:
+            self.spread_ttl_ms = 0
+            self._spread_ttl_ms = 0
+            self.signal_quality: dict[str, Any] = {}
+            self.metrics = SimpleNamespace(reset_symbol=lambda *_: None)
+
+    class DummyPolicy:
+        def consume_signal_transitions(self):  # pragma: no cover - simple stub
+            return []
+
+    fp = DummyFeaturePipe()
+    policy = DummyPolicy()
+    logger = logging.getLogger("test_worker_normalization")
+    executor = SimpleNamespace()
+    worker = _Worker(
+        fp,
+        policy,
+        logger,
+        executor,
+        None,
+        enforce_closed_bars=True,
+        close_lag_ms=0,
+        ws_dedup_enabled=False,
+        ws_dedup_log_skips=False,
+        ws_dedup_timeframe_ms=0,
+        throttle_cfg=None,
+        no_trade_cfg=None,
+        pipeline_cfg=None,
+        signal_quality_cfg=None,
+        zero_signal_alert=0,
+        state_enabled=False,
+        rest_candidates=None,
+        monitoring=None,
+        monitoring_agg=None,
+        worker_id="worker-test",
+        status_callback=None,
+        execution_mode="bar",
+        portfolio_equity=1_000.0,
+        max_total_weight=max_total_weight,
+    )
+    worker._weights = dict(existing_weights or {})
+    return worker
+
+
+def test_worker_normalizes_weights_above_cap():
+    worker = _make_worker(1.0, existing_weights={"ETHUSDT": 0.4})
+    order1 = Order(
+        ts=1,
+        symbol="BTCUSDT",
+        side=Side.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("0"),
+        price=None,
+        meta={"payload": {"target_weight": 0.7, "edge_bps": 10.0}},
+    )
+    order2 = Order(
+        ts=1,
+        symbol="LTCUSDT",
+        side=Side.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("0"),
+        price=None,
+        meta={"payload": {"target_weight": 0.7, "edge_bps": 12.0}},
+    )
+    normalized_orders, applied = worker._normalize_weight_targets([order1, order2])
+    assert applied is True
+    payloads = [o.meta["payload"] for o in normalized_orders]
+    assert sum(p["target_weight"] for p in payloads) == pytest.approx(0.6)
+    for payload, order in zip(payloads, normalized_orders):
+        assert payload["normalized"] is True
+        assert order.meta["normalized"] is True
+        assert payload["delta_weight"] == pytest.approx(payload["target_weight"])
+        assert payload["target_weight"] == pytest.approx(0.3)
+        assert payload.get("normalization")
+        assert payload["normalization"]["factor"] == pytest.approx(0.6 / 1.4)
+
+
+def test_bar_executor_propagates_normalized_flag():
+    executor = BarExecutor(
+        run_id="test",
+        bar_price="close",
+        cost_config=SpotCostConfig(),
+        default_equity_usd=1000.0,
+    )
+    order = Order(
+        ts=5,
+        symbol="BTCUSDT",
+        side=Side.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("0"),
+        price=None,
+        meta={
+            "bar": make_bar(5, 10000.0),
+            "normalized": True,
+            "payload": {
+                "target_weight": 0.8,
+                "edge_bps": 25.0,
+                "normalized": True,
+                "normalization": {"factor": 0.75},
+            },
+        },
+    )
+    report = executor.execute(order)
+    assert report.meta["normalized"] is True
+    assert report.meta["decision"]["normalized"] is True
+    assert report.meta["decision"]["normalization"] == {"factor": 0.75}
+    instructions = report.meta["instructions"]
+    assert len(instructions) == 1
+    assert instructions[0]["target_weight"] == pytest.approx(0.8)
+    snapshot = executor.monitoring_snapshot()
+    assert snapshot["normalized"] is True
+    assert snapshot["decision"]["normalized"] is True
 


### PR DESCRIPTION
## Summary
- add an optional `max_total_weight` portfolio setting to cap aggregate bar weights
- scale bar-mode targets when the cap is exceeded, annotate payloads as normalised, and log the adjustment
- propagate the normalised flag through the bar executor snapshot/metrics and cover the path with unit tests

## Testing
- pytest tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68d9af98ee40832fa85d71e92a75baa0