### PR TITLE
Add quote asset guard during runner initialisation

### DIFF
--- a/core_config.py
+++ b/core_config.py
@@ -747,6 +747,14 @@ class CommonRunConfig(BaseModel):
         description="Forward market regime updates to the slippage component for calibrated overrides.",
     )
     components: Components
+    symbol_specs_path: Optional[str] = Field(
+        default=None,
+        description="Optional path to symbol metadata containing quote assets.",
+    )
+    symbol_specs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Inline symbol metadata mapping keyed by symbol.",
+    )
 
     @model_validator(mode="after")
     def _sync_runtime_sections(cls, values: "CommonRunConfig") -> "CommonRunConfig":

--- a/tests/test_service_signal_runner_mixed_quote.py
+++ b/tests/test_service_signal_runner_mixed_quote.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import service_signal_runner
+from service_signal_runner import MixedQuoteError
+
+
+def test_service_signal_runner_rejects_mixed_quote(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    logs_dir = tmp_path / "logs"
+    artifacts_dir = tmp_path / "artifacts"
+    logs_dir.mkdir()
+    artifacts_dir.mkdir()
+
+    run_config = SimpleNamespace(
+        symbols=["BTCUSDT", "ETHBTC"],
+        data=SimpleNamespace(symbols=["BTCUSDT", "ETHBTC"]),
+        symbol_specs={
+            "BTCUSDT": {"quote_asset": "USDT"},
+            "ETHBTC": {"quote_asset": "BTC"},
+        },
+        execution=SimpleNamespace(mode="order"),
+        slippage_regime_updates=False,
+        slippage_calibration_enabled=False,
+        portfolio=None,
+        components=SimpleNamespace(),
+    )
+
+    cfg = service_signal_runner.SignalRunnerConfig(
+        logs_dir=str(logs_dir),
+        artifacts_dir=str(artifacts_dir),
+    )
+
+    caplog.set_level("INFO")
+
+    with pytest.raises(MixedQuoteError):
+        service_signal_runner.ServiceSignalRunner(
+            adapter=SimpleNamespace(),
+            feature_pipe=SimpleNamespace(),
+            policy=SimpleNamespace(),
+            risk_guards=None,
+            cfg=cfg,
+            monitoring_cfg=None,
+            monitoring_agg=None,
+            run_config=run_config,
+        )
+
+    status_path = logs_dir / "runner_status.json"
+    assert status_path.exists()
+    status_payload = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status_payload["init"]["reason"] == "mixed_quote"
+    assert status_payload["init"]["quotes"] == {"BTCUSDT": "USDT", "ETHBTC": "BTC"}
+    assert "mixed_quote" in caplog.text


### PR DESCRIPTION
## Summary
- allow CommonRunConfig to accept inline symbol metadata or a path to symbol specs
- load symbol quote metadata during ServiceSignalRunner initialisation, aborting with MixedQuoteError when quotes differ and surfacing the state in runner status
- add a regression test covering the mixed-quote guard behaviour

## Testing
- pytest tests/test_service_signal_runner_mixed_quote.py

------
https://chatgpt.com/codex/tasks/task_e_68da47332fa4832f9ff4b54768bbab8b