### PR TITLE
Handle min notional per TWAP slice

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -928,6 +928,7 @@ class BarExecutor(TradeExecutor):
         accumulated_weight = float(state.weight)
         total_notional_dec = Decimal("0")
         weight_tolerance = 1e-9
+        min_notional_tolerance = Decimal("1e-9") if min_notional > Decimal("0") else Decimal("0")
 
         for idx in range(parts):
             if idx == parts - 1:
@@ -955,6 +956,12 @@ class BarExecutor(TradeExecutor):
             executed_notional = Decimal("0")
             if price > Decimal("0") and quantized_qty > Decimal("0"):
                 executed_notional = quantized_qty * price
+            if (
+                min_notional > Decimal("0")
+                and executed_notional + min_notional_tolerance < min_notional
+            ):
+                return [], float(state.weight), 0.0, "below_min_notional"
+
             executed_delta = 0.0
             if equity_dec > Decimal("0") and executed_notional > Decimal("0"):
                 executed_fraction = executed_notional / equity_dec


### PR DESCRIPTION
## Summary
- enforce the symbol min_notional threshold for every generated TWAP slice in the bar executor
- add coverage for TWAP splits where each slice falls below min_notional and ensure the rebalance is rejected

## Testing
- pytest tests/test_bar_executor.py::test_bar_executor_rejects_twap_slices_below_min_notional

------
https://chatgpt.com/codex/tasks/task_e_68dba43178a4832fabc447bb20d1f225