### PR TITLE
Align SharedMemoryVecEnv reset with SB3 expectations

### DIFF
--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -15,10 +15,14 @@ def make_env():
     return CartPoleEnv()
 
 vec_env = SharedMemoryVecEnv([make_env, make_env], base_seed=123)
-obs, info = vec_env.reset()
+obs = vec_env.reset()
+reset_infos = vec_env.reset_infos  # информация о каждом воркере после reset
 # ... работа со средой ...
 vec_env.close()
 ```
+
+Поле `reset_infos` хранит словари `info` для каждого воркера и обновляется при
+каждом вызове `reset()`, повторяя поведение стандартных векторных обёрток SB3.
 
 ## Передача seed и управление ГПСЧ
 
@@ -55,7 +59,7 @@ def make_env():
 def rollout(seed, steps=5):
     env = SharedMemoryVecEnv([make_env, make_env], base_seed=seed)
     obs_seq = []
-    obs, _ = env.reset()
+    obs = env.reset()
     obs_seq.append(obs.copy())
     for _ in range(steps):
         actions = np.zeros((env.num_envs, 1), dtype=np.float32)

--- a/tests/test_shared_memory_vec_env_copy.py
+++ b/tests/test_shared_memory_vec_env_copy.py
@@ -23,7 +23,7 @@ class DummyEnv(Env):
 
 def test_step_returns_copies():
     vec_env = SharedMemoryVecEnv([lambda: DummyEnv()])
-    obs, _ = vec_env.reset()
+    obs = vec_env.reset()
     assert obs.base is None
     obs, rewards, dones, _ = vec_env.step(np.zeros((1,1), dtype=np.float32))
     assert obs.base is None

--- a/tests/test_shared_memory_vec_env_reproducible.py
+++ b/tests/test_shared_memory_vec_env_reproducible.py
@@ -28,7 +28,7 @@ class RNGEnv(Env):
 
 def rollout(seed, steps):
     vec_env = SharedMemoryVecEnv([lambda: RNGEnv()], base_seed=seed)
-    obs, _ = vec_env.reset()
+    obs = vec_env.reset()
     obs_seq = [obs.copy()]
     reward_seq = []
     for _ in range(steps):

--- a/tests/test_shared_memory_vec_env_seed.py
+++ b/tests/test_shared_memory_vec_env_seed.py
@@ -25,7 +25,7 @@ class RNGEnv(Env):
 
 def test_independent_rng_per_worker():
     vec_env = SharedMemoryVecEnv([lambda: RNGEnv(), lambda: RNGEnv()], base_seed=123)
-    obs, _ = vec_env.reset()
+    obs = vec_env.reset()
     assert obs[0] != obs[1]
     vec_env.step_async(np.zeros((2,1), dtype=np.float32))
     obs2, _, _, _ = vec_env.step_wait()

--- a/tests/test_shared_memory_vec_env_structured_actions.py
+++ b/tests/test_shared_memory_vec_env_structured_actions.py
@@ -41,7 +41,7 @@ class DictActionEnv(Env):
 def test_dict_action_round_trip():
     vec_env = SharedMemoryVecEnv([lambda: DictActionEnv()])
     try:
-        obs, _ = vec_env.reset()
+        obs = vec_env.reset()
         assert obs.shape == (1, 1)
 
         action = {


### PR DESCRIPTION
## Summary
- make SharedMemoryVecEnv.reset follow the SB3 VecEnv API by returning only observations and updating reset_infos
- propagate reset_infos through WatchdogVecEnv and update docs/tests to reflect the new contract

## Testing
- pytest tests/test_shared_memory_vec_env_reproducible.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e13952508c832fbdf4f04b89a3a2f3