### PR TITLE
Populate bar execution reports with reference prices

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -1056,13 +1056,23 @@ class BarExecutor(TradeExecutor):
         self._attach_execution_meta(order, execution_meta)
         report_meta["execution"] = dict(execution_meta)
 
+        exec_price = Decimal("0")
+        if price is not None:
+            try:
+                exec_price_candidate = price if isinstance(price, Decimal) else _as_decimal(price)
+            except Exception:  # pragma: no cover - defensive fallback
+                exec_price_candidate = None
+            else:
+                if exec_price_candidate > Decimal("0"):
+                    exec_price = exec_price_candidate
+
         return ExecReport(
             ts=bar.ts if bar is not None else order.ts,
             run_id=self.run_id,
             symbol=symbol,
             side=_normalize_side(order.side),
             order_type=order.order_type if isinstance(order.order_type, OrderType) else OrderType.MARKET,
-            price=Decimal("0"),
+            price=exec_price,
             quantity=Decimal("0"),
             fee=Decimal("0"),
             fee_asset=None,

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -433,6 +433,7 @@ def test_bar_executor_handles_envelope_meta():
     assert decision["impact_mode"] == "model"
     assert report.meta["adv_quote"] == pytest.approx(adv_quote)
     assert report.meta["reference_price"] == pytest.approx(float(bar.close))
+    assert report.price == bar.close
 
 
 def test_bar_executor_falls_back_to_nested_economics() -> None:


### PR DESCRIPTION
## Summary
- populate bar-mode execution reports with the current bar price so downstream analytics see a proper reference
- skip realized slippage calculations when no notional traded to keep legacy logs from producing extreme values
- extend bar executor and aggregation unit tests to confirm the new behaviour

## Testing
- pytest tests/test_bar_executor.py::test_bar_executor_handles_envelope_meta
- pytest tests/test_aggregate_exec_logs_bar_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68ddabd20a2c832f96b23379fccea5ae