### PR TITLE
Mark bar executor reports as filled when instructions exist

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -1070,6 +1070,8 @@ class BarExecutor(TradeExecutor):
                 if exec_price_candidate > Decimal("0"):
                     exec_price = exec_price_candidate
 
+        exec_status = ExecStatus.FILLED if filled else ExecStatus.CANCELED
+
         return ExecReport(
             ts=bar.ts if bar is not None else order.ts,
             run_id=self.run_id,
@@ -1080,7 +1082,7 @@ class BarExecutor(TradeExecutor):
             quantity=Decimal("0"),
             fee=Decimal("0"),
             fee_asset=None,
-            exec_status=ExecStatus.CANCELED,
+            exec_status=exec_status,
             liquidity=Liquidity.UNKNOWN,
             client_order_id=order.client_order_id,
             meta=report_meta,


### PR DESCRIPTION
## Summary
- compute the execution status in `BarExecutor.execute` based on whether instructions were emitted
- pass the derived status into `ExecReport` so filled bar executions report FILLED status

## Testing
- pytest tests/test_bar_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb34127c4832fac6805671e0a6ba3