### PR TITLE
Ensure zero turnover when bar execution is skipped

### DIFF
--- a/impl_bar_executor.py
+++ b/impl_bar_executor.py
@@ -913,6 +913,7 @@ class BarExecutor(TradeExecutor):
                 if remaining_candidates:
                     caps_eval["effective_cap"] = min(remaining_candidates)
         else:
+            turnover_usd = 0.0
             target_weight = final_state.weight
             delta_weight = 0.0
             dump_fn = getattr(metrics, "model_dump", None)
@@ -937,6 +938,7 @@ class BarExecutor(TradeExecutor):
         if not instructions:
             target_weight = final_state.weight
             delta_weight = 0.0
+            turnover_usd = 0.0
 
         storage_key = symbol_key or final_state.symbol
         self._states[storage_key] = final_state

--- a/tests/test_bar_executor.py
+++ b/tests/test_bar_executor.py
@@ -360,11 +360,18 @@ def test_bar_executor_clears_turnover_when_skipping_execution():
     decision = report.meta["decision"]
     assert decision["act_now"] is False
     assert decision["turnover_usd"] == pytest.approx(0.0)
+    execution_meta = report.meta["execution"]
+    assert execution_meta["turnover_usd"] == pytest.approx(0.0)
+    assert report.meta["executed_turnover_usd"] == pytest.approx(0.0)
     assert report.meta["instructions"] == []
 
     snapshot = executor.monitoring_snapshot()
     assert snapshot["act_now"] is False
     assert snapshot["turnover_usd"] == pytest.approx(0.0)
+    assert isinstance(order.meta, dict)
+    bar_execution = order.meta.get("_bar_execution")
+    assert bar_execution is not None
+    assert bar_execution["turnover_usd"] == pytest.approx(0.0)
 
 
 def test_bar_executor_turnover_cap_allows_quantized_trade():


### PR DESCRIPTION
## Summary
- reset the bar executor's turnover_usd to zero when skipping execution or emitting no instructions
- extend the skip-execution unit test to cover execution and order metadata turnover fields

## Testing
- pytest tests/test_bar_executor.py::test_bar_executor_clears_turnover_when_skipping_execution

------
https://chatgpt.com/codex/tasks/task_e_68ddc211f494832f94734a11159f574c