### PR TITLE
Respect provided turnover in decide_spot_trade

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -181,7 +181,23 @@ def decide_spot_trade(
         target_weight = portfolio_state.weight
 
     delta_weight = target_weight - portfolio_state.weight
-    turnover_usd = abs(delta_weight) * float(portfolio_state.equity_usd)
+
+    turnover_override = signal.get("turnover_usd")
+    turnover_usd: Optional[float] = None
+    if turnover_override is not None:
+        try:
+            candidate = float(turnover_override)
+        except (TypeError, ValueError):
+            candidate = None
+        if (
+            candidate is not None
+            and math.isfinite(candidate)
+            and candidate >= 0.0
+        ):
+            turnover_usd = candidate
+
+    if turnover_usd is None:
+        turnover_usd = abs(delta_weight) * float(portfolio_state.equity_usd)
 
     base_cost = float(cost_config.taker_fee_bps) + float(cost_config.half_spread_bps)
 

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -69,6 +69,17 @@ def test_decide_spot_trade_safety_margin_blocks_trade():
     assert metrics.impact_mode == "none"
 
 
+def test_decide_spot_trade_prefers_signal_turnover_usd():
+    state = PortfolioState(symbol="BTCUSDT", weight=0.0, equity_usd=0.0)
+    cfg = SpotCostConfig()
+    signal = {"target_weight": 0.5, "edge_bps": 10.0, "turnover_usd": 123.0}
+
+    metrics = decide_spot_trade(signal, state, cfg, adv_quote=None, safety_margin_bps=0.0)
+
+    assert metrics.turnover_usd == pytest.approx(123.0)
+    assert metrics.act_now is True
+
+
 def test_bar_executor_target_weight_single_instruction():
     executor = BarExecutor(
         run_id="test",


### PR DESCRIPTION
## Summary
- use a valid `turnover_usd` hint from the signal when present, falling back to the equity-based estimate otherwise
- add a regression test to ensure the override keeps `act_now` true even when portfolio equity is zero

## Testing
- pytest tests/test_bar_executor.py::test_decide_spot_trade_prefers_signal_turnover_usd


------
https://chatgpt.com/codex/tasks/task_e_68dce31cad0c832fbd71c61ac1f8f388