### PR TITLE
Fix BarBacktestSimBridge meta wrapping and add tests

### DIFF
--- a/service_backtest.py
+++ b/service_backtest.py
@@ -264,9 +264,12 @@ class BarBacktestSimBridge:
             meta = getattr(order, "meta", None)
             if isinstance(meta, Mapping):
                 payload = dict(meta)
+                if "payload" not in payload and "rebalance" not in payload:
+                    payload["payload"] = {}
+            elif meta is not None:
+                payload = {"payload": meta}
             else:
-                payload = {}
-            payload.setdefault("payload", {})
+                payload = {"payload": {}}
             if bar_payload is not None:
                 payload["bar"] = bar_payload
             payload["equity_usd"] = equity_before_costs


### PR DESCRIPTION
## Summary
- ensure BarBacktestSimBridge preserves non-mapping order metadata and avoids creating empty payloads when only rebalance data is present
- add regression tests covering SpotSignalEnvelope and rebalance-only metadata flowing through the bridge into BarExecutor

## Testing
- pytest tests/test_service_backtest_bar_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68dceac36d94832f9d5a1ae2903f247a