### PR TITLE
Ensure BarExecutor resets weights when skipping trades

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -439,6 +439,8 @@ class BarExecutor(TradeExecutor):
                 if remaining_candidates:
                     caps_eval["effective_cap"] = min(remaining_candidates)
         else:
+            target_weight = final_state.weight
+            delta_weight = 0.0
             dump_fn = getattr(metrics, "model_dump", None)
             metrics_data = dump_fn() if callable(dump_fn) else metrics.dict()
             if skip_reason is not None:
@@ -451,6 +453,10 @@ class BarExecutor(TradeExecutor):
                 metrics_data,
             )
 
+        if not instructions:
+            target_weight = final_state.weight
+            delta_weight = 0.0
+
         self._states[symbol] = final_state
 
         dump_fn = getattr(metrics, "model_dump", None)
@@ -461,6 +467,8 @@ class BarExecutor(TradeExecutor):
             decision_data["normalization"] = dict(normalization_data)
         if skip_reason is not None:
             decision_data["reason"] = skip_reason
+        decision_data["target_weight"] = target_weight
+        decision_data["delta_weight"] = delta_weight
         report_meta: Dict[str, Any] = {
             "mode": mode,
             "decision": decision_data,


### PR DESCRIPTION
## Summary
- reset skipped BarExecutor decisions to the prior portfolio weight before building report metadata and monitoring snapshots
- mirror the final target and delta weights into the recorded decision payload
- extend BarExecutor tests to cover skipped trades, including min rebalance enforcement and explicit skip reasons

## Testing
- pytest tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68dbbfada71c832fb1b9126a2deaee67