### PR TITLE
Handle ADV fallback from economics payload

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -754,6 +754,10 @@ class BarExecutor(TradeExecutor):
                     decision_signal[key] = numeric_value
                     continue
                 decision_signal[key] = value
+            if adv_quote is None:
+                adv_from_economics = self._coerce_float(economics_block.get("adv_quote"))
+                if adv_from_economics is not None:
+                    adv_quote = adv_from_economics
         if normalized_flag:
             decision_signal["normalized"] = True
         if normalization_data:


### PR DESCRIPTION
## Summary
- allow BarExecutor to reuse ADV quotes from the economics payload when the top-level field is absent
- ensure the resolved ADV value continues to flow through trade decisions and report metadata
- add a unit test that covers the new ADV fallback behaviour and verifies impact calculations

## Testing
- pytest tests/test_bar_executor.py::test_bar_executor_adv_fallback_from_economics


------
https://chatgpt.com/codex/tasks/task_e_68ddb2175448832fbc8a236ecfbdb474