### PR TITLE
Add per-symbol cooldown handling for bar adjustments

### DIFF
--- a/tests/test_service_signal_runner_payload.py
+++ b/tests/test_service_signal_runner_payload.py
@@ -1,16 +1,19 @@
-import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
+import logging
 
 import pytest
 
-from service_signal_runner import _Worker
+from service_signal_runner import _Worker, CooldownSettings
 
 
 def _make_worker() -> _Worker:
     worker = _Worker.__new__(_Worker)
     worker._weights = {}
     worker._logger = logging.getLogger("test_worker")
+    worker._cooldown_settings = CooldownSettings()
+    worker._symbol_cooldowns = {}
+    worker._symbol_cooldown_set_ts = {}
     return worker
 
 

--- a/tests/test_worker_cooldown.py
+++ b/tests/test_worker_cooldown.py
@@ -1,0 +1,78 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from service_signal_runner import _Worker
+
+
+def _make_bar_worker() -> _Worker:
+    worker = _Worker(
+        fp=SimpleNamespace(),
+        policy=SimpleNamespace(),
+        logger=logging.getLogger("test_cooldown"),
+        executor=SimpleNamespace(),
+        guards=None,
+        enforce_closed_bars=True,
+        throttle_cfg=None,
+        execution_mode="bar",
+        cooldown_settings={
+            "cooldown_bars": 2,
+            "turnover_cap": 0.4,
+            "cooldown_small_delta": 0.05,
+        },
+    )
+    emissions: list[tuple[str, int]] = []
+
+    def _emit(order: object, symbol: str, bar_ts: int) -> bool:
+        emissions.append((symbol, bar_ts))
+        return True
+
+    worker._emit = _emit  # type: ignore[method-assign]
+    worker._last_bar_ts["BTCUSDT"] = 1
+    return worker, emissions
+
+
+def _make_order(symbol: str, target: float) -> SimpleNamespace:
+    return SimpleNamespace(symbol=symbol, meta={"payload": {"target_weight": target}})
+
+
+def test_small_deltas_suppressed_during_cooldown() -> None:
+    worker, emissions = _make_bar_worker()
+    symbol = "BTCUSDT"
+
+    big_order = _make_order(symbol, 0.5)
+    result = worker.publish_decision(big_order, symbol, 1)
+    assert result.action == "pass"
+    assert worker._weights[symbol] == pytest.approx(0.5)
+    assert worker._symbol_cooldowns[symbol] == 2
+
+    worker._update_queue_metrics()
+    status = worker._last_status_payload
+    assert status["symbol_cooldowns"]["remaining"][symbol] == 2
+
+    small_order = _make_order(symbol, 0.52)
+    res = worker.publish_decision(small_order, symbol, 2)
+    assert res.action == "drop"
+    assert worker._weights[symbol] == pytest.approx(0.5)
+    worker._advance_symbol_cooldown(symbol, 2, new_bar=True)
+    worker._last_bar_ts[symbol] = 2
+
+    smaller_order = _make_order(symbol, 0.51)
+    res = worker.publish_decision(smaller_order, symbol, 3)
+    assert res.action == "drop"
+    worker._advance_symbol_cooldown(symbol, 3, new_bar=True)
+    worker._last_bar_ts[symbol] = 3
+    assert symbol not in worker._symbol_cooldowns
+
+    worker._update_queue_metrics()
+    post_status = worker._last_status_payload
+    assert post_status.get("symbol_cooldowns", {}).get("count", 0) == 0
+
+    final_order = _make_order(symbol, 0.52)
+    res = worker.publish_decision(final_order, symbol, 4)
+    assert res.action == "pass"
+    assert worker._weights[symbol] == pytest.approx(0.52)
+
+    # Only the initial large trade and the final adjustment should emit
+    assert emissions == [(symbol, 1), (symbol, 4)]


### PR DESCRIPTION
## Summary
- add a `CooldownSettings` helper and track per-symbol cooldown state in the signal worker
- suppress small delta bar adjustments while cooldown is active and expose cooldown telemetry/logs
- parse risk component cooldown params when wiring the service and add targeted tests

## Testing
- pytest tests/test_worker_cooldown.py tests/test_service_signal_runner_payload.py

------
https://chatgpt.com/codex/tasks/task_e_68da6c960efc832fb961cd0bb5bbb327