### PR TITLE
Handle immutable envelopes when recording signal timestamps

### DIFF
--- a/tests/test_service_signal_runner_process.py
+++ b/tests/test_service_signal_runner_process.py
@@ -4,16 +4,23 @@ import logging
 import types
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Any
 
 import clock
 import service_signal_runner
 from core_models import Bar
 from pipeline import PipelineResult, Stage
+from api.spot_signals import (
+    SpotSignalEconomics,
+    SpotSignalEnvelope,
+    SpotSignalTargetWeightPayload,
+)
 
 
 class _DummyMetric:
     def __init__(self) -> None:
         self.label_calls: list[tuple[str, ...]] = []
+        self.observe_calls: list[tuple[tuple[str, ...], tuple[Any, ...]]] = []
 
     def labels(self, *labels: str) -> "_DummyMetric":
         self.label_calls.append(tuple(str(label) for label in labels))
@@ -23,6 +30,11 @@ class _DummyMetric:
         return None
 
     def set(self, *args, **kwargs) -> None:  # pragma: no cover - metric helper
+        return None
+
+    def observe(self, *args, **kwargs) -> None:  # pragma: no cover - metric helper
+        labels = self.label_calls[-1] if self.label_calls else tuple()
+        self.observe_calls.append((labels, args))
         return None
 
 
@@ -130,3 +142,207 @@ def test_process_propagates_open_and_close(monkeypatch) -> None:
     assert ttl_calls == [(bar_close_ms, bar_close_ms + 1_000, timeframe_ms)]
     assert dedup_should_calls == [("BTCUSDT", bar_close_ms)]
     assert dedup_update_calls == [("BTCUSDT", bar_close_ms)]
+
+
+def test_process_spot_envelope_records_created_ts(monkeypatch) -> None:
+    timeframe_ms = 60_000
+    bar_close_ms = 1_700_000_000_000
+    now_ms = bar_close_ms + 500
+
+    monitoring_stub = SimpleNamespace()
+    monitoring_stub.inc_stage = lambda *args, **kwargs: None
+    monitoring_stub.record_signals = lambda *args, **kwargs: None
+    monitoring_stub.record_fill = lambda *args, **kwargs: None
+    monitoring_stub.record_pnl = lambda *args, **kwargs: None
+    monitoring_stub.inc_reason = lambda *args, **kwargs: None
+    monitoring_stub.alert_zero_signals = lambda *args, **kwargs: None
+    monitoring_stub.signal_error_rate = _DummyMetric()
+    monitoring_stub.ws_dup_skipped_count = _DummyMetric()
+    monitoring_stub.ttl_expired_boundary_count = _DummyMetric()
+    monitoring_stub.signal_boundary_count = _DummyMetric()
+    monitoring_stub.signal_published_count = _DummyMetric()
+    monitoring_stub.age_at_publish_ms = _DummyMetric()
+    monitoring_stub.signal_idempotency_skipped_count = _DummyMetric()
+    monitoring_stub.signal_absolute_count = _DummyMetric()
+    monitoring_stub.throttle_dropped_count = _DummyMetric()
+    monitoring_stub.throttle_enqueued_count = _DummyMetric()
+    monitoring_stub.throttle_queue_expired_count = _DummyMetric()
+    monkeypatch.setattr(service_signal_runner, "monitoring", monitoring_stub)
+    monkeypatch.setattr(
+        service_signal_runner, "pipeline_stage_drop_count", _DummyMetric()
+    )
+    monkeypatch.setattr(
+        service_signal_runner, "skipped_incomplete_bars", _DummyMetric()
+    )
+
+    monkeypatch.setattr(service_signal_runner.signal_bus, "ENABLED", True, raising=False)
+
+    skip_calls: list[tuple[str, int]] = []
+    update_calls: list[tuple[str, int]] = []
+
+    def _should_skip(symbol: str, close_ms: int) -> bool:
+        skip_calls.append((symbol, close_ms))
+        return False
+
+    def _update(symbol: str, close_ms: int) -> None:
+        update_calls.append((symbol, close_ms))
+
+    monkeypatch.setattr(service_signal_runner.signal_bus, "should_skip", _should_skip)
+    monkeypatch.setattr(service_signal_runner.signal_bus, "update", _update)
+
+    ttl_calls: list[dict[str, int]] = []
+
+    def _check_ttl(*, bar_close_ms: int, now_ms: int, timeframe_ms: int):
+        ttl_calls.append(
+            {
+                "bar_close_ms": bar_close_ms,
+                "now_ms": now_ms,
+                "timeframe_ms": timeframe_ms,
+            }
+        )
+        return True, bar_close_ms + timeframe_ms, None
+
+    monkeypatch.setattr(service_signal_runner, "check_ttl", _check_ttl)
+
+    publish_calls: list[dict[str, Any]] = []
+
+    def _publish_signal(
+        symbol: str,
+        close_ms: int,
+        payload: Any,
+        dispatch: Any,
+        *,
+        expires_at_ms: int | None = None,
+        **kwargs: Any,
+    ) -> bool:
+        publish_calls.append(
+            {
+                "symbol": symbol,
+                "bar_close_ms": close_ms,
+                "payload": payload,
+                "expires_at_ms": expires_at_ms,
+            }
+        )
+        return True
+
+    monkeypatch.setattr(
+        service_signal_runner, "publish_signal_envelope", _publish_signal
+    )
+
+    class _StubFeaturePipe:
+        def __init__(self) -> None:
+            self.signal_quality: dict[str, object] = {}
+            self.timeframe_ms = timeframe_ms
+            self.spread_ttl_ms = 0
+
+        def update(
+            self, bar: Bar, *, skip_metrics: bool | None = None
+        ) -> dict[str, float]:
+            return {"close": float(bar.close)}
+
+    class _StubPolicy:
+        def __init__(self) -> None:
+            self.timeframe_ms = timeframe_ms
+
+        def decide(self, features, ctx):
+            return [ctx.symbol]
+
+        def consume_signal_transitions(self):
+            return []
+
+    executor = SimpleNamespace(submit=lambda order: None, execute=lambda order: None)
+
+    worker = service_signal_runner._Worker(
+        _StubFeaturePipe(),
+        _StubPolicy(),
+        logging.getLogger("test-worker"),
+        executor,
+        enforce_closed_bars=False,
+        ws_dedup_enabled=True,
+        ws_dedup_timeframe_ms=timeframe_ms,
+        bar_timeframe_ms=timeframe_ms,
+        execution_mode="bar",
+    )
+
+    worker._apply_signal_quality_filter = types.MethodType(
+        lambda self, bar, *, skip_metrics=False: (True, {}),
+        worker,
+    )
+    worker._extract_features = types.MethodType(
+        lambda self, bar, *, skip_metrics=False: {},
+        worker,
+    )
+    worker._evaluate_no_trade_windows = types.MethodType(
+        lambda self, ts_ms, symbol, *, stage_cfg=None: (
+            service_signal_runner.PipelineResult(
+                action="pass", stage=service_signal_runner.Stage.WINDOWS
+            ),
+            None,
+        ),
+        worker,
+    )
+
+    def _closed_guard(*args, **kwargs):
+        return service_signal_runner.PipelineResult(
+            action="pass", stage=service_signal_runner.Stage.CLOSED_BAR
+        )
+
+    def _policy_decide(*_args, **_kwargs):
+        return service_signal_runner.PipelineResult(
+            action="pass",
+            stage=service_signal_runner.Stage.POLICY,
+            decision=[envelope],
+        )
+
+    def _apply_risk(*_args, **_kwargs):
+        return service_signal_runner.PipelineResult(
+            action="pass",
+            stage=service_signal_runner.Stage.RISK,
+            decision=[envelope],
+        )
+
+    monkeypatch.setattr(service_signal_runner, "closed_bar_guard", _closed_guard)
+    monkeypatch.setattr(service_signal_runner, "policy_decide", _policy_decide)
+    monkeypatch.setattr(service_signal_runner, "apply_risk", _apply_risk)
+
+    economics = SpotSignalEconomics(
+        edge_bps=10.0,
+        cost_bps=1.0,
+        net_bps=9.0,
+        turnover_usd=1_000.0,
+        act_now=True,
+        impact=0.0,
+        impact_mode="model",
+        adv_quote=50_000.0,
+    )
+    payload = SpotSignalTargetWeightPayload(
+        target_weight=0.5,
+        economics=economics,
+    )
+    envelope = SpotSignalEnvelope(
+        symbol="BTCUSDT",
+        bar_close_ms=bar_close_ms,
+        expires_at_ms=bar_close_ms + timeframe_ms,
+        payload=payload,
+    )
+
+    monkeypatch.setattr(clock, "now_ms", lambda: now_ms)
+
+    bar = Bar(
+        ts=bar_close_ms,
+        symbol="BTCUSDT",
+        open=Decimal("1"),
+        high=Decimal("1"),
+        low=Decimal("1"),
+        close=Decimal("1"),
+    )
+
+    emitted = worker.process(bar)
+
+    assert emitted == [envelope]
+    assert skip_calls == [("BTCUSDT", bar_close_ms)]
+    assert update_calls == [("BTCUSDT", bar_close_ms)]
+    assert publish_calls, "expected the envelope to be published"
+    expires_vals = {call["expires_at_ms"] for call in publish_calls}
+    assert expires_vals == {bar_close_ms + timeframe_ms}
+    assert any(call["now_ms"] == now_ms for call in ttl_calls)


### PR DESCRIPTION
## Summary
- add sidecar metadata handling so immutable orders can carry metadata like created timestamps
- update TTL and drop logic to read timestamps via the new helpers instead of mutating frozen objects
- cover bar-mode SpotSignalEnvelope processing with a regression test

## Testing
- pytest tests/test_service_signal_runner_process.py


------
https://chatgpt.com/codex/tasks/task_e_68de51628c3c832f958d4cce4fa57569