### PR TITLE
Fix scheduler wiring for custom recurrent PPO policy

### DIFF
--- a/distributional_ppo.py
+++ b/distributional_ppo.py
@@ -140,6 +140,9 @@ class DistributionalPPO(RecurrentPPO):
             self.policy = torch.compile(self.policy, mode="reduce-overhead")
             print("--> Policy compilation complete.")
         print(f"--> CVaR-in-loss settings: (alpha={self.cvar_alpha:.2f}, weight={self.cvar_weight:.2f}).")
+
+        if hasattr(self.policy, "optimizer_scheduler") and self.policy.optimizer_scheduler is not None:
+            self.lr_scheduler = self.policy.optimizer_scheduler
     
     def parameters(self, recurse: bool = True):
         """Позволяет обращаться к параметрам агента как к nn.Module."""

--- a/train_model_multi_patch.py
+++ b/train_model_multi_patch.py
@@ -935,7 +935,7 @@ def objective(trial: optuna.Trial,
         return OneCycleLR(optimizer=optimizer, max_lr=params["learning_rate"] * 3, total_steps=total_optimizer_steps)
     
     # Оборачиваем ее в словарь для передачи в policy_kwargs
-    policy_kwargs["lr_schedule"] = scheduler_fn
+    policy_kwargs["optimizer_scheduler_fn"] = scheduler_fn
     DistributionalPPO = _get_distributional_ppo()
     model = DistributionalPPO(
         use_torch_compile=True,


### PR DESCRIPTION
## Summary
- add explicit optimizer scheduler hook to CustomActorCriticPolicy to avoid colliding with sb3 lr_schedule argument
- propagate the instantiated scheduler back to DistributionalPPO so training can step it
- pass the custom scheduler function through optimizer_scheduler_fn in the training objective setup

## Testing
- python -m compileall custom_policy_patch1.py distributional_ppo.py train_model_multi_patch.py

------
https://chatgpt.com/codex/tasks/task_e_68e12e076e44832fb0aa49785403fa10