### PR TITLE
Propagate ADV quotes through signal envelopes

### DIFF
--- a/api/spot_signals.py
+++ b/api/spot_signals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 from pathlib import Path
 from typing import Any, Dict, Mapping, MutableMapping, Optional, Union, Literal
 
@@ -83,6 +84,11 @@ class SpotSignalEconomics(BaseModel):
             "Mode describing how the impact estimate was produced (e.g. 'model' or 'none')."
         ),
     )
+    adv_quote: Optional[float] = Field(
+        None,
+        ge=0.0,
+        description="Average daily quote volume used for participation modelling.",
+    )
 
     @field_validator("net_bps")
     @classmethod
@@ -102,6 +108,16 @@ class SpotSignalEconomics(BaseModel):
         if value < 0.0:
             return 0.0
         return float(value)
+
+    @field_validator("adv_quote")
+    @classmethod
+    def _validate_adv(cls, value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return None
+        coerced = float(value)
+        if coerced <= 0.0 or not math.isfinite(coerced):
+            return None
+        return coerced
 
 
 class SpotSignalTwapConfig(BaseModel):

--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -630,6 +630,7 @@ def decide_spot_trade(
         act_now=act_now,
         impact=impact,
         impact_mode=impact_mode,
+        adv_quote=adv_quote,
     )
 
 


### PR DESCRIPTION
## Summary
- add an optional `adv_quote` field to the spot signal payload schema and carry it through bar execution metrics
- extract ADV quotes from incoming orders, attach them to order meta, and include them in the published envelope payload
- extend worker tests to cover ADV propagation through dispatch and ensure bar executor behaviour when an ADV is supplied

## Testing
- pytest tests/test_service_signal_runner_payload.py tests/test_worker_idempotency.py tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68dda76a9718832f988b5a4230e7d962