### PR TITLE
Add execution_mode metadata to bar executor reports

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -952,6 +952,7 @@ class BarExecutor(TradeExecutor):
         decision_data["target_weight"] = target_weight
         decision_data["delta_weight"] = delta_weight
         report_meta: Dict[str, Any] = {
+            "execution_mode": "bar",
             "mode": mode,
             "decision": decision_data,
             "target_weight": target_weight,
@@ -1043,6 +1044,7 @@ class BarExecutor(TradeExecutor):
         self._last_snapshot = snapshot
 
         execution_meta: Dict[str, Any] = {
+            "execution_mode": "bar",
             "filled": filled,
             "turnover_usd": executed_turnover,
             "target_weight": float(target_weight),

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -117,6 +117,8 @@ def test_bar_executor_target_weight_single_instruction():
         },
     )
     report = executor.execute(order)
+    assert report.meta["execution_mode"] == "bar"
+    assert report.meta["execution"]["execution_mode"] == "bar"
     instructions = report.meta["instructions"]
     assert len(instructions) == 1
     instr = instructions[0]


### PR DESCRIPTION
## Summary
- ensure BarExecutor report metadata includes the execution_mode field alongside target weight details
- propagate the execution_mode flag into the nested execution meta payload
- extend the BarExecutor unit test to verify the bar execution_mode is present

## Testing
- pytest tests/test_bar_executor.py::test_bar_executor_target_weight_single_instruction

------
https://chatgpt.com/codex/tasks/task_e_68ddbd6c5248832f8fdf3896f868f3d7