### PR TITLE
Update packaging metadata to avoid setuptools warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tradingbot"
 version = "0.1.0"
+description = "Cython/C++ extensions: LOB and microstructure generator"
 dependencies = ["pandas>=2.0.0", "numpy>=1.24.0", "pydantic", "pyyaml"]
 
 [project.scripts]

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,6 @@ setup(
     entry_points={
         "console_scripts": ["no-trade-mask=apply_no_trade_mask:main"],
     },
-    install_requires=["pandas", "pydantic", "pyyaml"],
     ext_modules=cythonize(
         ext_modules,
         compiler_directives={


### PR DESCRIPTION
## Summary
- declare the extension package description directly in pyproject metadata
- rely on the pyproject dependency declarations instead of duplicating them in setup.py

## Testing
- python setup.py build_ext --inplace *(fails: existing reward.pyx Cython error unrelated to metadata changes)*

------
https://chatgpt.com/codex/tasks/task_e_68df9ae26f08832fb9fc53213a8667b1