### PR TITLE
Ensure run_full_cycle script can import project modules

### DIFF
--- a/scripts/run_full_cycle.py
+++ b/scripts/run_full_cycle.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 
 import argparse
 import shlex
+import sys
+from pathlib import Path
 from typing import List, Sequence
+
+# Ensure repository root is on sys.path when executed as a script
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from ingest_config import (
     FuturesConfig,


### PR DESCRIPTION
## Summary
- add the repository root to `sys.path` when running `scripts/run_full_cycle.py` directly so local imports succeed

## Testing
- python scripts/run_full_cycle.py --symbols BTCUSDT,ETHUSDT --interval 1h --start 2023-01-01 --end 2023-12-31 *(fails: HTTPS proxy 403 when contacting fapi.binance.com)*

------
https://chatgpt.com/codex/tasks/task_e_68df9ca81e94832fbecacb692626582f