### PR TITLE
Add ADV runtime configuration tests

### DIFF
--- a/service_backtest.py
+++ b/service_backtest.py
@@ -959,7 +959,7 @@ def _configure_adv_runtime(
             "%s: ExecutionSimulator lacks set_adv_store(); ADV runtime disabled",
             context,
         )
-        return None
+        return None, bar_capacity_cfg
     capacity_fraction = getattr(adv_cfg, "capacity_fraction", None)
     bars_override = getattr(adv_cfg, "bars_per_day_override", None)
     extra_block = getattr(adv_cfg, "extra", None)
@@ -992,14 +992,17 @@ def _configure_adv_runtime(
             )
         else:
             _log_adv_runtime_warnings(
-                existing_store, getattr(sim, "symbol", None), adv_cfg, context
+                existing_store,
+                getattr(sim, "symbol", None),
+                adv_cfg,
+                context=context,
             )
         return existing_store, bar_capacity_cfg
     try:
         store = ADVStore(adv_cfg)
     except Exception:
         logger.exception("%s: failed to initialise ADV store from config", context)
-        return None
+        return None, bar_capacity_cfg
     try:
         set_store(
             store,
@@ -1010,7 +1013,12 @@ def _configure_adv_runtime(
     except Exception:
         logger.exception("%s: failed to attach ADV store to simulator", context)
         return None, bar_capacity_cfg
-    _log_adv_runtime_warnings(store, getattr(sim, "symbol", None), adv_cfg, context)
+    _log_adv_runtime_warnings(
+        store,
+        getattr(sim, "symbol", None),
+        adv_cfg,
+        context=context,
+    )
     return store, bar_capacity_cfg
 
 

--- a/tests/backtest/test_configure_adv_runtime.py
+++ b/tests/backtest/test_configure_adv_runtime.py
@@ -1,0 +1,152 @@
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+if "exchange" not in sys.modules:
+    exchange_pkg = types.ModuleType("exchange")
+    exchange_pkg.__path__ = []  # mark as package
+    specs_mod = types.ModuleType("exchange.specs")
+    specs_mod.load_specs = lambda *args, **kwargs: {}
+    specs_mod.round_price_to_tick = lambda price, symbol=None: price
+    sys.modules["exchange"] = exchange_pkg
+    sys.modules["exchange.specs"] = specs_mod
+
+from service_backtest import ADVStore, _configure_adv_runtime
+
+
+class DummyRunCfg(types.SimpleNamespace):
+    pass
+
+
+class DummySimulator:
+    def __init__(self, *, adv_store: ADVStore | None = None, has_store: bool = False):
+        self._adv_store = adv_store
+        self._has_store = has_store
+        self.calls: list[dict[str, Any]] = []
+
+    def has_adv_store(self) -> bool:
+        return self._has_store
+
+    def set_adv_store(
+        self,
+        store: ADVStore,
+        *,
+        enabled: bool,
+        capacity_fraction: float | None,
+        bars_per_day_override: int | None,
+    ) -> None:
+        self.calls.append(
+            {
+                "store": store,
+                "enabled": enabled,
+                "capacity_fraction": capacity_fraction,
+                "bars_per_day_override": bars_per_day_override,
+            }
+        )
+
+
+@pytest.fixture
+def base_exec_cfg() -> dict[str, Any]:
+    return {"bar_capacity_base": {"enabled": True}}
+
+
+def test_reuses_existing_store_and_forwards_primary_config(base_exec_cfg):
+    existing_store = ADVStore({})
+    adv_cfg = types.SimpleNamespace(
+        enabled=True,
+        capacity_fraction=0.25,
+        bars_per_day_override=180,
+    )
+    run_cfg = DummyRunCfg(adv=adv_cfg, execution=base_exec_cfg)
+    sim = DummySimulator(adv_store=existing_store, has_store=True)
+
+    store, bar_capacity = _configure_adv_runtime(sim, run_cfg, context="test-run")
+
+    assert store is existing_store
+    assert bar_capacity == {"enabled": True}
+    assert sim.calls == [
+        {
+            "store": existing_store,
+            "enabled": True,
+            "capacity_fraction": 0.25,
+            "bars_per_day_override": 180,
+        }
+    ]
+
+
+def test_creates_fresh_store_and_uses_extra_overrides(base_exec_cfg):
+    adv_cfg = types.SimpleNamespace(
+        enabled=True,
+        extra={
+            "capacity_fraction": 0.5,
+            "bars_per_day": 96,
+        },
+    )
+    run_cfg = DummyRunCfg(adv=adv_cfg, execution=base_exec_cfg)
+    sim = DummySimulator()
+
+    store, bar_capacity = _configure_adv_runtime(sim, run_cfg, context="fresh")
+
+    assert isinstance(store, ADVStore)
+    assert bar_capacity == {"enabled": True}
+    assert sim.calls == [
+        {
+            "store": store,
+            "enabled": True,
+            "capacity_fraction": 0.5,
+            "bars_per_day_override": 96,
+        }
+    ]
+
+
+def test_missing_set_adv_store_logs_warning_and_disables(caplog, base_exec_cfg):
+    caplog.set_level("WARNING")
+    adv_cfg = types.SimpleNamespace(enabled=True)
+    run_cfg = DummyRunCfg(adv=adv_cfg, execution=base_exec_cfg)
+    sim = types.SimpleNamespace()
+
+    store, bar_capacity = _configure_adv_runtime(sim, run_cfg, context="no-api")
+
+    assert store is None
+    assert bar_capacity == {"enabled": True}
+    assert "lacks set_adv_store" in caplog.text
+
+
+def test_advstore_initialisation_failure_returns_none(monkeypatch, base_exec_cfg, caplog):
+    caplog.set_level("ERROR")
+    adv_cfg = types.SimpleNamespace(enabled=True)
+    run_cfg = DummyRunCfg(adv=adv_cfg, execution=base_exec_cfg)
+    sim = DummySimulator()
+
+    class ExplodingStore:
+        def __init__(self, _cfg):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr("service_backtest.ADVStore", ExplodingStore)
+
+    store, bar_capacity = _configure_adv_runtime(sim, run_cfg, context="boom-init")
+
+    assert store is None
+    assert bar_capacity == {"enabled": True}
+    assert "failed to initialise ADV store" in caplog.text
+
+
+def test_set_adv_store_failure_logs_and_returns_none(base_exec_cfg, caplog):
+    caplog.set_level("ERROR")
+    adv_cfg = types.SimpleNamespace(enabled=True)
+    run_cfg = DummyRunCfg(adv=adv_cfg, execution=base_exec_cfg)
+
+    class FailingSimulator(DummySimulator):
+        def set_adv_store(self, *args, **kwargs):
+            raise RuntimeError("attach fail")
+
+    sim = FailingSimulator(adv_store=None)
+
+    store, bar_capacity = _configure_adv_runtime(sim, run_cfg, context="boom-set")
+
+    assert store is None
+    assert bar_capacity == {"enabled": True}
+    assert "failed to attach ADV store" in caplog.text


### PR DESCRIPTION
## Summary
- add targeted tests for `_configure_adv_runtime` covering reuse, creation, warning, and failure paths
- stub external dependencies to allow isolated testing of ADV runtime configuration
- ensure `_configure_adv_runtime` consistently returns `(None, cfg)` on failures and passes the warning context keyword

## Testing
- pytest tests/backtest/test_configure_adv_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68dd632001cc832fb7571f76bd6177e5