### PR TITLE
Normalize ServiceSignalRunner execution mode input

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -5990,7 +5990,10 @@ class ServiceSignalRunner:
         mode = "order"
         if exec_cfg is not None:
             mode = str(getattr(exec_cfg, "mode", mode) or mode)
-        self._execution_mode = mode.lower()
+        mode = mode.strip().lower()
+        if mode not in {"bar", "order"}:
+            mode = "order"
+        self._execution_mode = mode
         self.alerts: AlertManager | None = None
         self.monitoring_agg: MonitoringAggregator | None = None
         self._clock_safe_mode = False

--- a/tests/test_service_mode_smoke.py
+++ b/tests/test_service_mode_smoke.py
@@ -113,6 +113,31 @@ def test_service_signal_runner_order_mode_instantiation(monkeypatch, tmp_path):
     assert runner._execution_mode == "order"
 
 
+def test_service_signal_runner_execution_mode_normalization(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    module = importlib.import_module("service_signal_runner")
+
+    class DummyAdapter:
+        sim = None
+        source = None
+        market_data = None
+        ws = None
+
+    cfg = module.SignalRunnerConfig(logs_dir=str(tmp_path / "logs"), run_id="test-normalized")
+    run_cfg = SimpleNamespace(execution=SimpleNamespace(mode=" bar "), slippage_regime_updates=False)
+
+    runner = module.ServiceSignalRunner(
+        DummyAdapter(),
+        object(),
+        lambda *args, **kwargs: [],
+        cfg=cfg,
+        run_config=run_cfg,
+    )
+
+    assert runner._execution_mode == "bar"
+
+
 def test_service_signal_runner_bar_mode_inline_execution(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Summary
- normalize the ServiceSignalRunner execution mode to handle whitespace and invalid values
- add a smoke test ensuring whitespace-padded execution modes resolve to supported values

## Testing
- pytest tests/test_service_mode_smoke.py -k normalization


------
https://chatgpt.com/codex/tasks/task_e_68de3a04b804832fbc8317b0827f6747