### PR TITLE
Remove seasonality warning when timestamp missing

### DIFF
--- a/execution_sim.py
+++ b/execution_sim.py
@@ -6745,10 +6745,7 @@ class ExecutionSimulator:
         liq_mult = 1.0
         spread_mult = 1.0
         how: Optional[int] = None
-        if ts_ms is None:
-            if self.use_seasonality:
-                logger.warning("ts_ms is None; seasonality multipliers not applied")
-        else:
+        if ts_ms is not None:
             # Convert UTC milliseconds to hour-of-week (0=Mon 00:00 UTC) via the
             # shared helper: (ts_ms // HOUR_MS + 72) % 168.  This keeps hour
             # indexing consistent across modules.

--- a/tests/test_liquidity_seasonality.py
+++ b/tests/test_liquidity_seasonality.py
@@ -155,7 +155,7 @@ def test_seasonality_file_missing(tmp_path):
     assert sim._last_spread_bps == 1.0
 
 
-def test_ts_ms_none_skips_multipliers_and_logs_warning(caplog):
+def test_ts_ms_none_skips_multipliers_without_logging(caplog):
     liq_mult = [2.0] * 168
     spr_mult = [3.0] * 168
     sim = ExecutionSimulator(
@@ -168,7 +168,7 @@ def test_ts_ms_none_skips_multipliers_and_logs_warning(caplog):
         )
     assert sim._last_liquidity == 5.0
     assert sim._last_spread_bps == 1.0
-    assert "ts_ms is None" in caplog.text
+    assert not caplog.records
 
 
 def test_seasonality_linear_interpolation():


### PR DESCRIPTION
## Summary
- stop logging a warning when seasonality multipliers are skipped because ts_ms is missing
- update the liquidity seasonality test to assert no warnings are emitted while keeping multiplier assertions

## Testing
- pytest tests/test_liquidity_seasonality.py

------
https://chatgpt.com/codex/tasks/task_e_68e17fc51684832f997e7eeb08a30928