### PR TITLE
Normalize decision signal weights and add regression test

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -327,7 +327,24 @@ class BarExecutor(TradeExecutor):
             decision_signal["normalized"] = True
         if normalization_data:
             decision_signal["normalization"] = dict(normalization_data)
-        decision_signal.setdefault("target_weight", target_weight)
+
+        if "target_weight" in decision_signal:
+            coerced_target = self._coerce_float(decision_signal.get("target_weight"))
+            if coerced_target is None:
+                decision_signal.pop("target_weight", None)
+            else:
+                decision_signal["target_weight"] = target_weight
+        else:
+            decision_signal["target_weight"] = target_weight
+
+        if "delta_weight" in decision_signal:
+            coerced_delta = self._coerce_float(decision_signal.get("delta_weight"))
+            if coerced_delta is None:
+                decision_signal.pop("delta_weight", None)
+            else:
+                decision_signal["delta_weight"] = delta_weight
+        else:
+            decision_signal["delta_weight"] = delta_weight
         metrics = decide_spot_trade(
             decision_signal,
             state,


### PR DESCRIPTION
## Summary
- normalize target and delta weight values recorded in decision signals, removing invalid inputs when they cannot be coerced to numbers
- ensure bar executor skips trades with malformed weight payloads without raising errors
- add regression coverage asserting that invalid weight inputs yield zero turnover and impact metrics

## Testing
- pytest tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68dbda113b58832fb33226d5e6e413b6