### PR TITLE
Support dotted CLI overrides in training script

### DIFF
--- a/tests/test_train_model_cli.py
+++ b/tests/test_train_model_cli.py
@@ -1,7 +1,9 @@
 import sys
 import types
+from typing import Any
 
 import pytest
+import yaml
 
 
 def _install_sb3_stub():
@@ -70,3 +72,74 @@ def test_dataset_split_none_skips_offline_bundle(monkeypatch: pytest.MonkeyPatch
         train_script.main()
 
     assert called is False
+
+
+def test_parse_cli_overrides_supports_scalars() -> None:
+    overrides = train_script._parse_cli_overrides(
+        ["--execution.mode", "bar", "--data.train_start_ts", "1672531200", "--flagged"]
+    )
+    assert overrides == {
+        "execution.mode": "bar",
+        "data.train_start_ts": 1672531200,
+        "flagged": True,
+    }
+
+
+def test_cli_overrides_applied_before_config_load(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    seasonality = tmp_path / "seasonality.json"
+    seasonality.write_text("{}", encoding="utf-8")
+
+    config_payload = {
+        "mode": "train",
+        "components": {
+            "market_data": {"target": "impl_offline_data:OfflineCSVBarSource"},
+            "executor": {"target": "impl_sim_executor:SimExecutor"},
+            "feature_pipe": {"target": "feature_pipe:FeaturePipe"},
+            "policy": {"target": "strategies.momentum:MomentumStrategy"},
+            "risk_guards": {"target": "impl_risk_basic:RiskBasicImpl"},
+        },
+        "data": {
+            "symbols": ["BTCUSDT"],
+            "timeframe": "1m",
+            "train_start_ts": 1609459200,
+            "train_end_ts": 1609545600,
+        },
+        "model": {"algo": "ppo", "params": {}},
+        "execution": {"mode": "order"},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config_payload), encoding="utf-8")
+
+    captured: dict[str, Any] = {}
+
+    def fake_loader(content: str):
+        captured_payload = yaml.safe_load(content)
+        captured["payload"] = captured_payload
+        raise RuntimeError("stop after overrides")
+
+    monkeypatch.setattr(train_script, "load_config_from_str", fake_loader)
+
+    argv = [
+        "train_model_multi_patch.py",
+        "--config",
+        str(config_path),
+        "--dataset-split",
+        "none",
+        "--liquidity-seasonality",
+        str(seasonality),
+        "--execution.mode",
+        "bar",
+        "--data.train_start_ts",
+        "1672531200",
+        "--data.val_start_ts",
+        "1698796800",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with pytest.raises(RuntimeError, match="stop after overrides"):
+        train_script.main()
+
+    payload = captured["payload"]
+    assert payload["execution"]["mode"] == "bar"
+    assert payload["data"]["train_start_ts"] == 1672531200
+    assert payload["data"]["val_start_ts"] == 1698796800


### PR DESCRIPTION
## Summary
- allow train_model_multi_patch.py to consume dotted CLI overrides and apply them to the loaded config before parsing
- coerce override values into native Python scalars and ensure mappings are created as needed
- add regression tests covering override parsing and config injection semantics

## Testing
- pytest tests/test_train_model_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e25cf9d5dc832f918b3bbde7c7e252