### PR TITLE
Sanitize turnover before aggregating bar execution metrics

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -1138,6 +1138,9 @@ class MonitoringAggregator:
             turnover = float(turnover_usd)
         except Exception:
             turnover = 0.0
+        else:
+            if not math.isfinite(turnover) or turnover < 0:
+                turnover = 0.0
         cap_value: Optional[float]
         try:
             cap_value = float(cap_usd) if cap_usd is not None else None


### PR DESCRIPTION
## Summary
- sanitize turnover in `MonitoringAggregator.record_bar_execution` to reset NaN/inf/negative values before aggregation
- add a regression test ensuring sanitized turnover keeps cumulative snapshots finite

## Testing
- pytest tests/monitoring/test_bar_execution_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb6fc0f24832f9c671fe6d14963b2