### PR TITLE
Add cost bias monitoring and realized slippage aggregation

### DIFF
--- a/configs/monitoring.yaml
+++ b/configs/monitoring.yaml
@@ -9,6 +9,7 @@ thresholds:
   fill_ratio_min: 0.0         # alert if order fill ratio drops below this; 0 disables
   pnl_min: 0.0                # alert if daily PnL drops below this; 0 disables
   zero_signals: 0             # alert after N consecutive zero-signal bars; 0 disables
+  cost_bias_bps: 0.0          # alert if |cost bias| (bps) over recent bars exceeds this; 0 disables
 alerts:
   enabled: false              # disable external alerting
   command: null               # command to execute when alerts trigger

--- a/core_config.py
+++ b/core_config.py
@@ -298,6 +298,7 @@ class MonitoringThresholdsConfig:
     fill_ratio_min: float = 0.0
     pnl_min: float = 0.0
     zero_signals: int = 0
+    cost_bias_bps: float = 0.0
 
 
 @dataclass

--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -1300,6 +1300,44 @@ class _Worker:
             metrics["impact_mode"] = impact_mode
         if reason_label:
             metrics["reason"] = reason_label
+        cost_estimate = self._coerce_float(
+            self._find_in_mapping(
+                decision,
+                ("modeled_cost_bps", "cost_bps", "expected_cost_bps"),
+            )
+        )
+        if cost_estimate is None and snapshot is not None:
+            cost_estimate = self._coerce_float(
+                self._find_in_mapping(snapshot, ("modeled_cost_bps", "cost_bps"))
+            )
+        realized_cost = self._coerce_float(
+            self._find_in_mapping(
+                decision,
+                ("realized_slippage_bps", "realized_cost_bps"),
+            )
+        )
+        if realized_cost is None and snapshot is not None:
+            realized_cost = self._coerce_float(
+                self._find_in_mapping(
+                    snapshot,
+                    ("realized_slippage_bps", "realized_cost_bps"),
+                )
+            )
+        bias_val = self._coerce_float(
+            self._find_in_mapping(decision, ("cost_bias_bps",))
+        )
+        if bias_val is None and snapshot is not None:
+            bias_val = self._coerce_float(
+                self._find_in_mapping(snapshot, ("cost_bias_bps",))
+            )
+        if bias_val is None and realized_cost is not None and cost_estimate is not None:
+            bias_val = realized_cost - cost_estimate
+        if cost_estimate is not None:
+            metrics["modeled_cost_bps"] = cost_estimate
+        if realized_cost is not None:
+            metrics["realized_slippage_bps"] = realized_cost
+        if bias_val is not None:
+            metrics["cost_bias_bps"] = bias_val
         if normalization_details:
             metrics["normalization"] = normalization_details
         return metrics

--- a/tests/test_aggregate_exec_logs_bar_mode.py
+++ b/tests/test_aggregate_exec_logs_bar_mode.py
@@ -83,6 +83,11 @@ def test_aggregate_accepts_bar_mode_logs(tmp_path: Path) -> None:
     assert row["bar_cap_usd"] == pytest.approx(30_000.0)
     assert row["bar_act_now_rate"] == pytest.approx(0.5)
     assert row["bar_turnover_vs_cap"] == pytest.approx(800.0 / 30_000.0)
+    assert "realized_slippage_bps" in row.index
+    assert "modeled_cost_bps" in row.index
+    assert "cost_bias_bps" in row.index
+    assert pd.isna(row["realized_slippage_bps"])
+    assert pd.isna(row["modeled_cost_bps"])
 
     days = pd.read_csv(out_days)
     assert days.shape[0] == 1
@@ -92,3 +97,4 @@ def test_aggregate_accepts_bar_mode_logs(tmp_path: Path) -> None:
     assert day["bar_turnover_usd"] == pytest.approx(800.0)
     assert day["bar_cap_usd"] == pytest.approx(30_000.0)
     assert day["bar_turnover_vs_cap"] == pytest.approx(800.0 / 30_000.0)
+    assert "cost_bias_bps" in day.index

--- a/tests/test_aggregate_exec_logs_costs.py
+++ b/tests/test_aggregate_exec_logs_costs.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from aggregate_exec_logs import aggregate
+
+
+@pytest.mark.parametrize("bar_seconds", [60, 300])
+def test_aggregate_cost_metrics(tmp_path: Path, bar_seconds: int) -> None:
+    trades = pd.DataFrame(
+        [
+            {
+                "ts": 1_000,
+                "run_id": "order",
+                "symbol": "BTCUSDT",
+                "side": "BUY",
+                "order_type": "MARKET",
+                "price": 101.0,
+                "quantity": 1.0,
+                "fee": 0.0,
+                "fee_asset": "USDT",
+                "pnl": 0.0,
+                "exec_status": "FILLED",
+                "liquidity": "TAKER",
+                "client_order_id": "a",
+                "order_id": "1",
+                "execution_profile": "order",
+                "market_regime": "NORMAL",
+                "meta_json": json.dumps(
+                    {
+                        "reference_price": 100.0,
+                        "decision": {"cost_bps": 80.0},
+                    }
+                ),
+            },
+            {
+                "ts": 2_000,
+                "run_id": "order",
+                "symbol": "BTCUSDT",
+                "side": "SELL",
+                "order_type": "MARKET",
+                "price": 99.0,
+                "quantity": 2.0,
+                "fee": 0.0,
+                "fee_asset": "USDT",
+                "pnl": 0.0,
+                "exec_status": "FILLED",
+                "liquidity": "TAKER",
+                "client_order_id": "b",
+                "order_id": "2",
+                "execution_profile": "order",
+                "market_regime": "NORMAL",
+                "meta_json": json.dumps(
+                    {
+                        "reference_price": 100.0,
+                        "decision": {"cost_bps": 120.0},
+                    }
+                ),
+            },
+        ]
+    )
+    trades_path = tmp_path / "log_trades.csv"
+    trades.to_csv(trades_path, index=False)
+
+    out_bars = tmp_path / "bars.csv"
+    out_days = tmp_path / "days.csv"
+    metrics_md = tmp_path / "metrics.md"
+
+    aggregate(
+        str(trades_path),
+        "",
+        str(out_bars),
+        str(out_days),
+        bar_seconds=bar_seconds,
+        metrics_md=str(metrics_md),
+    )
+
+    bars = pd.read_csv(out_bars)
+    assert bars.shape[0] == 1
+    row = bars.iloc[0]
+    realized = row["realized_slippage_bps"]
+    modeled = row["modeled_cost_bps"]
+    bias = row["cost_bias_bps"]
+    assert realized == pytest.approx(100.0)
+    assert modeled == pytest.approx(320.0 / 3.0)
+    assert bias == pytest.approx(100.0 - 320.0 / 3.0)
+
+    days = pd.read_csv(out_days)
+    assert days.shape[0] == 1
+    day = days.iloc[0]
+    assert day["realized_slippage_bps"] == pytest.approx(realized)
+    assert day["modeled_cost_bps"] == pytest.approx(modeled)
+    assert day["cost_bias_bps"] == pytest.approx(bias)
+
+    md_text = metrics_md.read_text(encoding="utf-8")
+    assert "Execution Costs" in md_text
+    assert "realized_slippage_bps" in md_text
+    assert "modeled_cost_bps" in md_text

--- a/tests/test_monitoring_cost_bias.py
+++ b/tests/test_monitoring_cost_bias.py
@@ -1,0 +1,44 @@
+import time
+
+from services.monitoring import MonitoringAggregator
+from core_config import MonitoringConfig, MonitoringThresholdsConfig
+
+
+class DummyAlerts:
+    def __init__(self) -> None:
+        self.notifications: list[tuple[str, str]] = []
+
+    def notify(self, key: str, message: str) -> None:
+        self.notifications.append((key, message))
+
+
+def test_monitoring_cost_bias_alerts() -> None:
+    thresholds = MonitoringThresholdsConfig(cost_bias_bps=5.0)
+    cfg = MonitoringConfig(enabled=True, thresholds=thresholds)
+    alerts = DummyAlerts()
+    agg = MonitoringAggregator(cfg, alerts)
+
+    agg.set_execution_mode("bar")
+    agg.record_bar_execution(
+        "BTCUSDT",
+        decisions=1,
+        act_now=1,
+        turnover_usd=1_000.0,
+        modeled_cost_bps=90.0,
+        realized_slippage_bps=100.0,
+    )
+    agg.tick(int(time.time() * 1000))
+    assert any(key.startswith("cost_bias_") for key, _ in alerts.notifications)
+
+    alerts.notifications.clear()
+    agg.record_bar_execution(
+        "BTCUSDT",
+        decisions=1,
+        act_now=1,
+        turnover_usd=1_000.0,
+        modeled_cost_bps=100.0,
+        realized_slippage_bps=100.0,
+    )
+    agg.tick(int(time.time() * 1000))
+    assert not alerts.notifications
+    assert not agg._cost_bias_alerted


### PR DESCRIPTION
## Summary
- compute per-trade realized slippage, modeled cost, and derived cost bias in `aggregate_exec_logs` and persist the bar/day aggregates and Markdown summaries
- wire the new cost metrics through bar execution snapshots, expose a configurable `cost_bias_bps` threshold, and alert when recent bias exceeds it
- add focused tests covering the aggregation outputs and the monitoring alert path

## Testing
- `pytest tests/test_aggregate_exec_logs_costs.py tests/test_monitoring_cost_bias.py tests/test_aggregate_exec_logs_bar_mode.py`


------
https://chatgpt.com/codex/tasks/task_e_68daa2f50e10832fadbeb4a84222aeea