### PR TITLE
Align training dependencies with extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,12 @@ name = "tradingbot"
 version = "0.1.0"
 description = "Cython/C++ extensions: LOB and microstructure generator"
 dependencies = [
-    "pandas>=2.0.0",
     "numpy>=1.24.0",
+    "optuna>=3.0.0,<4.0.0",
+    "pandas>=2.0.0",
     "pydantic",
     "pyyaml",
     "stable-baselines3>=2.0.0,<3.0.0",
-    "optuna>=3.0.0,<4.0.0",
 ]
 
 [project.scripts]
@@ -20,15 +20,15 @@ no-trade-mask = "apply_no_trade_mask:main"
 
 [project.optional-dependencies]
 extra = [
-    "pandas>=2.0.0",
     "numpy>=1.24.0",
+    "optuna>=3.0.0,<4.0.0",
+    "pandas>=2.0.0",
     "pyarrow>=12.0.0",
     "requests>=2.31.0",
     "investpy==1.0.8",
     "joblib>=1.3.0",
     "torch>=2.0.0 ; platform_system!='Windows'",
     "stable-baselines3>=2.0.0,<3.0.0",
-    "optuna>=3.0.0,<4.0.0",
     "fastapi>=0.110.0",
     "uvicorn>=0.27.0",
 ]

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,11 +1,11 @@
-pandas>=2.0.0
 numpy>=1.24.0
+optuna>=3.0.0,<4.0.0
+pandas>=2.0.0
 pyarrow>=12.0.0
 requests>=2.31.0
 investpy==1.0.8
 joblib>=1.3.0
 torch>=2.0.0 ; platform_system!="Windows"  # если нужен PyTorch для .pt моделей
 stable-baselines3>=2.0.0,<3.0.0
-optuna>=3.0.0,<4.0.0
 fastapi>=0.110.0
 uvicorn>=0.27.0


### PR DESCRIPTION
## Summary
- ensure `stable-baselines3` and `optuna` are present in the core dependency list and mirrored in the `extra` optional group
- reorder `requirements_extra.txt` so the same packages appear with the project extras for easier maintenance

## Testing
- pip install -r requirements_extra.txt
- python train_model_multi_patch.py --help *(fails: ModuleNotFoundError: No module named 'infra')*

------
https://chatgpt.com/codex/tasks/task_e_68dfd3c30ca0832faab7652e1617d1fb