### PR TITLE
Forward bar cost metrics to monitoring aggregator

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -4431,6 +4431,11 @@ class _Worker:
                                 turnover_usd=float(bar_metrics.get("turnover_usd", 0.0)),
                                 cap_usd=bar_metrics.get("cap_usd"),
                                 impact_mode=bar_metrics.get("impact_mode"),
+                                modeled_cost_bps=bar_metrics.get("modeled_cost_bps"),
+                                realized_slippage_bps=bar_metrics.get(
+                                    "realized_slippage_bps"
+                                ),
+                                cost_bias_bps=bar_metrics.get("cost_bias_bps"),
                             )
                         except Exception:
                             pass

--- a/tests/test_monitoring_cost_bias.py
+++ b/tests/test_monitoring_cost_bias.py
@@ -1,7 +1,14 @@
+import logging
 import time
+from decimal import Decimal
 
+import pytest
+
+from core_models import Bar
 from services.monitoring import MonitoringAggregator
 from core_config import MonitoringConfig, MonitoringThresholdsConfig
+from pipeline import PipelineConfig
+from service_signal_runner import _Worker
 
 
 class DummyAlerts:
@@ -42,3 +49,73 @@ def test_monitoring_cost_bias_alerts() -> None:
     agg.tick(int(time.time() * 1000))
     assert not alerts.notifications
     assert not agg._cost_bias_alerted
+
+
+def test_worker_forwards_cost_metrics_to_monitoring() -> None:
+    thresholds = MonitoringThresholdsConfig()
+    cfg = MonitoringConfig(enabled=True, thresholds=thresholds)
+    alerts = DummyAlerts()
+    agg = MonitoringAggregator(cfg, alerts)
+
+    class DummyMetrics:
+        def reset_symbol(self, symbol: str) -> None:  # pragma: no cover - noop
+            pass
+
+    class DummyFeaturePipe:
+        def __init__(self) -> None:
+            self.metrics = DummyMetrics()
+            self.signal_quality: dict[str, object] = {}
+
+    class DummyExecutor:
+        def __init__(self, snapshot: dict[str, object]) -> None:
+            self.monitoring_snapshot = snapshot
+
+    modeled = 123.45
+    realized = 150.0
+    bias = 7.89
+    snapshot = {
+        "decision": {
+            "turnover_usd": 1_000.0,
+            "act_now": True,
+            "modeled_cost_bps": modeled,
+            "realized_slippage_bps": realized,
+            "cost_bias_bps": bias,
+        },
+        "turnover_usd": 1_000.0,
+        "cap_usd": 5_000.0,
+    }
+
+    worker = _Worker(
+        fp=DummyFeaturePipe(),
+        policy=object(),
+        logger=logging.getLogger("test"),
+        executor=DummyExecutor(snapshot),
+        enforce_closed_bars=False,
+        pipeline_cfg=PipelineConfig(enabled=False),
+        monitoring=agg,
+        execution_mode="bar",
+        rest_candidates=[],
+    )
+
+    bar = Bar(
+        ts=1_000_000,
+        symbol="BTCUSDT",
+        open=Decimal("1"),
+        high=Decimal("1"),
+        low=Decimal("1"),
+        close=Decimal("1"),
+    )
+
+    worker.process(bar)
+
+    entries = agg._bar_events["1m"]
+    assert entries, "expected bar execution metrics to be recorded"
+    entry = entries[-1]
+    assert entry["modeled_cost_bps"] == pytest.approx(modeled)
+    assert entry["realized_slippage_bps"] == pytest.approx(realized)
+    assert entry["cost_bias_bps"] == pytest.approx(bias)
+
+    window_snapshot = agg._bar_window_snapshot("1m")
+    assert window_snapshot["modeled_cost_bps"] == pytest.approx(modeled)
+    assert window_snapshot["realized_slippage_bps"] == pytest.approx(realized)
+    assert window_snapshot["cost_bias_bps"] == pytest.approx(bias)


### PR DESCRIPTION
## Summary
- forward modeled, realized, and bias cost metrics from the bar runner into the monitoring aggregator
- add a regression test ensuring bar cost metrics are recorded and aggregated when present in the executor snapshot

## Testing
- pytest tests/test_monitoring_cost_bias.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4460d93c832fa321a43aa15e39ef