### PR TITLE
Integrate symbol metadata into bar executor rounding

### DIFF
--- a/data/symbol_specs.json
+++ b/data/symbol_specs.json
@@ -1,0 +1,20 @@
+{
+  "BTCUSDT": {
+    "quote_asset": "USDT",
+    "min_notional": 10.0,
+    "step_size": 0.0001,
+    "tick_size": 0.01
+  },
+  "ETHUSDT": {
+    "quote_asset": "USDT",
+    "min_notional": 10.0,
+    "step_size": 0.0001,
+    "tick_size": 0.01
+  },
+  "ETHBTC": {
+    "quote_asset": "BTC",
+    "min_notional": 0.0005,
+    "step_size": 0.0001,
+    "tick_size": 0.000001
+  }
+}


### PR DESCRIPTION
## Summary
- add a default `data/symbol_specs.json` with min-notional, step size, and tick size metadata
- load symbol specs in `ServiceSignalRunner` and pass them through to the bar executor
- round bar-executor instructions to exchange increments, block below-min notionals, and surface requested vs. executed weights

## Testing
- pytest tests/test_bar_executor.py tests/test_service_signal_runner_mixed_quote.py

------
https://chatgpt.com/codex/tasks/task_e_68da4bdf95e8832f8b0efb7d5c2fc71d