### PR TITLE
Add quote volume handling for Binance public bars

### DIFF
--- a/impl_binance_public.py
+++ b/impl_binance_public.py
@@ -118,6 +118,14 @@ class BinancePublicBarSource(MarketDataSource):
             if "k" not in payload:
                 return
             k = payload["k"]
+            volume_quote = None
+            raw_volume_quote = k.get("q")
+            if raw_volume_quote not in (None, ""):
+                try:
+                    volume_quote = Decimal(raw_volume_quote)
+                except (ArithmeticError, ValueError, TypeError):
+                    volume_quote = None
+
             bar = Bar(
                 ts=int(k["t"]),
                 symbol=str(k["s"]).upper(),
@@ -126,6 +134,7 @@ class BinancePublicBarSource(MarketDataSource):
                 low=Decimal(k["l"]),
                 close=Decimal(k["c"]),
                 volume_base=Decimal(k["v"]),
+                volume_quote=volume_quote,
                 trades=int(k.get("n", 0)),
                 is_final=bool(k.get("x", False)),
             )

--- a/tests/test_binance_public_bar_source.py
+++ b/tests/test_binance_public_bar_source.py
@@ -1,0 +1,35 @@
+import json
+from decimal import Decimal
+
+import impl_binance_public
+
+
+def test_handle_message_populates_volume_quote(monkeypatch):
+    monkeypatch.setattr(impl_binance_public, "websockets", object())
+
+    source = impl_binance_public.BinancePublicBarSource(timeframe="1m")
+
+    message = json.dumps(
+        {
+            "data": {
+                "k": {
+                    "t": 1,
+                    "s": "btcusdt",
+                    "o": "1",
+                    "h": "2",
+                    "l": "0.5",
+                    "c": "1.5",
+                    "v": "10",
+                    "q": "100",
+                    "n": 3,
+                    "x": True,
+                }
+            }
+        }
+    )
+
+    source._handle_message(message)
+
+    bar = source._q.get_nowait()
+    assert bar.volume_base == Decimal("10")
+    assert bar.volume_quote == Decimal("100")


### PR DESCRIPTION
## Summary
- parse quote volume from Binance kline messages when constructing Bar objects
- add a unit test covering quote volume population in BinancePublicBarSource

## Testing
- pytest tests/test_binance_public_bar_source.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc1007098832fbf43824a58cadc99