### PR TITLE
Preserve bar executor cap headroom reporting

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -362,6 +362,7 @@ class BarExecutor(TradeExecutor):
             turnover_usd = 0.0
 
         caps_eval = self._evaluate_turnover_caps(symbol, state, bar)
+        pre_trade_cap = caps_eval.get("effective_cap")
         skip_due_to_cap = False
         effective_cap = caps_eval.get("effective_cap")
         if effective_cap is not None and raw_turnover_usd > float(effective_cap) + 1e-9:
@@ -490,9 +491,9 @@ class BarExecutor(TradeExecutor):
             report_meta["reference_price"] = float(price)
         if adv_quote is not None:
             report_meta["adv_quote"] = adv_quote
-        cap_effective = caps_eval.get("effective_cap")
-        if cap_effective is not None:
-            report_meta["cap_usd"] = float(cap_effective)
+        cap_effective_pre = pre_trade_cap
+        if cap_effective_pre is not None:
+            report_meta["cap_usd"] = float(cap_effective_pre)
         if caps_eval.get("symbol_limit") is not None:
             report_meta["symbol_turnover_cap_usd"] = float(caps_eval["symbol_limit"])
         if caps_eval.get("portfolio_limit") is not None:
@@ -538,8 +539,8 @@ class BarExecutor(TradeExecutor):
             snapshot["normalization"] = dict(normalization_data)
         if skip_reason is not None:
             snapshot["reason"] = skip_reason
-        if cap_effective is not None:
-            snapshot["cap_usd"] = float(cap_effective)
+        if cap_effective_pre is not None:
+            snapshot["cap_usd"] = float(cap_effective_pre)
         if caps_eval.get("symbol_limit") is not None:
             snapshot["symbol_cap_usd"] = float(caps_eval["symbol_limit"])
         if caps_eval.get("portfolio_limit") is not None:

--- a/tests/test_aggregate_exec_logs_bar_mode.py
+++ b/tests/test_aggregate_exec_logs_bar_mode.py
@@ -42,6 +42,7 @@ def test_aggregate_accepts_bar_mode_logs(tmp_path: Path) -> None:
         "target_weight": 0.5,
         "delta_weight": 0.5,
         "adv_quote": 10_000.0,
+        "cap_usd": 12_000.0,
         "bar_ts": 60_000,
     }
     meta_second = {
@@ -56,6 +57,7 @@ def test_aggregate_accepts_bar_mode_logs(tmp_path: Path) -> None:
         "target_weight": 0.2,
         "delta_weight": -0.3,
         "adv_quote": 20_000.0,
+        "cap_usd": 8_000.0,
         "bar_ts": 60_000,
     }
 
@@ -80,9 +82,9 @@ def test_aggregate_accepts_bar_mode_logs(tmp_path: Path) -> None:
     assert row["bar_decisions"] == 2
     assert row["bar_act_now"] == 1
     assert row["bar_turnover_usd"] == pytest.approx(800.0)
-    assert row["bar_cap_usd"] == pytest.approx(30_000.0)
+    assert row["bar_cap_usd"] == pytest.approx(20_000.0)
     assert row["bar_act_now_rate"] == pytest.approx(0.5)
-    assert row["bar_turnover_vs_cap"] == pytest.approx(800.0 / 30_000.0)
+    assert row["bar_turnover_vs_cap"] == pytest.approx(800.0 / 20_000.0)
     assert "realized_slippage_bps" in row.index
     assert "modeled_cost_bps" in row.index
     assert "cost_bias_bps" in row.index
@@ -95,6 +97,6 @@ def test_aggregate_accepts_bar_mode_logs(tmp_path: Path) -> None:
     assert day["bar_decisions"] == 2
     assert day["bar_act_now"] == 1
     assert day["bar_turnover_usd"] == pytest.approx(800.0)
-    assert day["bar_cap_usd"] == pytest.approx(30_000.0)
-    assert day["bar_turnover_vs_cap"] == pytest.approx(800.0 / 30_000.0)
+    assert day["bar_cap_usd"] == pytest.approx(20_000.0)
+    assert day["bar_turnover_vs_cap"] == pytest.approx(800.0 / 20_000.0)
     assert "cost_bias_bps" in day.index

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -535,7 +535,7 @@ def test_bar_executor_turnover_cap_tracks_portfolio_usage():
     assert first_report.meta["instructions"]
     assert first_report.meta.get("turnover_cap_enforced") is None
     assert first_report.meta["portfolio_turnover_cap_usd"] == pytest.approx(150.0)
-    assert first_report.meta["cap_usd"] == pytest.approx(100.0)
+    assert first_report.meta["cap_usd"] == pytest.approx(150.0)
 
     second_order = Order(
         ts=41,
@@ -558,6 +558,7 @@ def test_bar_executor_turnover_cap_tracks_portfolio_usage():
     snapshot = executor.monitoring_snapshot()
     assert snapshot["turnover_usd"] == pytest.approx(0.0)
     assert snapshot.get("turnover_cap_enforced") is True
+    assert snapshot["cap_usd"] == pytest.approx(100.0)
 
 def test_bar_executor_respects_min_rebalance_step():
     executor = BarExecutor(


### PR DESCRIPTION
## Summary
- capture the effective turnover cap prior to registering turnover in the bar executor
- report the preserved headroom in bar execution metadata while keeping post-trade remaining fields
- extend bar-mode aggregation tests to exercise cap usage and ratios with explicit cap values

## Testing
- pytest tests/test_bar_executor.py::test_bar_executor_turnover_cap_tracks_portfolio_usage tests/test_bar_executor.py::test_bar_executor_turnover_cap_blocks_trade tests/test_aggregate_exec_logs_bar_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc64b8224832f9c052b935b25c745