### PR TITLE
Execute bar orders inline when dispatcher missing

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -4795,6 +4795,21 @@ class _Worker:
         if not published:
             return False
         self._remember_idempotency_key(idempotency_key)
+        if (
+            self._execution_mode == "bar"
+            and self._signal_dispatcher is None
+        ):
+            execute = getattr(self._executor, "execute", None)
+            if callable(execute):
+                try:
+                    execute(o)
+                except Exception:
+                    try:
+                        self._logger.exception(
+                            "failed to execute bar order inline", exc_info=True
+                        )
+                    except Exception:
+                        pass
         if self._execution_mode != "bar":
             submit = getattr(self._executor, "submit", None)
             if callable(submit):


### PR DESCRIPTION
## Summary
- execute bar-mode orders inline when no signal dispatcher is available so `_bar_execution` metadata is populated
- add a regression test covering inline execution behavior and weight updates in bar mode

## Testing
- pytest tests/test_service_mode_smoke.py::test_service_signal_runner_bar_mode_inline_execution

------
https://chatgpt.com/codex/tasks/task_e_68dd91743d1c832fa280a94347966e95