### PR TITLE
Fix weight cap normalization per symbol

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -358,8 +358,18 @@ class BarExecutor(TradeExecutor):
                 if key in decision_signal and decision_signal.get(key) is not None:
                     continue
                 value = economics_block.get(key)
-                if value is not None:
-                    decision_signal[key] = value
+                if value is None:
+                    continue
+                if key == "turnover_usd":
+                    try:
+                        numeric_value = float(value)
+                    except (TypeError, ValueError):
+                        numeric_value = None
+                    if numeric_value is None or numeric_value <= 0.0:
+                        continue
+                    decision_signal[key] = numeric_value
+                    continue
+                decision_signal[key] = value
         if normalized_flag:
             decision_signal["normalized"] = True
         if normalization_data:


### PR DESCRIPTION
## Summary
- deduplicate weight-cap aggregation per symbol so normalization factors use current totals once per asset
- ignore zero or invalid turnover overrides when building bar-executor decisions to keep trades actionable
- add regression coverage for duplicate-symbol orders sharing the same weight target

## Testing
- pytest tests/test_service_signal_runner_payload.py tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf85213d0832f944d74f70097357e