### PR TITLE
Preserve executed quantities in bar executor state

### DIFF
--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -126,6 +126,7 @@ def test_bar_executor_target_weight_single_instruction():
     positions = executor.get_open_positions()
     pos = positions["BTCUSDT"]
     assert pos.meta["weight"] == 0.5
+    assert pos.qty == Decimal("0.05")
 
 
 def test_bar_executor_handles_symbol_case_variants():

--- a/tests/test_service_backtest_bar_bridge.py
+++ b/tests/test_service_backtest_bar_bridge.py
@@ -140,6 +140,7 @@ def test_spot_signal_envelope_payload_passthrough(bar_bridge_cls: type[Any]) -> 
 
     positions = executor.get_open_positions([symbol])
     assert positions[symbol].meta["weight"] == pytest.approx(0.5)
+    assert positions[symbol].qty == Decimal("5")
 
 
 def test_rebalance_only_payload_preserved(bar_bridge_cls: type[Any]) -> None:
@@ -175,3 +176,4 @@ def test_rebalance_only_payload_preserved(bar_bridge_cls: type[Any]) -> None:
 
     positions = executor.get_open_positions([symbol])
     assert positions[symbol].meta["weight"] == pytest.approx(0.3)
+    assert positions[symbol].qty == Decimal("3")


### PR DESCRIPTION
## Summary
- extend PortfolioState with an executed quantity field and propagate it through instruction building and open position snapshots
- ensure service backtest bridge expectations align with stored quantities

## Testing
- pytest tests/test_bar_executor.py tests/test_service_backtest_bar_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68dd08b1b668832f822b3653ec280bdf