### PR TITLE
Fix market regime coercion and unblock Cython build

### DIFF
--- a/cpp_microstructure_generator.h
+++ b/cpp_microstructure_generator.h
@@ -49,6 +49,26 @@ class OrderBook;
 
 enum class MicroEventType : int { LIMIT = 0, MARKET = 1, CANCEL = 2 };
 
+constexpr MicroEventType operator|(MicroEventType lhs, MicroEventType rhs) {
+    return static_cast<MicroEventType>(static_cast<int>(lhs) | static_cast<int>(rhs));
+}
+
+constexpr MicroEventType operator<<(MicroEventType lhs, int rhs) {
+    return static_cast<MicroEventType>(static_cast<int>(lhs) << rhs);
+}
+
+constexpr MicroEventType operator*(MicroEventType lhs, MicroEventType rhs) {
+    return static_cast<MicroEventType>(static_cast<int>(lhs) * static_cast<int>(rhs));
+}
+
+constexpr MicroEventType operator*(MicroEventType lhs, int rhs) {
+    return static_cast<MicroEventType>(static_cast<int>(lhs) * rhs);
+}
+
+constexpr MicroEventType operator*(int lhs, MicroEventType rhs) {
+    return static_cast<MicroEventType>(lhs * static_cast<int>(rhs));
+}
+
 static constexpr int CH_LIM_BUY  = 0;
 static constexpr int CH_LIM_SELL = 1;
 static constexpr int CH_MKT_BUY  = 2;

--- a/lob_state_cython.pyx
+++ b/lob_state_cython.pyx
@@ -14,7 +14,7 @@ cimport numpy as np
 import numpy as np
 
 import core_constants as consts
-from core_constants cimport MarketRegime, NORMAL, CHOPPY_FLAT, STRONG_TREND
+from core_constants cimport MarketRegime, NORMAL, CHOPPY_FLAT, STRONG_TREND, ILLIQUID
 from coreworkspace cimport SimulationWorkspace
 from fast_lob cimport CythonLOB, OrderBook
 from obs_builder cimport build_observation_vector_c
@@ -99,7 +99,7 @@ cdef extern from "MarketSimulator.h":
             double* low,
             double* volume_usd,
             size_t n_steps,
-            uint64_t seed = 0
+            uint64_t seed
         ) except +
         double step(size_t i, double black_swan_probability, bint is_training_mode)
         void set_regime_distribution(const ArrayDouble4& probs)
@@ -310,14 +310,33 @@ cdef class MarketSimulatorWrapper:
     cpdef double get_bb_upper(self, size_t idx):
         return self.thisptr.get_bb_upper(idx)
 
-    cpdef force_market_regime(self, str regime_name, size_t start_idx, size_t duration):
+    cpdef force_market_regime(self, object regime_name, size_t start_idx, size_t duration):
+        """Force a regime via MarketRegime, an integer code, or a string alias."""
         cdef MarketRegime regime
-        if regime_name == "choppy_flat" or regime_name == "flat":
-            regime = CHOPPY_FLAT
-        elif regime_name in ("strong_trend", "liquidity_shock", "trend"):
-            regime = STRONG_TREND
+
+        if isinstance(regime_name, consts.MarketRegime):
+            regime = <MarketRegime><int>regime_name
+        elif isinstance(regime_name, int):
+            if regime_name == consts.MarketRegime.NORMAL:
+                regime = NORMAL
+            elif regime_name == consts.MarketRegime.CHOPPY_FLAT:
+                regime = CHOPPY_FLAT
+            elif regime_name == consts.MarketRegime.STRONG_TREND:
+                regime = STRONG_TREND
+            elif regime_name == consts.MarketRegime.ILLIQUID:
+                regime = ILLIQUID
+            else:
+                raise ValueError("Unknown market regime code: %s" % (regime_name,))
         else:
-            regime = NORMAL
+            regime_str = str(regime_name).strip().lower()
+            if regime_str in ("choppy_flat", "flat"):
+                regime = CHOPPY_FLAT
+            elif regime_str in ("strong_trend", "liquidity_shock", "trend"):
+                regime = STRONG_TREND
+            elif regime_str in ("illiquid", "illiquidity"):
+                regime = ILLIQUID
+            else:
+                regime = NORMAL
 
         if self.thisptr is NULL:
             raise RuntimeError("MarketSimulator instance not initialised")
@@ -422,7 +441,7 @@ cdef class CyMicrostructureGenerator:
             del self.thisptr
             self.thisptr = NULL
 
-    cpdef set_seed(self, unsigned long long seed):
+    cpdef void set_seed(self, unsigned long long seed):
         """Set the random seed for the underlying generator."""
         if self.thisptr is NULL:
             raise ValueError("Generator is not initialized")

--- a/marketmarket_simulator_wrapper.pxd
+++ b/marketmarket_simulator_wrapper.pxd
@@ -30,7 +30,7 @@ cdef extern from "MarketSimulator.h" nogil:
             double* low,
             double* volume_usd,
             size_t n_steps,
-            uint64_t seed = 0
+            uint64_t seed
         ) except +
         double step(size_t i, double black_swan_probability, bint is_training_mode)
         void set_seed(uint64_t seed)


### PR DESCRIPTION
## Summary
- update `MarketSimulatorWrapper.force_market_regime` to handle enum, int, and legacy string inputs while mapping numeric codes directly to C++ regimes
- align Cython declarations with their `.pxd` signatures and remove constructor defaults so the build no longer generates signature conflicts
- add arithmetic and bitwise helpers for the `MicroEventType` enum class so Cython-generated conversions compile cleanly with modern compilers

## Testing
- python setup.py build_ext --inplace

------
https://chatgpt.com/codex/tasks/task_e_68e05ae8bd2c832f8e33fb075879e7f3