### PR TITLE
Add Python set_seed binding for CyMicrostructureGenerator

### DIFF
--- a/lob_state_cython.pxd
+++ b/lob_state_cython.pxd
@@ -115,6 +115,7 @@ cdef class CyMicrostructureGenerator:
     cdef CppMicrostructureGenerator* thisptr
     cdef public double base_order_imbalance_ratio
     cdef public double base_cancel_ratio
+    cpdef void set_seed(self, unsigned long long seed)
     cpdef unsigned long long generate_public_events_cy(
         self,
         vector[MicroEvent]& out_events,

--- a/lob_state_cython.pyx
+++ b/lob_state_cython.pyx
@@ -349,6 +349,12 @@ cdef class CyMicrostructureGenerator:
             del self.thisptr
             self.thisptr = NULL
 
+    cpdef set_seed(self, unsigned long long seed):
+        """Set the random seed for the underlying generator."""
+        if self.thisptr is NULL:
+            raise ValueError("Generator is not initialized")
+        self.thisptr.set_seed(seed)
+
     cpdef unsigned long long generate_public_events_cy(self,
             vector[MicroEvent]& out_events,
             CythonLOB lob,


### PR DESCRIPTION
## Summary
- add a Python-exposed `set_seed` method on `CyMicrostructureGenerator`
- validate generator initialization before forwarding to the underlying C++ object
- update the corresponding pxd declaration so the method is available to Cython consumers

## Testing
- `python - <<'PY'
import numpy
import pyximport
pyximport.install(language_level=3, setup_args={"include_dirs": [numpy.get_include(), "."]})
from lob_state_cython import CyMicrostructureGenerator

gen = CyMicrostructureGenerator()
gen.set_seed(42)
print("set_seed succeeded")
PY` *(fails: Cython build requires full C++ build context; see log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68e055cbdca4832fb3c13723e493ba31