### PR TITLE
Add stable-baselines3 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ extra = [
     "investpy==1.0.8",
     "joblib>=1.3.0",
     "torch>=2.0.0 ; platform_system!='Windows'",
+    "stable-baselines3>=2.0.0,<3.0.0",
     "fastapi>=0.110.0",
     "uvicorn>=0.27.0",
 ]

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -5,5 +5,6 @@ requests>=2.31.0
 investpy==1.0.8
 joblib>=1.3.0
 torch>=2.0.0 ; platform_system!="Windows"  # если нужен PyTorch для .pt моделей
+stable-baselines3>=2.0.0,<3.0.0
 fastapi>=0.110.0
 uvicorn>=0.27.0


### PR DESCRIPTION
## Summary
- add the stable-baselines3 dependency to the optional extras in `pyproject.toml`
- keep the extra requirements text file in sync so the package is installed when preparing the environment

## Testing
- `pip install -r requirements_extra.txt`
- `python train_model_multi_patch.py --help` *(fails: ModuleNotFoundError: No module named 'optuna')*

------
https://chatgpt.com/codex/tasks/task_e_68dfcad32bbc832fbf179ed7380a802a