### PR TITLE
Ensure turnover resets when skipping bars

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -328,15 +328,20 @@ class BarExecutor(TradeExecutor):
             self.safety_margin_bps,
         )
 
+        turnover_override: Optional[float] = None
         if skip_reason is not None:
+            updates = {"act_now": False, "turnover_usd": 0.0}
             if hasattr(metrics, "model_copy"):
-                metrics = metrics.model_copy(update={"act_now": False})
+                metrics = metrics.model_copy(update=updates)
             else:  # pragma: no cover - compatibility fallback
-                metrics = metrics.copy(update={"act_now": False})
+                metrics = metrics.copy(update=updates)
+            turnover_override = 0.0
 
         min_step = self.min_rebalance_step
         skip_due_to_step = False
         raw_turnover_usd = float(getattr(metrics, "turnover_usd", 0.0))
+        if turnover_override is not None:
+            raw_turnover_usd = turnover_override
         turnover_usd = raw_turnover_usd
         if min_step > 0.0 and abs(delta_weight) < min_step:
             skip_due_to_step = True

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -415,6 +415,7 @@ def test_bar_executor_skips_when_price_invalid(price: float):
     decision = report.meta["decision"]
     assert decision["act_now"] is False
     assert decision.get("reason") == "no_price"
+    assert decision["turnover_usd"] == 0.0
 
     snapshot = executor.monitoring_snapshot()
     assert snapshot.get("act_now") is False


### PR DESCRIPTION
## Summary
- ensure skipped bars force the execution metrics to report zero turnover
- keep local turnover bookkeeping aligned with the skipped-bar override
- cover the regression with a test that asserts zero turnover when prices are invalid

## Testing
- `pytest tests/test_bar_executor.py::test_bar_executor_skips_when_price_invalid`


------
https://chatgpt.com/codex/tasks/task_e_68db9aa1d418832f879c4c4594b4e4d6