### PR TITLE
Handle missing turnover data in bar mode cost calculation

### DIFF
--- a/feature_pipe.py
+++ b/feature_pipe.py
@@ -825,7 +825,7 @@ class FeaturePipe:
             trade_mask = turnover_values > 0.0
         else:
             turnover_values = None
-            trade_mask = np.ones(n_rows, dtype=bool)
+            trade_mask = np.zeros(n_rows, dtype=bool)
 
         costs_decimal = np.zeros(n_rows, dtype=float)
         if base_cost_bps > 0.0:


### PR DESCRIPTION
## Summary
- treat missing turnover data as no trades when computing bar-mode costs
- add regression coverage ensuring bar-mode targets are unchanged without turnover inputs

## Testing
- pytest tests/test_feature_pipe_metrics.py -k "no_turnover or records_spread" -q


------
https://chatgpt.com/codex/tasks/task_e_68dbce958e30832fa90b6180000f254b