### PR TITLE
Handle zero cap removal in bar execution snapshots

### DIFF
--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -1238,8 +1238,11 @@ class MonitoringAggregator:
         self._bar_totals["decisions"] += dec
         self._bar_totals["act_now"] += act
         self._bar_totals["turnover_usd"] += turnover
-        if cap_value is not None and cap_value > 0 and symbol_text:
-            self._bar_caps_by_symbol[symbol_text] = cap_value
+        if symbol_text:
+            if cap_value is not None and cap_value > 0:
+                self._bar_caps_by_symbol[symbol_text] = cap_value
+            else:
+                self._bar_caps_by_symbol.pop(symbol_text, None)
         if mode_key:
             self._bar_mode_totals[mode_key] += dec
         if weight_value is not None and weight_value > 0:

--- a/tests/monitoring/test_bar_execution_snapshot.py
+++ b/tests/monitoring/test_bar_execution_snapshot.py
@@ -109,6 +109,44 @@ def test_bar_execution_snapshot_aggregates_unique_caps() -> None:
     assert cumulative["turnover_vs_cap"] == pytest.approx(expected_ratio)
 
 
+def test_bar_execution_snapshot_removes_zero_caps() -> None:
+    aggregator = _make_enabled_monitoring_aggregator()
+
+    aggregator.record_bar_execution(
+        "BTCUSDT",
+        decisions=10,
+        act_now=5,
+        turnover_usd=1_000.0,
+        cap_usd=10_000.0,
+    )
+    aggregator.record_bar_execution(
+        "ETHUSDT",
+        decisions=6,
+        act_now=3,
+        turnover_usd=600.0,
+        cap_usd=5_000.0,
+    )
+
+    aggregator.record_bar_execution(
+        "BTCUSDT",
+        decisions=4,
+        act_now=2,
+        turnover_usd=400.0,
+        cap_usd=0.0,
+    )
+
+    snapshot = aggregator._bar_execution_snapshot()
+    cumulative = snapshot["cumulative"]
+
+    expected_cap = 5_000.0
+    expected_turnover = 1_000.0 + 600.0 + 400.0
+
+    assert cumulative["cap_usd"] == pytest.approx(expected_cap)
+    assert cumulative["turnover_vs_cap"] == pytest.approx(
+        expected_turnover / expected_cap
+    )
+
+
 def test_record_bar_execution_sanitises_turnover_values() -> None:
     aggregator = _make_enabled_monitoring_aggregator()
 


### PR DESCRIPTION
## Summary
- ensure bar execution cap tracking removes symbols when their cap becomes non-positive
- add a regression test covering zero-cap transitions to validate cumulative cap and ratio calculations

## Testing
- pytest tests/monitoring/test_bar_execution_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68de59041958832f9f02827f4a333d32