### PR TITLE
Add RL dependencies to base and extra configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,14 @@ build-backend = "setuptools.build_meta"
 name = "tradingbot"
 version = "0.1.0"
 description = "Cython/C++ extensions: LOB and microstructure generator"
-dependencies = ["pandas>=2.0.0", "numpy>=1.24.0", "pydantic", "pyyaml"]
+dependencies = [
+    "pandas>=2.0.0",
+    "numpy>=1.24.0",
+    "pydantic",
+    "pyyaml",
+    "stable-baselines3>=2.0.0,<3.0.0",
+    "optuna>=3.0.0,<4.0.0",
+]
 
 [project.scripts]
 no-trade-mask = "apply_no_trade_mask:main"
@@ -21,6 +28,7 @@ extra = [
     "joblib>=1.3.0",
     "torch>=2.0.0 ; platform_system!='Windows'",
     "stable-baselines3>=2.0.0,<3.0.0",
+    "optuna>=3.0.0,<4.0.0",
     "fastapi>=0.110.0",
     "uvicorn>=0.27.0",
 ]

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -6,5 +6,6 @@ investpy==1.0.8
 joblib>=1.3.0
 torch>=2.0.0 ; platform_system!="Windows"  # если нужен PyTorch для .pt моделей
 stable-baselines3>=2.0.0,<3.0.0
+optuna>=3.0.0,<4.0.0
 fastapi>=0.110.0
 uvicorn>=0.27.0


### PR DESCRIPTION
## Summary
- add stable-baselines3 and optuna to the core project dependencies
- ensure the extra dependency set pulls in the same reinforcement learning tooling

## Testing
- pip install -r requirements_extra.txt

------
https://chatgpt.com/codex/tasks/task_e_68dfce86dfd8832fad4e3772c2b54889