### PR TITLE
Fix lr schedule compatibility in custom policy

### DIFF
--- a/custom_policy_patch1.py
+++ b/custom_policy_patch1.py
@@ -15,9 +15,10 @@ import torch
 import torch.nn as nn
 import numpy as np
 from gymnasium import spaces
-from typing import Tuple, Type
+from typing import Tuple, Type, Optional, Dict, Any
 
 from sb3_contrib.common.recurrent.policies import RecurrentActorCriticPolicy
+from stable_baselines3.common.type_aliases import Schedule  # тип коллбэка lr_schedule
 
 
 
@@ -56,11 +57,20 @@ class CustomActorCriticPolicy(RecurrentActorCriticPolicy):
         self,
         observation_space: spaces.Space,
         action_space: spaces.Space,
-        lr_schedule,
+        # правильное имя в SB3:
+        lr_schedule: Optional[Schedule] = None,
         *args,
+        # бэк-компат: если кто-то ещё передаёт старое имя:
+        lr_scheduler: Optional[Schedule] = None,
+        optimizer_class=None,
+        optimizer_kwargs: Optional[Dict[str, Any]] = None,
         arch_params=None,
         **kwargs,
     ):
+        # если нам пришло lr_scheduler (старое имя) — мапим на lr_schedule
+        if lr_schedule is None and lr_scheduler is not None:
+            lr_schedule = lr_scheduler
+
         arch_params = arch_params or {}
         hidden_dim = arch_params.get('hidden_dim', 64)
         self.hidden_dim = hidden_dim
@@ -84,6 +94,8 @@ class CustomActorCriticPolicy(RecurrentActorCriticPolicy):
             action_space,
             lr_schedule,
             *args,
+            optimizer_class=optimizer_class,
+            optimizer_kwargs=optimizer_kwargs,
             **kwargs,
         )
         

--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -935,7 +935,7 @@ def objective(trial: optuna.Trial,
         return OneCycleLR(optimizer=optimizer, max_lr=params["learning_rate"] * 3, total_steps=total_optimizer_steps)
     
     # Оборачиваем ее в словарь для передачи в policy_kwargs
-    policy_kwargs["lr_scheduler"] = scheduler_fn
+    policy_kwargs["lr_schedule"] = scheduler_fn
     DistributionalPPO = _get_distributional_ppo()
     model = DistributionalPPO(
         use_torch_compile=True,


### PR DESCRIPTION
## Summary
- map legacy `lr_scheduler` keyword to the Stable-Baselines3 `lr_schedule` argument in `CustomActorCriticPolicy`
- import the SB3 `Schedule` type alias for clarity and update the training pipeline to pass `lr_schedule`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e12b2ceaf8832f8126b88552cb1973