### PR TITLE
Handle non-finite turnover values in daily turnover limits

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -3581,12 +3581,17 @@ class _Worker:
                 sym, payload, current_weight=working_weight
             )
             requested = self._extract_order_turnover(order)
-            if requested <= 0.0:
+            requested_non_finite = not math.isfinite(requested)
+            if requested_non_finite:
+                requested = 0.0
+            if requested <= 0.0 and not requested_non_finite:
                 delta = abs(float(delta_weight))
                 if delta > 0.0:
                     equity = self._resolve_order_equity(order, payload, sym)
                     if equity is not None and equity > 0.0:
                         requested = delta * float(equity)
+                        if not math.isfinite(requested):
+                            requested = 0.0
             headroom_candidates: list[float] = []
             if symbol_limit is not None:
                 headroom_candidates.append(max(0.0, float(symbol_limit) - symbol_used))
@@ -3608,6 +3613,8 @@ class _Worker:
                     pass
                 continue
             executed = requested
+            if not math.isfinite(executed):
+                executed = 0.0
             clamped = False
             if headroom is not None and requested > headroom + 1e-9:
                 if not self._scale_order_for_turnover(
@@ -3633,6 +3640,8 @@ class _Worker:
                 target_weight, delta_weight, _ = self._resolve_weight_targets(
                     sym, payload, current_weight=working_weight
                 )
+                if not math.isfinite(executed):
+                    executed = 0.0
                 try:
                     self._logger.info(
                         "DAILY_TURNOVER_CLAMP %s",


### PR DESCRIPTION
## Summary
- guard _apply_daily_turnover_limits against non-finite requested and executed turnover values so they cannot corrupt symbol/portfolio counters
- sanitize the executed turnover after clamping so logged metadata remains finite
- add a regression test that feeds a NaN turnover payload and asserts counters stay healthy

## Testing
- pytest tests/test_daily_turnover_limits.py

------
https://chatgpt.com/codex/tasks/task_e_68dd93e7769c832f953dbb5ad48065bf