### PR TITLE
Normalize millisecond timestamps in fetch_all_data_patch

### DIFF
--- a/fetch_all_data_patch.py
+++ b/fetch_all_data_patch.py
@@ -66,9 +66,14 @@ def _ensure_required_columns(df: pd.DataFrame) -> pd.DataFrame:
     df = df.copy()
     float_cols = ["open","high","low","close","volume","quote_asset_volume",
                   "taker_buy_base_asset_volume","taker_buy_quote_asset_volume"]
-    int_cols = ["timestamp","number_of_trades"]
+    int_cols = ["number_of_trades"]
     for c in float_cols:
         df[c] = df[c].astype(float)
+    # Normalize timestamp column (detect milliseconds and convert to seconds)
+    ts = pd.to_numeric(df["timestamp"], errors="raise")
+    if ts.max() > 10_000_000_000:
+        ts = ts // 1000
+    df["timestamp"] = ts.astype("int64")
     for c in int_cols:
         df[c] = df[c].astype("int64")
     df["symbol"] = df["symbol"].astype(str)

--- a/tests/test_fetch_all_data_patch.py
+++ b/tests/test_fetch_all_data_patch.py
@@ -55,3 +55,28 @@ def test_load_all_data_preserves_single_fear_greed_column(tmp_path, monkeypatch)
     assert "fear_greed_value" in loaded.columns
     assert list(loaded["fear_greed_value"].astype(float)) == [10.0, 20.0, 30.0]
     assert "fear_greed_value_orig" not in loaded.columns
+
+
+def test_load_all_data_converts_millisecond_timestamps(tmp_path, monkeypatch):
+    symbol = "ETHUSDT"
+    base_ts_ms = 1_650_000_000_000
+    df = _build_base_frame(symbol)
+    df["timestamp"] = [base_ts_ms, base_ts_ms + 3_600_000, base_ts_ms + 7_200_000]
+
+    candle_path = tmp_path / f"{symbol}.feather"
+    candle_path.write_text("dummy")
+
+    monkeypatch.setattr(fetch_all_data_patch, "FNG_PATH", os.fspath(tmp_path / "fear_greed.csv"))
+    monkeypatch.setattr(
+        fetch_all_data_patch.pd,
+        "read_feather",
+        lambda path, **kwargs: df.copy(),
+    )
+
+    all_dfs, _ = fetch_all_data_patch.load_all_data([os.fspath(candle_path)])
+    loaded = all_dfs[symbol]
+
+    expected_start = (base_ts_ms // 1000 // 3600) * 3600
+    expected_timestamps = [expected_start + offset for offset in (0, 3600, 7200)]
+
+    assert list(loaded["timestamp"]) == expected_timestamps


### PR DESCRIPTION
## Summary
- normalize timestamps in `fetch_all_data_patch._ensure_required_columns` by detecting millisecond inputs and converting them to seconds before alignment
- add regression coverage ensuring `load_all_data` converts millisecond candle timestamps to hour-aligned seconds

## Testing
- `pytest tests/test_fetch_all_data_patch.py`


------
https://chatgpt.com/codex/tasks/task_e_68dffc454144832fa2d40f9c56739b51