### PR TITLE
Wire trading env to real infra modules

### DIFF
--- a/event_bus.py
+++ b/event_bus.py
@@ -14,6 +14,27 @@ from dataclasses import asdict, is_dataclass
 from multiprocessing import Lock
 from utils.prometheus import Counter
 
+
+class Topics:
+    """Common event topics used across trading components."""
+
+    RISK = "risk"
+
+
+__all__ = [
+    "Topics",
+    "configure",
+    "set_defaults",
+    "run_dir",
+    "log_signal_metric",
+    "log_trade",
+    "log_trade_row",
+    "log_trade_exec",
+    "log_risk",
+    "flush",
+    "close",
+]
+
 # Уровень событий: NONE=0, SUMMARY=1, FULL=2
 class EventLevel(int):
     NONE = 0

--- a/tests/test_close_shift.py
+++ b/tests/test_close_shift.py
@@ -5,17 +5,7 @@ import numpy as np
 import pandas as pd
 
 sys.path.append(os.getcwd())
-# stub minimal infra modules required for import
-infra_pkg = types.ModuleType("infra")
-event_bus_stub = types.ModuleType("event_bus")
-event_bus_stub.publish = lambda *a, **k: None
-event_bus_stub.Topics = object
-time_provider_stub = types.ModuleType("time_provider")
-time_provider_stub.TimeProvider = object
-time_provider_stub.RealTimeProvider = object
-sys.modules["infra"] = infra_pkg
-sys.modules["infra.event_bus"] = event_bus_stub
-sys.modules["infra.time_provider"] = time_provider_stub
+# stub minimal optional modules required for import
 lob_state_stub = types.ModuleType("lob_state_cython")
 lob_state_stub.N_FEATURES = 1
 sys.modules["lob_state_cython"] = lob_state_stub

--- a/tests/test_leak_guard_env.py
+++ b/tests/test_leak_guard_env.py
@@ -7,17 +7,6 @@ import pytest
 
 sys.path.append(os.getcwd())
 
-# stub minimal infra modules required for import
-infra_pkg = types.ModuleType("infra")
-event_bus_stub = types.ModuleType("event_bus")
-event_bus_stub.publish = lambda *a, **k: None
-event_bus_stub.Topics = object
-time_provider_stub = types.ModuleType("time_provider")
-time_provider_stub.TimeProvider = object
-time_provider_stub.RealTimeProvider = object
-sys.modules["infra"] = infra_pkg
-sys.modules["infra.event_bus"] = event_bus_stub
-sys.modules["infra.time_provider"] = time_provider_stub
 lob_state_stub = types.ModuleType("lob_state_cython")
 lob_state_stub.N_FEATURES = 1
 sys.modules["lob_state_cython"] = lob_state_stub

--- a/tests/test_no_trade_mask.py
+++ b/tests/test_no_trade_mask.py
@@ -6,16 +6,6 @@ import pandas as pd
 
 sys.path.append(os.getcwd())
 
-infra_pkg = types.ModuleType("infra")
-event_bus_stub = types.ModuleType("event_bus")
-event_bus_stub.publish = lambda *a, **k: None
-event_bus_stub.Topics = object
-time_provider_stub = types.ModuleType("time_provider")
-time_provider_stub.TimeProvider = object
-time_provider_stub.RealTimeProvider = object
-sys.modules["infra"] = infra_pkg
-sys.modules["infra.event_bus"] = event_bus_stub
-sys.modules["infra.time_provider"] = time_provider_stub
 lob_state_stub = types.ModuleType("lob_state_cython")
 lob_state_stub.N_FEATURES = 1
 sys.modules["lob_state_cython"] = lob_state_stub

--- a/trading_patchnew.py
+++ b/trading_patchnew.py
@@ -63,8 +63,8 @@ except ModuleNotFoundError:  # pragma: no cover - depends on optional dependency
 
 import numpy as np
 import pandas as pd
-from infra.event_bus import Topics
-from infra.time_provider import TimeProvider, RealTimeProvider
+from event_bus import Topics
+from utils.time_provider import TimeProvider, RealTimeProvider
 from leakguard import LeakGuard, LeakConfig
 from no_trade import (
     NoTradeConfig,

--- a/utils/time_provider.py
+++ b/utils/time_provider.py
@@ -1,0 +1,39 @@
+"""Time provider abstractions for trading components.
+
+The default implementation returns the current wall-clock time while also
+providing a simple testing hook for deterministic time sources.
+"""
+from __future__ import annotations
+
+import time
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TimeProvider(Protocol):
+    """Protocol describing objects that can provide monotonic timestamps."""
+
+    def time(self) -> float:
+        """Return the current time in seconds."""
+
+    def time_ms(self) -> int:
+        """Return the current time in milliseconds."""
+
+    def sleep(self, seconds: float) -> None:
+        """Sleep for ``seconds`` seconds."""
+
+
+class RealTimeProvider:
+    """Concrete :class:`TimeProvider` using :mod:`time` functions."""
+
+    def time(self) -> float:
+        return time.time()
+
+    def time_ms(self) -> int:
+        return int(self.time() * 1000.0)
+
+    def sleep(self, seconds: float) -> None:
+        time.sleep(seconds)
+
+
+__all__ = ["TimeProvider", "RealTimeProvider"]


### PR DESCRIPTION
## Summary
- export a Topics namespace from `event_bus` and add a concrete `utils.time_provider` implementation
- update `trading_patchnew` to use the real modules and refresh unit tests to monkeypatch them directly
- simplify ancillary tests by removing old `infra.*` stubs now that concrete modules exist

## Testing
- pytest tests/env/test_trading_env_intrabar.py
- pytest tests/test_no_trade_mask.py tests/test_leak_guard_env.py tests/test_close_shift.py
- python train_model_multi_patch.py --help *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68dfd60c22f8832f8e22c4c74fa7a1ca