### PR TITLE
Fix BarBacktestSimBridge meta mutation for frozen orders

### DIFF
--- a/service_backtest.py
+++ b/service_backtest.py
@@ -297,7 +297,14 @@ class BarBacktestSimBridge:
             if bar_payload is not None:
                 payload["bar"] = bar_payload
             payload["equity_usd"] = equity_before_costs
-            order.meta = payload
+
+            if isinstance(meta, dict):
+                meta.update(payload)
+            else:
+                try:
+                    object.__setattr__(order, "meta", payload)
+                except AttributeError:
+                    setattr(order, "meta", payload)
 
             report = self.executor.execute(order)
             report_meta = getattr(report, "meta", {})


### PR DESCRIPTION
## Summary
- update `BarBacktestSimBridge` to update existing order meta dictionaries or rebind via `object.__setattr__`
- add a regression test that exercises the bridge with a real `core_models.Order`

## Testing
- pytest tests/test_service_backtest_bar_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2aed3208832fb5e8df2a70ac11f1