### PR TITLE
Preserve bar execution metadata on orders

### DIFF
--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -421,6 +421,13 @@ def test_bar_executor_handles_envelope_meta():
 
     report = executor.execute(order)
 
+    assert isinstance(order.meta, dict)
+    assert set(order.meta.keys()) >= {"payload", "_bar_execution"}
+    payload_meta = order.meta["payload"]
+    assert payload_meta["target_weight"] == pytest.approx(payload.target_weight)
+    economics_meta = payload_meta.get("economics")
+    assert economics_meta["edge_bps"] == pytest.approx(economics.edge_bps)
+
     instructions = report.meta["instructions"]
     assert len(instructions) == 1
     instruction = instructions[0]


### PR DESCRIPTION
## Summary
- materialize existing order metadata before adding the `_bar_execution` block so envelope payloads remain accessible
- merge execution metadata with any existing `_bar_execution` details instead of overwriting them
- extend the envelope execution test to assert that payload fields survive alongside the attached execution metadata

## Testing
- pytest tests/test_bar_executor.py -k envelope -q

------
https://chatgpt.com/codex/tasks/task_e_68ddad9e256c832fa14e415afd693bf2