### PR TITLE
Align Cython MarketSimulator bindings with new interface

### DIFF
--- a/marketmarket_simulator_wrapper.pxd
+++ b/marketmarket_simulator_wrapper.pxd
@@ -30,7 +30,7 @@ cdef extern from "MarketSimulator.h" nogil:
             double* low,
             double* volume_usd,
             size_t n_steps,
-            uint64_t seed
+            uint64_t seed = 0
         ) except +
         double step(size_t i, double black_swan_probability, bint is_training_mode)
         void set_seed(uint64_t seed)


### PR DESCRIPTION
## Summary
- sync the `MarketSimulator` Cython extern declarations with the current C++ header, including double-buffer pointers and helper methods
- refactor `MarketSimulatorWrapper` to manage float64 NumPy buffers, pass the updated constructor signature, and provide a local last-price accessor
- update the shared `.pxd` declaration so the constructor exposes the optional seed argument

## Testing
- not run (Cython extension build not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0493ef5f0832fb4b7875d2f24f82f