### PR TITLE
Add lob_state_cython extension module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,20 @@ ext_modules = [
         extra_compile_args=cxx_args,
         extra_link_args=link_args,
     ),
+    Extension(
+        name="lob_state_cython",
+        sources=[
+            "lob_state_cython.pyx",
+            "MarketSimulator.cpp",
+            "cpp_microstructure_generator.cpp",
+        ],
+        include_dirs=include_dirs,
+        libraries=libraries,
+        library_dirs=library_dirs,
+        language="c++",
+        extra_compile_args=cxx_args,
+        extra_link_args=link_args,
+    ),
 ]
 
 setup(


### PR DESCRIPTION
## Summary
- register the `lob_state_cython` Cython extension in `setup.py`
- reuse the simulator sources so the Cython wrapper links against the existing C++ implementation

## Testing
- `python setup.py build_ext --inplace` *(fails: g++ cannot find definitions for MarketEvent/MarketEventType in lob_state_cython.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68e0421733d4832fae7da7fc58873cb9