### PR TITLE
Adjust TTL handling to use bar close timestamps

### DIFF
--- a/tests/test_publish_decision.py
+++ b/tests/test_publish_decision.py
@@ -31,7 +31,11 @@ def _make_worker(mode: str) -> _Worker:
 def test_publish_decision_queue_mode():
     worker = _make_worker("queue")
     called = []
-    worker._emit = lambda o, s, b: (called.append(o) or True)  # type: ignore
+    def _emit(order, symbol, bar_close_ms, *, bar_open_ms=None):
+        called.append(order)
+        return True
+
+    worker._emit = _emit  # type: ignore[method-assign]
     order = SimpleNamespace()
     res = worker.publish_decision(order, "BTC", 1)
     assert res.action == "queue"
@@ -42,7 +46,11 @@ def test_publish_decision_queue_mode():
 def test_publish_decision_drop_mode():
     worker = _make_worker("drop")
     called = []
-    worker._emit = lambda o, s, b: (called.append(o) or True)  # type: ignore
+    def _emit(order, symbol, bar_close_ms, *, bar_open_ms=None):
+        called.append(order)
+        return True
+
+    worker._emit = _emit  # type: ignore[method-assign]
     order = SimpleNamespace()
     res = worker.publish_decision(order, "BTC", 1)
     assert res.action == "drop"

--- a/tests/test_worker_cooldown.py
+++ b/tests/test_worker_cooldown.py
@@ -25,8 +25,9 @@ def _make_bar_worker() -> _Worker:
     )
     emissions: list[tuple[str, int]] = []
 
-    def _emit(order: object, symbol: str, bar_ts: int) -> bool:
-        emissions.append((symbol, bar_ts))
+    def _emit(order: object, symbol: str, bar_close_ms: int, *, bar_open_ms: int | None = None) -> bool:
+        recorded_ts = bar_open_ms if bar_open_ms is not None else bar_close_ms
+        emissions.append((symbol, recorded_ts))
         return True
 
     worker._emit = _emit  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary
- compute bar close timestamps from bar opens when a timeframe is available and reuse them for TTL validation and publish metadata
- keep passing bar opens to cooldown/idempotency logic while carrying both open and close values through the publish/queue path
- refresh worker tests for the new signatures and add coverage that confirms TTL remains valid for one full timeframe after the close

## Testing
- pytest tests/test_worker_idempotency.py tests/test_publish_decision.py tests/test_worker_cooldown.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0dc58f18832fb03db058edc242d4