### PR TITLE
Ensure monitoring aggregator registers bar-mode workers

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -606,6 +606,10 @@ class _Worker:
         self._monitoring: MonitoringAggregator | None = (
             monitoring if monitoring is not None else monitoring_agg
         )
+        execution_mode_normalized = str(execution_mode or "order").lower()
+        if execution_mode_normalized not in {"order", "bar"}:
+            execution_mode_normalized = "order"
+        self._execution_mode = execution_mode_normalized
         try:
             cache_size = int(idempotency_cache_size)
         except (TypeError, ValueError):
@@ -624,7 +628,6 @@ class _Worker:
         self._symbol_bucket_factory = None
         self._symbol_buckets = None
         self._queue = None
-        self._execution_mode = str(execution_mode or "order").lower()
         try:
             self._portfolio_equity = (
                 float(portfolio_equity) if portfolio_equity is not None else None

--- a/tests/test_worker_monitoring_mode.py
+++ b/tests/test_worker_monitoring_mode.py
@@ -1,0 +1,36 @@
+import logging
+
+from core_config import MonitoringConfig
+from service_signal_runner import _Worker
+from services.monitoring import MonitoringAggregator
+
+
+class DummyAlerts:
+    def notify(self, key: str, message: str) -> None:  # pragma: no cover - test helper
+        pass
+
+
+class DummyFeaturePipe:
+    spread_ttl_ms = 0
+
+
+class DummyPolicy:
+    pass
+
+
+def test_worker_sets_monitoring_execution_mode_to_bar() -> None:
+    monitoring_cfg = MonitoringConfig(enabled=True)
+    aggregator = MonitoringAggregator(monitoring_cfg, DummyAlerts())
+
+    _Worker(
+        DummyFeaturePipe(),
+        DummyPolicy(),
+        logging.getLogger(__name__),
+        object(),
+        enforce_closed_bars=True,
+        monitoring=aggregator,
+        execution_mode="bar",
+    )
+
+    metrics = aggregator._build_metrics(0, {}, [])
+    assert metrics["execution_mode"] == "bar"


### PR DESCRIPTION
## Summary
- normalize the worker execution mode before registering it with monitoring
- add a regression test to ensure bar-mode workers update the monitoring aggregator

## Testing
- pytest tests/test_worker_monitoring_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68daea2a7358832f972471ca3e796eee