### PR TITLE
Handle signal valid-until expiry

### DIFF
--- a/services/signal_bus.py
+++ b/services/signal_bus.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from typing import Any, Callable, Dict
 from dataclasses import dataclass
 from collections import defaultdict
+from collections.abc import Mapping
+from datetime import datetime, timezone
+import math
 import os
 
 from api.spot_signals import SpotSignalEnvelope, build_envelope, sign_envelope
@@ -195,6 +198,111 @@ def log_drop(envelope: SpotSignalEnvelope, reason: str) -> None:
         pass
 
 
+def _coerce_timestamp_ms(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif hasattr(value, "to_pydatetime"):
+        try:
+            dt = value.to_pydatetime()
+        except Exception:
+            dt = None
+        if not isinstance(dt, datetime):
+            dt = None
+    else:
+        dt = None
+    if dt is not None:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return int(round(dt.timestamp() * 1000.0))
+    if isinstance(value, (int, float)):
+        if isinstance(value, bool):
+            return None
+        if not math.isfinite(float(value)):
+            return None
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return int(text)
+        except ValueError:
+            try:
+                return int(float(text))
+            except ValueError:
+                normalized = text
+                if text.endswith("Z") or text.endswith("z"):
+                    normalized = text[:-1] + "+00:00"
+                try:
+                    dt = datetime.fromisoformat(normalized)
+                except ValueError:
+                    return None
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                else:
+                    dt = dt.astimezone(timezone.utc)
+                return int(round(dt.timestamp() * 1000.0))
+    timestamp = getattr(value, "timestamp", None)
+    if callable(timestamp):
+        try:
+            ts = float(timestamp())
+        except Exception:
+            return None
+        if not math.isfinite(ts):
+            return None
+        return int(round(ts * 1000.0))
+    return None
+
+
+def _extract_valid_until_ms(payload: Any, provided: Any = None) -> int | None:
+    ms = _coerce_timestamp_ms(provided)
+    if ms is not None:
+        return ms
+
+    def _from_mapping(mapping: Mapping[str, Any]) -> int | None:
+        for key in ("valid_until_ms", "valid_until"):
+            if key not in mapping:
+                continue
+            candidate = _coerce_timestamp_ms(mapping.get(key))
+            if candidate is not None:
+                return candidate
+        return None
+
+    if isinstance(payload, Mapping):
+        mapped = _from_mapping(payload)
+        if mapped is not None:
+            return mapped
+
+    for accessor in ("model_dump", "dict"):
+        getter = getattr(payload, accessor, None)
+        if not callable(getter):
+            continue
+        try:
+            data = getter()
+        except Exception:
+            continue
+        if isinstance(data, Mapping):
+            mapped = _from_mapping(data)
+            if mapped is not None:
+                return mapped
+
+    for attr in ("valid_until_ms", "valid_until"):
+        if not hasattr(payload, attr):
+            continue
+        try:
+            value = getattr(payload, attr)
+        except Exception:
+            continue
+        candidate = _coerce_timestamp_ms(value)
+        if candidate is not None:
+            return candidate
+    return None
+
+
 def publish_signal(
     symbol: str,
     bar_close_ms: int,
@@ -204,6 +312,7 @@ def publish_signal(
     expires_at_ms: int,
     now_ms: int | None = None,
     dedup_key: str | None = None,
+    valid_until_ms: int | None = None,
 ) -> bool:
     """Опубликовать сигнал, если он ещё не публиковался и не истёк TTL.
 
@@ -212,6 +321,10 @@ def publish_signal(
     dedup_key:
         Optional explicit deduplication key.  If provided, it overrides
         :func:`signal_id`.
+    valid_until_ms:
+        Optional signal validity horizon. When provided (or embedded in the
+        payload) signals past this timestamp are rejected with a dedicated
+        metric even if ``expires_at_ms`` is still in the future.
 
     Возвращает ``True``, если сигнал был отправлен, иначе ``False``.
     """
@@ -220,6 +333,7 @@ def publish_signal(
     expires_at_ms_int = int(expires_at_ms)
 
     envelope_cache: SpotSignalEnvelope | None = None
+    valid_until_ms_int = _extract_valid_until_ms(payload, valid_until_ms)
 
     def _envelope() -> SpotSignalEnvelope:
         nonlocal envelope_cache
@@ -239,6 +353,11 @@ def publish_signal(
     _ensure_loaded()
     sid = dedup_key or signal_id(symbol, bar_close_ms_int)
     now = now_ms if now_ms is not None else utils_time.now_ms()
+    if valid_until_ms_int is not None and now >= valid_until_ms_int:
+        log_drop(_envelope(), "valid_until_expired")
+        return False
+    if valid_until_ms_int is not None:
+        expires_at_ms_int = min(expires_at_ms_int, valid_until_ms_int)
     if now >= expires_at_ms_int:
         log_drop(_envelope(), "expired")
         return False

--- a/tests/test_service_signal_runner_payload.py
+++ b/tests/test_service_signal_runner_payload.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from service_signal_runner import _Worker
+
+
+def _make_worker() -> _Worker:
+    worker = _Worker.__new__(_Worker)
+    worker._weights = {}
+    return worker
+
+
+def test_build_envelope_payload_captures_valid_until_from_meta():
+    worker = _make_worker()
+    valid_until_iso = "2024-01-01T00:00:01Z"
+    order_payload = {"target_weight": 0.2}
+    order = SimpleNamespace(meta={"payload": order_payload, "valid_until": valid_until_iso})
+
+    payload, valid_until_ms = worker._build_envelope_payload(order, "BTCUSDT")
+
+    expected = int(datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    assert payload["valid_until_ms"] == expected
+    assert valid_until_ms == expected
+    assert payload["kind"] == "target_weight"
+    assert payload["target_weight"] == 0.2


### PR DESCRIPTION
## Summary
- propagate valid_until metadata from the signal runner into signal envelopes and constrain dedup expirations
- reject envelopes on the signal bus when valid_until has elapsed and log the dedicated drop reason
- add unit tests covering valid_until extraction and bus-side expiry handling

## Testing
- pytest tests/test_signal_bus.py::test_publish_signal_rejects_expired_valid_until tests/test_service_signal_runner_payload.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b8f8b098832f8b32f3c14897c08e