### PR TITLE
Reset turnover metrics when skipping bar executions

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -336,23 +336,30 @@ class BarExecutor(TradeExecutor):
 
         min_step = self.min_rebalance_step
         skip_due_to_step = False
+        raw_turnover_usd = float(getattr(metrics, "turnover_usd", 0.0))
+        turnover_usd = raw_turnover_usd
         if min_step > 0.0 and abs(delta_weight) < min_step:
             skip_due_to_step = True
             if hasattr(metrics, "model_copy"):
-                metrics = metrics.model_copy(update={"act_now": False})
+                metrics = metrics.model_copy(
+                    update={"act_now": False, "turnover_usd": 0.0}
+                )
             else:  # pragma: no cover - compatibility fallback
-                metrics = metrics.copy(update={"act_now": False})
+                metrics = metrics.copy(update={"act_now": False, "turnover_usd": 0.0})
+            turnover_usd = 0.0
 
         caps_eval = self._evaluate_turnover_caps(symbol, state, bar)
-        turnover_usd = float(getattr(metrics, "turnover_usd", 0.0))
         skip_due_to_cap = False
         effective_cap = caps_eval.get("effective_cap")
-        if effective_cap is not None and turnover_usd > float(effective_cap) + 1e-9:
+        if effective_cap is not None and raw_turnover_usd > float(effective_cap) + 1e-9:
             skip_due_to_cap = True
             if hasattr(metrics, "model_copy"):
-                metrics = metrics.model_copy(update={"act_now": False})
+                metrics = metrics.model_copy(
+                    update={"act_now": False, "turnover_usd": 0.0}
+                )
             else:  # pragma: no cover - compatibility fallback
-                metrics = metrics.copy(update={"act_now": False})
+                metrics = metrics.copy(update={"act_now": False, "turnover_usd": 0.0})
+            turnover_usd = 0.0
 
         instructions: List[RebalanceInstruction] = []
         final_state = state

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -400,6 +400,11 @@ def test_bar_executor_turnover_cap_tracks_portfolio_usage():
     assert second_report.meta["instructions"] == []
     assert second_report.meta.get("turnover_cap_enforced") is True
     assert second_report.meta["cap_usd"] == pytest.approx(100.0)
+    assert second_report.meta["decision"]["turnover_usd"] == pytest.approx(0.0)
+
+    snapshot = executor.monitoring_snapshot()
+    assert snapshot["turnover_usd"] == pytest.approx(0.0)
+    assert snapshot.get("turnover_cap_enforced") is True
 
 def test_bar_executor_respects_min_rebalance_step():
     executor = BarExecutor(
@@ -423,8 +428,13 @@ def test_bar_executor_respects_min_rebalance_step():
     report = executor.execute(order)
     assert report.meta.get("min_step_enforced") is True
     assert report.meta["instructions"] == []
+    assert report.meta["decision"]["turnover_usd"] == pytest.approx(0.0)
     positions = executor.get_open_positions()
     assert positions["BTCUSDT"].meta["weight"] == 0.0
+
+    snapshot = executor.monitoring_snapshot()
+    assert snapshot["turnover_usd"] == pytest.approx(0.0)
+    assert snapshot.get("min_step_enforced") is True
 
 
 def test_bar_executor_skips_when_edge_insufficient():


### PR DESCRIPTION
## Summary
- ensure bar executor zeroes turnover metrics whenever skips occur due to min step or turnover caps
- propagate the zero turnover figures into monitoring snapshots and execution reports
- extend bar executor tests to cover skip scenarios and assert turnover is reported as zero

## Testing
- pytest tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68db91253630832f963c8021b25b5f2a