### PR TITLE
Respect act_now flag in bar executor

### DIFF
--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -80,6 +80,22 @@ def test_decide_spot_trade_prefers_signal_turnover_usd():
     assert metrics.act_now is True
 
 
+def test_decide_spot_trade_honors_false_act_now_flag():
+    state = PortfolioState(symbol="BTCUSDT", weight=0.0, equity_usd=1000.0)
+    cfg = SpotCostConfig()
+    signal = {
+        "target_weight": 0.2,
+        "edge_bps": 50.0,
+        "act_now": "false",
+    }
+
+    metrics = decide_spot_trade(signal, state, cfg, adv_quote=None, safety_margin_bps=0.0)
+
+    assert metrics.net_bps > 0.0
+    assert metrics.turnover_usd == pytest.approx(200.0)
+    assert metrics.act_now is False
+
+
 def test_bar_executor_target_weight_single_instruction():
     executor = BarExecutor(
         run_id="test",


### PR DESCRIPTION
## Summary
- coerce `act_now` hints from bar-mode signals before evaluating trade viability
- gate `act_now` on both the requested flag and the economic checks
- add coverage ensuring `act_now=False` signals stay dormant even with positive edge

## Testing
- pytest tests/test_bar_executor.py::test_decide_spot_trade_honors_false_act_now_flag


------
https://chatgpt.com/codex/tasks/task_e_68dce7405ae4832f94af67abe8beaeeb