### PR TITLE
Document daily turnover cap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   `rounding` умеет использовать `commission_step` из биржевых фильтров и
   таблиц комиссий, а `settlement` описывает расчёт комиссий в альтернативном
   активе (например, BNB) с учётом скидок.
+- **Daily turnover caps**: Added configuration fields, runtime enforcement, and
+  monitoring visibility for daily USD/BPS turnover limits across per-symbol and
+  portfolio aggregates. Includes persistence hooks and targeted pytest coverage
+  ensuring partial/deferred execution when caps bind.
 
 ### Deprecated
 - `LatencyImpl.dump_latency_multipliers` and

--- a/script_backtest.py
+++ b/script_backtest.py
@@ -82,6 +82,10 @@ def _apply_runtime_overrides(
             args.costs_turnover_cap_symbol_usd,
             args.costs_turnover_cap_portfolio_bps,
             args.costs_turnover_cap_portfolio_usd,
+            args.costs_turnover_cap_symbol_daily_bps,
+            args.costs_turnover_cap_symbol_daily_usd,
+            args.costs_turnover_cap_portfolio_daily_bps,
+            args.costs_turnover_cap_portfolio_daily_usd,
         )
     ):
         costs_block = dict(cfg_dict.get("costs") or {})
@@ -129,6 +133,20 @@ def _apply_runtime_overrides(
             )
             exec_symbol_caps_block["usd"] = symbol_caps_block["usd"]
 
+        if args.costs_turnover_cap_symbol_daily_bps is not None:
+            symbol_caps_block["daily_bps"] = _require_non_negative(
+                args.costs_turnover_cap_symbol_daily_bps,
+                "costs-turnover-cap-symbol-daily-bps",
+            )
+            exec_symbol_caps_block["daily_bps"] = symbol_caps_block["daily_bps"]
+
+        if args.costs_turnover_cap_symbol_daily_usd is not None:
+            symbol_caps_block["daily_usd"] = _require_non_negative(
+                args.costs_turnover_cap_symbol_daily_usd,
+                "costs-turnover-cap-symbol-daily-usd",
+            )
+            exec_symbol_caps_block["daily_usd"] = symbol_caps_block["daily_usd"]
+
         if args.costs_turnover_cap_portfolio_bps is not None:
             portfolio_caps_block["bps"] = _require_non_negative(
                 args.costs_turnover_cap_portfolio_bps,
@@ -142,6 +160,20 @@ def _apply_runtime_overrides(
                 "costs-turnover-cap-portfolio-usd",
             )
             exec_portfolio_caps_block["usd"] = portfolio_caps_block["usd"]
+
+        if args.costs_turnover_cap_portfolio_daily_bps is not None:
+            portfolio_caps_block["daily_bps"] = _require_non_negative(
+                args.costs_turnover_cap_portfolio_daily_bps,
+                "costs-turnover-cap-portfolio-daily-bps",
+            )
+            exec_portfolio_caps_block["daily_bps"] = portfolio_caps_block["daily_bps"]
+
+        if args.costs_turnover_cap_portfolio_daily_usd is not None:
+            portfolio_caps_block["daily_usd"] = _require_non_negative(
+                args.costs_turnover_cap_portfolio_daily_usd,
+                "costs-turnover-cap-portfolio-daily-usd",
+            )
+            exec_portfolio_caps_block["daily_usd"] = portfolio_caps_block["daily_usd"]
 
         if impact_block:
             costs_block["impact"] = impact_block
@@ -281,6 +313,16 @@ def main() -> None:
         help="Override costs.turnover_caps.per_symbol.usd (>=0)",
     )
     runtime_group.add_argument(
+        "--costs-turnover-cap-symbol-daily-bps",
+        type=float,
+        help="Override costs.turnover_caps.per_symbol.daily_bps (>=0)",
+    )
+    runtime_group.add_argument(
+        "--costs-turnover-cap-symbol-daily-usd",
+        type=float,
+        help="Override costs.turnover_caps.per_symbol.daily_usd (>=0)",
+    )
+    runtime_group.add_argument(
         "--costs-turnover-cap-portfolio-bps",
         type=float,
         help="Override costs.turnover_caps.portfolio.bps (>=0)",
@@ -289,6 +331,16 @@ def main() -> None:
         "--costs-turnover-cap-portfolio-usd",
         type=float,
         help="Override costs.turnover_caps.portfolio.usd (>=0)",
+    )
+    runtime_group.add_argument(
+        "--costs-turnover-cap-portfolio-daily-bps",
+        type=float,
+        help="Override costs.turnover_caps.portfolio.daily_bps (>=0)",
+    )
+    runtime_group.add_argument(
+        "--costs-turnover-cap-portfolio-daily-usd",
+        type=float,
+        help="Override costs.turnover_caps.portfolio.daily_usd (>=0)",
     )
     args = p.parse_args()
 

--- a/script_live.py
+++ b/script_live.py
@@ -89,6 +89,10 @@ def _apply_runtime_overrides(
             args.costs_turnover_cap_symbol_usd,
             args.costs_turnover_cap_portfolio_bps,
             args.costs_turnover_cap_portfolio_usd,
+            args.costs_turnover_cap_symbol_daily_bps,
+            args.costs_turnover_cap_symbol_daily_usd,
+            args.costs_turnover_cap_portfolio_daily_bps,
+            args.costs_turnover_cap_portfolio_daily_usd,
         )
     ):
         costs_block = dict(cfg_dict.get("costs") or {})
@@ -136,6 +140,20 @@ def _apply_runtime_overrides(
             )
             exec_symbol_caps_block["usd"] = symbol_caps_block["usd"]
 
+        if args.costs_turnover_cap_symbol_daily_bps is not None:
+            symbol_caps_block["daily_bps"] = _require_non_negative(
+                args.costs_turnover_cap_symbol_daily_bps,
+                "costs-turnover-cap-symbol-daily-bps",
+            )
+            exec_symbol_caps_block["daily_bps"] = symbol_caps_block["daily_bps"]
+
+        if args.costs_turnover_cap_symbol_daily_usd is not None:
+            symbol_caps_block["daily_usd"] = _require_non_negative(
+                args.costs_turnover_cap_symbol_daily_usd,
+                "costs-turnover-cap-symbol-daily-usd",
+            )
+            exec_symbol_caps_block["daily_usd"] = symbol_caps_block["daily_usd"]
+
         if args.costs_turnover_cap_portfolio_bps is not None:
             portfolio_caps_block["bps"] = _require_non_negative(
                 args.costs_turnover_cap_portfolio_bps,
@@ -149,6 +167,20 @@ def _apply_runtime_overrides(
                 "costs-turnover-cap-portfolio-usd",
             )
             exec_portfolio_caps_block["usd"] = portfolio_caps_block["usd"]
+
+        if args.costs_turnover_cap_portfolio_daily_bps is not None:
+            portfolio_caps_block["daily_bps"] = _require_non_negative(
+                args.costs_turnover_cap_portfolio_daily_bps,
+                "costs-turnover-cap-portfolio-daily-bps",
+            )
+            exec_portfolio_caps_block["daily_bps"] = portfolio_caps_block["daily_bps"]
+
+        if args.costs_turnover_cap_portfolio_daily_usd is not None:
+            portfolio_caps_block["daily_usd"] = _require_non_negative(
+                args.costs_turnover_cap_portfolio_daily_usd,
+                "costs-turnover-cap-portfolio-daily-usd",
+            )
+            exec_portfolio_caps_block["daily_usd"] = portfolio_caps_block["daily_usd"]
 
         if impact_block:
             costs_block["impact"] = impact_block
@@ -342,6 +374,16 @@ def main() -> None:
         help="Override costs.turnover_caps.per_symbol.usd (>=0)",
     )
     runtime_group.add_argument(
+        "--costs-turnover-cap-symbol-daily-bps",
+        type=float,
+        help="Override costs.turnover_caps.per_symbol.daily_bps (>=0)",
+    )
+    runtime_group.add_argument(
+        "--costs-turnover-cap-symbol-daily-usd",
+        type=float,
+        help="Override costs.turnover_caps.per_symbol.daily_usd (>=0)",
+    )
+    runtime_group.add_argument(
         "--costs-turnover-cap-portfolio-bps",
         type=float,
         help="Override costs.turnover_caps.portfolio.bps (>=0)",
@@ -350,6 +392,16 @@ def main() -> None:
         "--costs-turnover-cap-portfolio-usd",
         type=float,
         help="Override costs.turnover_caps.portfolio.usd (>=0)",
+    )
+    runtime_group.add_argument(
+        "--costs-turnover-cap-portfolio-daily-bps",
+        type=float,
+        help="Override costs.turnover_caps.portfolio.daily_bps (>=0)",
+    )
+    runtime_group.add_argument(
+        "--costs-turnover-cap-portfolio-daily-usd",
+        type=float,
+        help="Override costs.turnover_caps.portfolio.daily_usd (>=0)",
     )
     p.add_argument(
         "--runtime-trade-config",

--- a/tests/test_common_run_config_sections.py
+++ b/tests/test_common_run_config_sections.py
@@ -112,8 +112,10 @@ def test_execution_runtime_config_serializes_new_fields():
             turnover_caps:
               per_symbol:
                 bps: 250
+                daily_usd: 2000.0
               portfolio:
                 usd: 50000.0
+                daily_bps: 150
         """
     )
     cfg = load_config_from_str(yaml_cfg)
@@ -124,15 +126,19 @@ def test_execution_runtime_config_serializes_new_fields():
     caps = cfg.execution.costs.turnover_caps
     assert caps.per_symbol is not None
     assert caps.per_symbol.bps == 250
+    assert caps.per_symbol.daily_usd == pytest.approx(2000.0)
     assert caps.portfolio is not None
     assert caps.portfolio.usd == 50_000.0
+    assert caps.portfolio.daily_bps == pytest.approx(150.0)
 
     dumped = cfg.execution.dict()
     assert dumped["safety_margin_bps"] == 7.5
     assert pytest.approx(dumped["max_participation"], rel=1e-9) == 0.05
     turnover_caps = dumped["costs"]["turnover_caps"]
     assert turnover_caps["per_symbol"]["bps"] == 250
+    assert turnover_caps["per_symbol"]["daily_usd"] == 2000.0
     assert turnover_caps["portfolio"]["usd"] == 50_000.0
+    assert turnover_caps["portfolio"]["daily_bps"] == 150
 
 
 @pytest.mark.parametrize("cli_equity", [None, 2_500_000.0])
@@ -169,6 +175,10 @@ def test_runtime_trade_defaults_precedence(tmp_path, cli_equity):
         costs_turnover_cap_symbol_usd=None,
         costs_turnover_cap_portfolio_bps=None,
         costs_turnover_cap_portfolio_usd=None,
+        costs_turnover_cap_symbol_daily_bps=None,
+        costs_turnover_cap_symbol_daily_usd=None,
+        costs_turnover_cap_portfolio_daily_bps=None,
+        costs_turnover_cap_portfolio_daily_usd=None,
     )
 
     merged = _apply_runtime_overrides(cfg_dict, args)

--- a/tests/test_daily_turnover_limits.py
+++ b/tests/test_daily_turnover_limits.py
@@ -1,0 +1,96 @@
+import logging
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from core_config import SpotTurnoverCaps, SpotTurnoverLimit
+from core_models import Order, OrderType, Side
+from service_signal_runner import _Worker
+
+
+def _make_worker_with_daily_cap(limit_usd: float) -> _Worker:
+    class DummyFeaturePipe:
+        def __init__(self) -> None:
+            self.spread_ttl_ms = 0
+            self._spread_ttl_ms = 0
+            self.signal_quality = {}
+            self.metrics = SimpleNamespace(reset_symbol=lambda *_: None)
+
+    class DummyPolicy:
+        def consume_signal_transitions(self):  # pragma: no cover - stub
+            return []
+
+    turnover_caps = SpotTurnoverCaps(
+        per_symbol=SpotTurnoverLimit(daily_usd=limit_usd),
+        portfolio=SpotTurnoverLimit(daily_usd=limit_usd),
+    )
+    executor = SimpleNamespace(turnover_caps=turnover_caps)
+    worker = _Worker(
+        DummyFeaturePipe(),
+        DummyPolicy(),
+        logging.getLogger("test_daily_turnover"),
+        executor,
+        None,
+        enforce_closed_bars=True,
+        close_lag_ms=0,
+        ws_dedup_enabled=False,
+        ws_dedup_log_skips=False,
+        ws_dedup_timeframe_ms=0,
+        throttle_cfg=None,
+        no_trade_cfg=None,
+        pipeline_cfg=None,
+        signal_quality_cfg=None,
+        zero_signal_alert=0,
+        state_enabled=False,
+        rest_candidates=None,
+        monitoring=None,
+        monitoring_agg=None,
+        worker_id="worker-test",
+        status_callback=None,
+        execution_mode="bar",
+        portfolio_equity=1_000.0,
+        max_total_weight=None,
+    )
+    return worker
+
+
+def _make_order(symbol: str, target_weight: float, turnover_usd: float) -> Order:
+    return Order(
+        ts=0,
+        symbol=symbol,
+        side=Side.BUY,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("0"),
+        price=None,
+        meta={
+            "payload": {"target_weight": target_weight},
+            "decision": {"turnover_usd": turnover_usd},
+        },
+    )
+
+
+def test_daily_turnover_cap_clamps_and_defers() -> None:
+    worker = _make_worker_with_daily_cap(500.0)
+
+    first = _make_order("BTCUSDT", 0.4, 400.0)
+    adjusted_first = worker._apply_daily_turnover_limits([first], "BTCUSDT", 1)
+    assert len(adjusted_first) == 1
+    assert adjusted_first[0].meta.get("_daily_turnover_usd") == pytest.approx(400.0)
+    worker._commit_exposure(adjusted_first[0])
+    assert worker._daily_symbol_turnover["BTCUSDT"]["total"] == pytest.approx(400.0)
+
+    second = _make_order("BTCUSDT", 0.9, 500.0)
+    adjusted_second = worker._apply_daily_turnover_limits([second], "BTCUSDT", 1)
+    assert len(adjusted_second) == 1
+    payload = adjusted_second[0].meta["payload"]
+    assert payload["target_weight"] == pytest.approx(0.5)
+    assert adjusted_second[0].meta.get("_daily_turnover_usd") == pytest.approx(100.0)
+    worker._commit_exposure(adjusted_second[0])
+    assert worker._daily_symbol_turnover["BTCUSDT"]["total"] == pytest.approx(500.0)
+
+    third = _make_order("BTCUSDT", 0.6, 100.0)
+    adjusted_third = worker._apply_daily_turnover_limits([third], "BTCUSDT", 1)
+    assert adjusted_third == []
+    snapshot = worker._daily_turnover_snapshot()
+    assert snapshot["portfolio"]["remaining_usd"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- document the new daily turnover cap enforcement in the changelog so operators can see the feature in release notes

## Testing
- pytest tests/test_daily_turnover_limits.py

------
https://chatgpt.com/codex/tasks/task_e_68da63807740832f9a80526e64e704ff