### PR TITLE
Fix ADV extraction to ignore turnover caps

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -1263,9 +1263,7 @@ class _Worker:
 
         if isinstance(meta, MappingABC):
             _collect(meta.get("adv_quote"))
-            nested_meta_adv = self._find_in_mapping(
-                meta, ("adv_quote", "cap_quote", "cap_usd", "daily_notional_cap")
-            )
+            nested_meta_adv = self._find_in_mapping(meta, ("adv_quote",))
             if nested_meta_adv is not None:
                 _collect(nested_meta_adv)
 

--- a/tests/test_service_signal_runner_payload.py
+++ b/tests/test_service_signal_runner_payload.py
@@ -133,6 +133,16 @@ def test_build_envelope_payload_extracts_adv_quote() -> None:
     assert payload["economics"]["adv_quote"] == pytest.approx(adv_quote)
 
 
+def test_build_envelope_payload_does_not_fall_back_to_cap_usd() -> None:
+    worker = _make_worker()
+    order = SimpleNamespace(meta={"cap_usd": 1_000.0}, payload={"target_weight": 0.1})
+
+    payload, _, adv_quote = worker._build_envelope_payload(order, "BTCUSDT")
+
+    assert adv_quote is None
+    assert payload["economics"].get("adv_quote") is None
+
+
 def test_normalize_weight_targets_aggregates_symbol_totals() -> None:
     worker = _make_worker()
     worker._execution_mode = "bar"


### PR DESCRIPTION
## Summary
- restrict ADV extraction to dedicated adv_quote fields in the signal runner worker
- add a regression test ensuring cap_usd metadata does not populate adv_quote

## Testing
- pytest tests/test_service_signal_runner_payload.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc74a65cc832f93bd49b5a97e789e