### PR TITLE
Align Cython declarations with MicroEventType enum class

### DIFF
--- a/array_specializations.pxd
+++ b/array_specializations.pxd
@@ -1,0 +1,19 @@
+# cython: language_level=3
+from libc.stddef cimport size_t
+
+cdef extern from "<array>" namespace "std" nogil:
+    cdef cppclass ArrayDouble4 "std::array<double, 4>":
+        ArrayDouble4() except +
+        double& operator[](size_t) except +
+
+    cdef cppclass ArrayDouble6 "std::array<double, 6>":
+        ArrayDouble6() except +
+        double& operator[](size_t) except +
+
+    cdef cppclass ArrayDouble168 "std::array<double, 168>":
+        ArrayDouble168() except +
+        double& operator[](size_t) except +
+
+    cdef cppclass ArrayDouble6x6 "std::array<std::array<double, 6>, 6>":
+        ArrayDouble6x6() except +
+        ArrayDouble6& operator[](size_t) except +

--- a/lob_state_cython.pxd
+++ b/lob_state_cython.pxd
@@ -1,16 +1,16 @@
 # cython: language_level=3, language=c++
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
-from libcpp.array cimport array as cpp_array
+from array_specializations cimport ArrayDouble6, ArrayDouble6x6
 
 from fast_lob cimport OrderBook, CythonLOB
 from core_constants cimport MarketRegime
 
 cdef extern from "cpp_microstructure_generator.h":
-    cdef enum MicroEventType:
-        LIMIT
-        MARKET
-        CANCEL
+    cdef enum MicroEventType "MicroEventType":
+        LIMIT "MicroEventType::LIMIT"
+        MARKET "MicroEventType::MARKET"
+        CANCEL "MicroEventType::CANCEL"
 
     cdef int CH_LIM_BUY
     cdef int CH_LIM_SELL
@@ -28,10 +28,8 @@ cdef extern from "cpp_microstructure_generator.h":
         unsigned long long order_id
         int timestamp
 
-    ctypedef cpp_array[double, 6] ArrayDouble6
-    ctypedef cpp_array[ArrayDouble6, 6] ArrayDouble6x6
-
     cdef cppclass HawkesParams:
+        HawkesParams() except +
         ArrayDouble6 mu
         ArrayDouble6x6 alpha
         ArrayDouble6x6 beta
@@ -83,16 +81,16 @@ cdef extern from "cpp_microstructure_generator.h":
     cdef cppclass CppMicrostructureGenerator:
         CppMicrostructureGenerator() except +
         void set_seed(unsigned long long seed)
-        void set_hawkes_params(HawkesParams const& hp)
-        void set_size_models(SizeDist const& limit_sz, SizeDist const& market_sz)
-        void set_placement_profile(PlacementProfile const& pp)
+        void set_hawkes_params(const HawkesParams& hp)
+        void set_size_models(const SizeDist& limit_sz, const SizeDist& market_sz)
+        void set_placement_profile(const PlacementProfile& pp)
         void set_cancel_rate(double base_cancel_rate)
-        void set_flash_shocks(ShockParams const& sp)
-        void set_black_swan(BlackSwanParams const& bp)
+        void set_flash_shocks(const ShockParams& sp)
+        void set_black_swan(const BlackSwanParams& bp)
         void set_regime(MarketRegime regime)
-        void reset(long long mid0_ticks, long long best_bid_ticks=*, long long best_ask_ticks=*)
+        void reset(long long mid0_ticks, long long best_bid_ticks=0, long long best_ask_ticks=0)
         int step(OrderBook& lob, int timestamp, MicroEvent* out_events, int cap)
-        MicroFeatures current_features(OrderBook const& lob) const
+        MicroFeatures current_features(const OrderBook& lob) const
         unsigned long long last_order_id() const
         void copy_lambda_hat(double* out) const
 

--- a/lob_state_cython.pyx
+++ b/lob_state_cython.pyx
@@ -1,7 +1,7 @@
 # cython: language_level=3, language=c++, c_string_type=str, c_string_encoding=utf-8, boundscheck=False, wraparound=False
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
-from libcpp.array cimport array as cpp_array
+from array_specializations cimport ArrayDouble4, ArrayDouble168
 
 from cython cimport Py_ssize_t
 from libc.stddef cimport size_t
@@ -88,9 +88,6 @@ N_FEATURES = _compute_n_features()
 # Используется для предварительного выделения памяти под NumPy массивы.
 DEF MAX_TRADES_PER_STEP = 10000
 DEF MAX_GENERATED_EVENTS_PER_TYPE = 5000
-
-ctypedef cpp_array[double, 4] ArrayDouble4
-ctypedef cpp_array[double, 168] ArrayDouble168
 
 cdef extern from "MarketSimulator.h":
 

--- a/micro_sim.pyx
+++ b/micro_sim.pyx
@@ -17,7 +17,7 @@ cdef extern from "OrderBook.h":
         pass
 
 cdef extern from "cpp_microstructure_generator.h":
-    cdef enum MicroEventType:
+    cdef enum MicroEventType "MicroEventType":
         pass
 
     cdef struct MicroEvent:


### PR DESCRIPTION
## Summary
- ensure Cython binds the C++ MicroEventType enum class via scoped enumerators
- provide std::array specializations and const-ref signatures to match the C++ API
- update lob_state_cython and micro_sim usages to rely on the scoped enum values

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68e04e3ffbec832f87b5de9f9d920e1a