### PR TITLE
Clamp signal expiry to bar close

### DIFF
--- a/service_signal_runner.py
+++ b/service_signal_runner.py
@@ -2486,6 +2486,7 @@ class _Worker:
                 payload_expires_ms = None
             if payload_expires_ms is not None:
                 expires_at_ms = min(expires_at_ms, payload_expires_ms)
+        expires_at_ms = max(expires_at_ms, base_bar_close_ms)
         try:
             return build_signal_envelope(
                 symbol=str(symbol),
@@ -5119,6 +5120,7 @@ class _Worker:
                 valid_until_ms_int = None
         if valid_until_ms_int is not None:
             expires_at_ms = min(expires_at_ms, valid_until_ms_int)
+        expires_at_ms = max(expires_at_ms, bar_close_ms)
         published = True
         stack_pushed = False
         if getattr(signal_bus, "ENABLED", False):


### PR DESCRIPTION
## Summary
- clamp publish and drop envelopes so expires_at_ms never precedes the bar close
- add monitoring stub helper and regression tests covering publish and drop expiry clamping

## Testing
- pytest tests/test_service_signal_runner_process.py

------
https://chatgpt.com/codex/tasks/task_e_68df0263e684832f9f2b2f8b31b7dc97